### PR TITLE
feat: Primary checks for installed mods/mod versions

### DIFF
--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -438,6 +438,8 @@
     <Compile Include="Properties\IgnoreAccessModifiers.cs" />
     <Compile Include="Extensions\MockExtentions.cs" />
     <Compile Include="Extensions\ObjectExtension.cs" />
+    <Compile Include="Utils\ModCompatibility.cs" />
+    <Compile Include="Utils\NetworkCompatibiltyAttribute.cs" />
     <Compile Include="Utils\ObjImporter.cs" />
     <Compile Include="Utils\PatchInitAttribute.cs" />
     <Compile Include="Utils\Paths.cs" />

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using BepInEx;
+using BepInEx.Configuration;
 using JotunnLib.ConsoleCommands;
 using JotunnLib.Managers;
 using JotunnLib.Utils;
@@ -64,8 +65,15 @@ namespace JotunnLib
             InitCommands(); // should that be a manager?
 
             Logger.LogInfo("JotunnLib v" + Version + " loaded successfully");
+
+#if DEBUG
+            Config.Bind("ModCompatibilityTest", "Enable", true, new ConfigDescription("Enable to test Mod compatibility testing", null));
+            Config.SettingChanged += ModCompatibility.Config_SettingChanged;
+            ModCompatibility.enableTestCase = (bool)Config["ModCompatibilityTest", "Enable"].BoxedValue;
+#endif
         }
-        
+
+
         /// <summary>
         /// Initialize patches
         /// </summary>

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -12,6 +12,7 @@ using JotunnLib.Utils;
 namespace JotunnLib
 {
     [BepInPlugin(ModGuid, "JotunnLib", Version)]
+    [NetworkCompatibilty(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     public class Main : BaseUnityPlugin
     {
         // Version

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -35,7 +35,9 @@ namespace JotunnLib.Managers
 
         public void OnPointerClick(PointerEventData eventData)
         {
+#if DEBUG
             Logger.LogMessage(eventData.GetObjectString());
+#endif
         }
 
         private void Awake()

--- a/JotunnLib/Utils/BepInExUtils.cs
+++ b/JotunnLib/Utils/BepInExUtils.cs
@@ -10,14 +10,20 @@ namespace JotunnLib.Utils
         ///     Get a dictionary of loaded plugins which depend on JotunnLib
         /// </summary>
         /// <returns></returns>
-        internal static Dictionary<string, BaseUnityPlugin> GetDependentPlugins()
+        internal static Dictionary<string, BaseUnityPlugin> GetDependentPlugins(bool includeJotunnLib = false)
         {
             var result = new Dictionary<string, BaseUnityPlugin>();
 
-            var plugins = BepInEx.Bootstrap.Chainloader.PluginInfos.Select(x=>x.Value.Instance).ToArray();
+            var plugins = BepInEx.Bootstrap.Chainloader.PluginInfos.Select(x => x.Value.Instance).ToArray();
 
             foreach (var plugin in plugins)
             {
+                if (includeJotunnLib && plugin.Info.Metadata.GUID == Main.ModGuid)
+                {
+                    result.Add(plugin.Info.Metadata.GUID, plugin);
+                    continue;
+                }
+
                 foreach (var dependencyAttribute in plugin.GetType().GetCustomAttributes(typeof(BepInDependency), false).Cast<BepInDependency>())
                 {
                     if (dependencyAttribute.DependencyGUID == Main.ModGuid)

--- a/JotunnLib/Utils/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility.cs
@@ -19,6 +19,10 @@ namespace JotunnLib.Utils
 
         private static int getVersionTrigger = 0;
 
+#if DEBUG
+        internal static bool enableTestCase = false;
+#endif
+
         [PatchInit(-1000)]
         public static void InitPatch()
         {
@@ -138,14 +142,13 @@ namespace JotunnLib.Utils
                 }
             }
 
-#if TESTCASE
-            // To check this part, remove the #if TESTCASE and 
-            if (ZNet.instance != null && (ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance()))
+#if DEBUG
+            if (enableTestCase)
             {
                 valheimVersion += "!";
             }
-
 #endif
+
             return valheimVersion;
         }
 
@@ -220,5 +223,16 @@ namespace JotunnLib.Utils
                 return sb.ToString();
             }
         }
+
+
+#if DEBUG
+        internal static void Config_SettingChanged(object sender, BepInEx.Configuration.SettingChangedEventArgs e)
+        {
+            if (e.ChangedSetting.Definition.Section == "ModCompatibilityTest" && e.ChangedSetting.Definition.Key == "Enable")
+            {
+                enableTestCase = (bool)e.ChangedSetting.BoxedValue;
+            }
+        }
+#endif
     }
 }

--- a/JotunnLib/Utils/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using JotunnLib.Managers;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace JotunnLib.Utils
+{
+    public class ModCompatibility
+    {
+        /// <summary>
+        /// Stores the last server message
+        /// </summary>
+        private static string LastServerMessage = "";
+
+        [PatchInit(-1000)]
+        public static void InitPatch()
+        {
+            On.Version.GetVersionString += Version_GetVersionString;
+            On.ZNet.RPC_PeerInfo += ZNet_RPC_PeerInfo;
+            On.ZNet.SendPeerInfo += ZNet_SendPeerInfo;
+            SceneManager.sceneLoaded += SceneManager_sceneLoaded;
+        }
+
+        private static void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadMode)
+        {
+            // Show message box if there is a message to show
+            if (!string.IsNullOrEmpty(LastServerMessage) && scene.name == "start")
+            {
+                var panel = GUIManager.Instance.CreateWoodpanel(GUIManager.PixelFix.transform, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
+                    new Vector2(0f, 0f), 500, 500);
+                panel.SetActive(true);
+
+                var remote = new MessageData(LastServerMessage);
+                var local = new MessageData(Version.GetVersionString());
+
+                var text = new GameObject("Text", typeof(RectTransform), typeof(Text), typeof(Outline));
+
+                var showText = "Remote version: " + Environment.NewLine + remote + Environment.NewLine + "Local version: " + Environment.NewLine + local;
+
+                text.GetComponent<Text>().text = showText;
+                text.GetComponent<Text>().color = new Color(1f, 0.631f, 0.235f, 1f);
+                text.GetComponent<Text>().font = GUIManager.Instance.AveriaSerifBold;
+                text.GetComponent<Text>().fontSize = 19;
+                text.GetComponent<Outline>().effectColor = new Color(0, 0, 0, 1);
+                text.GetComponent<RectTransform>().anchorMin = new Vector2(0.5f, 0.5f);
+                text.GetComponent<RectTransform>().anchorMax = new Vector2(0.5f, 0.5f);
+                text.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 450);
+                text.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 450);
+
+                text.transform.SetParent(panel.transform, false);
+
+                var button = GUIManager.Instance.CreateButton("OK", panel.transform, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f), new Vector2(0f, -215f));
+                button.SetActive(true);
+                button.GetComponent<Button>().onClick.AddListener(() =>
+                {
+                    panel.SetActive(false);
+                    Object.Destroy(panel);
+                });
+
+                LastServerMessage = "";
+            }
+        }
+
+        // Hook SendPeerInfo on client to add our method to the rpc
+        private static void ZNet_SendPeerInfo(On.ZNet.orig_SendPeerInfo orig, ZNet self, ZRpc rpc, string password)
+        {
+            rpc.Register(nameof(RPC_JotunnLib_StoreServerMessage), new Action<ZRpc, string>(RPC_JotunnLib_StoreServerMessage));
+            orig(self, rpc, password);
+        }
+
+        
+        private static void ZNet_RPC_PeerInfo(On.ZNet.orig_RPC_PeerInfo orig, ZNet self, ZRpc rpc, ZPackage pkg)
+        {
+            if (ZNet.instance.IsServerInstance())
+            {
+                // Check if version is correct
+                var xx = pkg.ReadLong();
+                var vers = pkg.ReadString();
+
+                // Reset package reader position
+                pkg.m_reader.BaseStream.Position = 0;
+
+                // Check version ourselves to be able to send back some data
+                var serverVersion = Version.GetVersionString();
+                if (serverVersion != vers)
+                {
+                    rpc.Invoke(nameof(RPC_JotunnLib_StoreServerMessage), serverVersion);
+                }
+            }
+
+            // call original method
+            orig(self, rpc, pkg);
+        }
+
+        // Our own implementation of the GetVersionString
+        private static string Version_GetVersionString(On.Version.orig_GetVersionString orig)
+        {
+            var valheimVersion = orig();
+
+            foreach (var mod in GetEnforcedMods())
+            {
+                if (mod.Item3 == CompatibilityLevel.EveryoneMustHaveMod)
+                {
+                    valheimVersion += $"@{mod.Item1}";
+                    if (mod.Item4 == VersionStrictness.EveryoneNeedSameModVersion)
+                    {
+                        valheimVersion += $":{mod.Item2.Major}.{mod.Item2.Minor}.{mod.Item2.Build}";
+                    }
+                }
+            }
+
+#if TESTCASE
+            // TODO: Remove test case
+            if (ZNet.instance != null && ZNet.instance.IsServerInstance())
+            {
+                valheimVersion += "!";
+            }
+#endif
+
+            return valheimVersion;
+        }
+
+        /// <summary>
+        /// Get module 
+        /// </summary>
+        /// <returns></returns>
+        internal static IEnumerable<Tuple<string, System.Version, CompatibilityLevel, VersionStrictness>> GetEnforcedMods()
+        {
+            foreach (var plugin in BepInExUtils.GetDependentPlugins())
+            {
+                var nca = plugin.Value.GetType().GetCustomAttributes(typeof(NetworkCompatibiltyAttribute), true).Cast<NetworkCompatibiltyAttribute>()
+                    .FirstOrDefault();
+                if (nca != null)
+                {
+                    yield return new Tuple<string, System.Version, CompatibilityLevel, VersionStrictness>(plugin.Value.Info.Metadata.Name,
+                        plugin.Value.Info.Metadata.Version, nca.EnforceModOnClients, nca.EnforceSameVersion);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Store server's message
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="data"></param>
+        public static void RPC_JotunnLib_StoreServerMessage(ZRpc sender, string data)
+        {
+            if (ZNet.instance.IsClientInstance())
+            {
+                LastServerMessage = data;
+            }
+        }
+
+        /// <summary>
+        /// Deserialize version string into a usable format
+        /// </summary>
+        private class MessageData
+        {
+            public MessageData(string input)
+            {
+                ValheimVersion = input.Split('@')[0];
+                var remaining = input.Substring(ValheimVersion.Length + 1);
+
+                var modules = remaining.Split('@');
+                foreach (var module in modules)
+                {
+                    Modules.Add(module);
+                }
+            }
+
+            public string ValheimVersion { get; }
+            public List<string> Modules { get; } = new List<string>();
+
+            public override string ToString()
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("Valheim: " + ValheimVersion);
+                foreach (var module in Modules)
+                {
+                    var parts = module.Split(':');
+                    sb.AppendLine(parts[0] + ": v" + parts[1]);
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/JotunnLib/Utils/NetworkCompatibiltyAttribute.cs
+++ b/JotunnLib/Utils/NetworkCompatibiltyAttribute.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace JotunnLib.Utils
+{
+    /// <summary>
+    /// Enum used for telling whether or not the mod should be needed by everyone in multiplayer games.
+    /// Also can specify if the mod does not work in multiplayer.
+    /// </summary>
+    public enum CompatibilityLevel {
+        NoNeedForSync,
+        EveryoneMustHaveMod
+    }
+
+    /// <summary>
+    /// Enum used for telling whether or not the same mod version should be used by both the server and the clients.
+    /// This enum is only useful if CompatibilityLevel.EveryoneMustHaveMod was chosen.
+    /// </summary>
+    public enum VersionStrictness {
+        DifferentModVersionsAreOk,
+        EveryoneNeedSameModVersion
+    }
+
+    /// <summary>
+    /// Mod compatibility attribute
+    ///
+    /// PLEASE READ
+    /// Example usage:
+    /// If your mod adds its own RPCs, EnforceModOnClients is likely a must (otherwise clients would just discard the messages from the server), same version you do have to determine, if your sent data changed
+    /// If your mod adds items, you always should enforce mods on client and same version (there could be nasty side effects with different versions of an item)
+    /// If your mod is just GUI changes (for example bigger inventory, additional equip slots) there is no need to set this attribute
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class|AttributeTargets.Assembly)]
+    public class NetworkCompatibiltyAttribute : Attribute
+    {
+        public CompatibilityLevel EnforceModOnClients { get; set; }
+
+        public VersionStrictness EnforceSameVersion { get; set; }
+
+        public NetworkCompatibiltyAttribute(CompatibilityLevel enforceMod, VersionStrictness enforceVersion)
+        {
+            EnforceModOnClients = enforceMod;
+            EnforceSameVersion = enforceVersion;
+        }
+    }
+}

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -15,6 +15,7 @@ namespace TestMod
 {
     [BepInPlugin("com.bepinex.plugins.jotunnlib.testmod", "JotunnLib Test Mod", "0.1.0")]
     [BepInDependency(JotunnLib.Main.ModGuid)]
+    [NetworkCompatibilty(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     class TestMod : BaseUnityPlugin
     {
         public AssetBundle TestAssets;


### PR DESCRIPTION
feat: Primary checks for installed mods/mod versions
TODO: Text output on the shown panel if version/mod mismatch is observed

Test case now works off a config value in the JotunnLib configuration (debug builds only)


---- obsolete ----
To check functionality, remove the #if TESTCASE in ModCompatibility.cs, line 141. This will let the server return a wrong version string. 
---- obsolete ----
