### PR TITLE
chore: Refactor most classes to adhere to naming conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,5 +33,28 @@ Setting up development environment for compilation:
 </Project>
 ```
 
-## Code formatting
-WIP
+## Commiting, branching, and versioning
+- For commiting, we adhere to [Convetional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+- For branching, we use [Git Flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+- For versioning, we will be using [Semantic Versioning](https://semver.org/)
+
+## Naming conventions, code style, and formatting
+For this project, we use the same naming conventions as Microsoft's .NET framework. A [summary can be found here](https://github.com/ktaranov/naming-convention/blob/master/C%23%20Coding%20Standards%20and%20Naming%20Conventions.md).  
+
+_Note: **ALL** public methods/properties/variables defined in public classes require XML documentation comments._  
+  
+Additionally, we enforce the following naming rules:
+- Visibility of classes, methods, properties, and variables should always be specified, and should never be left blank (even if meant to be internal)
+- Message methods (ex. `Awake`, `Update`) inherited from Unity's `Monobehaviour` should be internal or private
+- Manager type class names must be suffixed with `Manager`
+- Config type class names must be suffixed with `Config`
+- Util type classes consisting of mainly static methods should be suffixed with either `Util` or `Helper`, and be placed in the `Utils` namespace
+- All extension methods for classes should be in the `Extensions` namespace, and the class names should be suffixed with `Extension`
+
+This is not strict, however, methods and methods defined in classes should ideally be defined in the following order:
+- (public, internal, private) const variables
+- (public, internal, private) static properties
+- (public, internal, private) readonly variables
+- (public, internal, private) variables
+- (public, internal, static) methods
+- (public, internal, static) methods

--- a/JotunnBuildTask/AssemblyPublicizer.cs
+++ b/JotunnBuildTask/AssemblyPublicizer.cs
@@ -15,7 +15,7 @@ namespace JotunnBuildTask
         /// <returns></returns>
         public static bool PublicizeDll(string file, string ValheimPath)
         {
-            var outputPath = Path.Combine(Path.GetDirectoryName(file), Program._publicized_assemblies);
+            var outputPath = Path.Combine(Path.GetDirectoryName(file), Program.PublicizedAssemblies);
 
             if (!File.Exists(file))
             {
@@ -33,20 +33,20 @@ namespace JotunnBuildTask
             try
             {
                 assemblyDefinition = AssemblyDefinition.ReadAssembly(file);
-                if (Directory.Exists(Path.Combine(ValheimPath, Program._valheimData,
-                    Program._managed)))
+                if (Directory.Exists(Path.Combine(ValheimPath, Program.ValheimData,
+                    Program.Managed)))
                 {
-                    ((BaseAssemblyResolver)assemblyDefinition.MainModule.AssemblyResolver).AddSearchDirectory(Path.Combine(ValheimPath, Program._valheimData,
-                      Program._managed));
+                    ((BaseAssemblyResolver)assemblyDefinition.MainModule.AssemblyResolver).AddSearchDirectory(Path.Combine(ValheimPath, Program.ValheimData,
+                      Program.Managed));
                 }
-                if (Directory.Exists(Path.Combine(ValheimPath, Program._valheimServerData,
-                    Program._managed)))
+                if (Directory.Exists(Path.Combine(ValheimPath, Program.ValheimServerData,
+                    Program.Managed)))
                 {
-                    ((BaseAssemblyResolver)assemblyDefinition.MainModule.AssemblyResolver).AddSearchDirectory(Path.Combine(ValheimPath, Program._valheimServerData,
-                        Program._managed));
+                    ((BaseAssemblyResolver)assemblyDefinition.MainModule.AssemblyResolver).AddSearchDirectory(Path.Combine(ValheimPath, Program.ValheimServerData,
+                        Program.Managed));
                 }
 
-                ((BaseAssemblyResolver)assemblyDefinition.MainModule.AssemblyResolver).AddSearchDirectory(Path.Combine(ValheimPath, Program._unstripped_corlib));
+                ((BaseAssemblyResolver)assemblyDefinition.MainModule.AssemblyResolver).AddSearchDirectory(Path.Combine(ValheimPath, Program.UnstrippedCorlib));
             }
             catch (Exception exception)
             {
@@ -87,7 +87,7 @@ namespace JotunnBuildTask
             }
 
 
-            var outputFilename = Path.Combine(outputPath, $"{Path.GetFileNameWithoutExtension(file)}_{Program._publicized}{Path.GetExtension(file)}");
+            var outputFilename = Path.Combine(outputPath, $"{Path.GetFileNameWithoutExtension(file)}_{Program.Publicized}{Path.GetExtension(file)}");
 
             try
             {

--- a/JotunnBuildTask/Program.cs
+++ b/JotunnBuildTask/Program.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.Remoting.Channels;
 using System.Security.Cryptography;
-using System.Text;
 using Mono.Cecil;
 using MonoMod;
 using MonoMod.RuntimeDetour.HookGen;
@@ -12,43 +9,43 @@ namespace JotunnBuildTask
 {
     internal class Program
     {
-        private static string ValheimPath = "";
-        public const string _valheimServerData = "valheim_server_Data";
-        public const string _valheimData= "valheim_Data";
-        public const string _managed = "Managed";
-        public const string _unstripped_corlib = "unstripped_corlib";
-        public const string _publicized_assemblies = "publicized_assemblies";
-        public const string _bepinex = "BepInEx";
-        public const string _plugins = "plugins";
-        public const string _mmhook = "MMHOOK";
-        public const string _publicized = "publicized";
+        internal static string ValheimPath = "";
+        internal const string ValheimServerData = "valheim_server_Data";
+        internal const string ValheimData= "valheim_Data";
+        internal const string Managed = "Managed";
+        internal const string UnstrippedCorlib = "unstripped_corlib";
+        internal const string PublicizedAssemblies = "publicized_assemblies";
+        internal const string Bepinex = "BepInEx";
+        internal const string Plugins = "plugins";
+        internal const string Mmhook = "MMHOOK";
+        internal const string Publicized = "publicized";
+
         /// <summary>
-        ///     Create new MMHOOK dll's if they don't exist or have changed
+        ///     Create new MMHOOK dll's if they don't exist or have changed.
         /// </summary>
         /// <param name="args">Valheim folder</param>
         /// <returns>0 if successful</returns>
-        private static int Main(string[] args)
+        internal static int Main(string[] args)
         {
             try
             {
-
                 if (args.Length != 1)
                 {
                     Console.WriteLine("Only one argument: Path to Valheim");
                     return -2;
                 }
 
-                if (!Directory.Exists(Path.Combine(args[0], _bepinex, _plugins, _mmhook)))
+                if (!Directory.Exists(Path.Combine(args[0], Bepinex, Plugins, Mmhook)))
                 {
-                    Directory.CreateDirectory(Path.Combine(args[0], _bepinex, _plugins, _mmhook));
+                    Directory.CreateDirectory(Path.Combine(args[0], Bepinex, Plugins, Mmhook));
                 }
 
-                var outputFolder = Path.Combine(args[0], _bepinex, _plugins, _mmhook);
+                var outputFolder = Path.Combine(args[0], Bepinex, Plugins, Mmhook);
 
                 ValheimPath = args[0];
-                if (Directory.Exists(Path.Combine(args[0], _valheimData, _managed)))
+                if (Directory.Exists(Path.Combine(args[0], ValheimData, Managed)))
                 {
-                    foreach (var file in Directory.GetFiles(Path.Combine(args[0], _valheimData, _managed), "assembly_*.dll"))
+                    foreach (var file in Directory.GetFiles(Path.Combine(args[0], ValheimData, Managed), "assembly_*.dll"))
                     {
                         if (!HashAndCompare(file, outputFolder))
                         {
@@ -58,9 +55,9 @@ namespace JotunnBuildTask
                     }
                 }
 
-                if (Directory.Exists(Path.Combine(args[0], _valheimServerData, _managed)))
+                if (Directory.Exists(Path.Combine(args[0], ValheimServerData, Managed)))
                 {
-                    foreach (var file in Directory.GetFiles(Path.Combine(args[0], _valheimServerData, _managed), "assembly_*.dll"))
+                    foreach (var file in Directory.GetFiles(Path.Combine(args[0], ValheimServerData, Managed), "assembly_*.dll"))
                     {
                         if (!HashAndCompare(file, outputFolder))
                         {
@@ -69,8 +66,6 @@ namespace JotunnBuildTask
                         }
                     }
                 }
-
-
 
                 return 0;
             }
@@ -82,12 +77,12 @@ namespace JotunnBuildTask
         }
 
         /// <summary>
-        ///     Hash file and compare with old hash
-        ///     Create new MMHOOK dll if not equal
+        ///     Hash file and compare with old hash.
+        ///     Create new MMHOOK dll if not equal.
         /// </summary>
         /// <param name="file">dll to monomod</param>
         /// <param name="outputFolder">output file name</param>
-        private static bool HashAndCompare(string file, string outputFolder)
+        internal static bool HashAndCompare(string file, string outputFolder)
         {
             var hash = MD5HashFile(file);
 
@@ -107,11 +102,11 @@ namespace JotunnBuildTask
                 return false;
             }
 
-            string publicizedFile = Path.Combine(Path.GetDirectoryName(file), _publicized_assemblies,
-                $"{Path.GetFileNameWithoutExtension(file)}_{_publicized}{Path.GetExtension(file)}");
+            string publicizedFile = Path.Combine(Path.GetDirectoryName(file), PublicizedAssemblies,
+                $"{Path.GetFileNameWithoutExtension(file)}_{Publicized}{Path.GetExtension(file)}");
 
             // only write the hash to file if HookGen was successful
-            if (InvokeHookgen(publicizedFile, Path.Combine(outputFolder, $"{_mmhook}_{Path.GetFileNameWithoutExtension(file)}_{_publicized}{Path.GetExtension(file)}"), hash))
+            if (InvokeHookgen(publicizedFile, Path.Combine(outputFolder, $"{Mmhook}_{Path.GetFileNameWithoutExtension(file)}_{Publicized}{Path.GetExtension(file)}"), hash))
             {
                 File.WriteAllText(hashFilePath, hash);
                 return true;
@@ -121,28 +116,28 @@ namespace JotunnBuildTask
         }
 
         /// <summary>
-        ///     Call monomod hookgen
+        ///     Call Monomod hookgen.
         /// </summary>
         /// <param name="file">input dll</param>
         /// <param name="output">output dll</param>
         /// <returns></returns>
-        private static bool InvokeHookgen(string file, string output, string md5)
+        internal static bool InvokeHookgen(string file, string output, string md5)
         {
             MonoModder modder = new MonoModder();
             modder.InputPath = file;
             modder.OutputPath = output;
             modder.ReadingMode = ReadingMode.Deferred;
 
-            if (Directory.Exists(Path.Combine(ValheimPath, _valheimData, _managed)))
+            if (Directory.Exists(Path.Combine(ValheimPath, ValheimData, Managed)))
             {
-                ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, _valheimData, _managed));
+                ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, ValheimData, Managed));
             }
 
-            if (Directory.Exists(Path.Combine(ValheimPath, _valheimServerData, _managed)))
+            if (Directory.Exists(Path.Combine(ValheimPath, ValheimServerData, Managed)))
             {
-                ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, _valheimServerData, _managed));
+                ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, ValheimServerData, Managed));
             }
-            ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, _unstripped_corlib));
+            ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, UnstrippedCorlib));
 
             modder.Read();
 
@@ -169,11 +164,11 @@ namespace JotunnBuildTask
         }
 
         /// <summary>
-        ///     Hash file (MD5)
+        ///     Hash file (MD5).
         /// </summary>
         /// <param name="filename">filename</param>
         /// <returns>MD5 hash</returns>
-        private static string MD5HashFile(string filename)
+        internal static string MD5HashFile(string filename)
         {
             var hash = MD5.Create().ComputeHash(File.ReadAllBytes(filename));
             return BitConverter.ToString(hash).Replace("-", "");

--- a/JotunnDoc/Docs/InputDoc.cs
+++ b/JotunnDoc/Docs/InputDoc.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.SceneManagement;
-using JotunnLib.Managers;
-using JotunnLib.Utils;
 
 namespace JotunnDoc.Docs
 {

--- a/JotunnDoc/JotunnDoc.cs
+++ b/JotunnDoc/JotunnDoc.cs
@@ -1,12 +1,8 @@
-﻿using System;
+﻿using System.Text.RegularExpressions;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using BepInEx;
 using UnityEngine;
-using JotunnLib.Managers;
 using JotunnDoc.Docs;
-using System.Text.RegularExpressions;
 
 namespace JotunnDoc
 {
@@ -18,9 +14,6 @@ namespace JotunnDoc
 
         private void Awake()
         {
-            // Harmony harmony = new Harmony("jotunndoc");
-            // harmony.PatchAll();
-
             docs = new List<Doc>()
             {
                 new PrefabDoc(),

--- a/JotunnDoc/Patches/ZRoutedRpcPatches.cs
+++ b/JotunnDoc/Patches/ZRoutedRpcPatches.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using JotunnLib.Utils;
 using UnityEngine;
 
@@ -16,7 +12,7 @@ namespace JotunnDoc.Patches
             On.ZRoutedRpc.Register += ZRoutedRpc_Register;
         }
 
-        private static void ZRoutedRpc_Register(On.ZRoutedRpc.orig_Register orig, ZRoutedRpc self, string name, Action<long> f)
+        internal static void ZRoutedRpc_Register(On.ZRoutedRpc.orig_Register orig, ZRoutedRpc self, string name, Action<long> f)
         {
             Debug.Log("Registered RPC: " + name + " (" + name.GetStableHashCode() + ")");
             orig(self, name, f);

--- a/JotunnLib/Configs/LocalizationConfig.cs
+++ b/JotunnLib/Configs/LocalizationConfig.cs
@@ -4,17 +4,17 @@ namespace JotunnLib.Configs
 {
     public class LocalizationConfig
     {
+        public string Language { get; set; } = "English";
         public Dictionary<string, string> Translations = new Dictionary<string, string>();
 
         public LocalizationConfig()
         {
+
         }
 
         public LocalizationConfig(string language)
         {
             Language = language;
         }
-
-        public string Language { get; set; } = "English";
     }
 }

--- a/JotunnLib/Configs/SkillConfig.cs
+++ b/JotunnLib/Configs/SkillConfig.cs
@@ -4,11 +4,10 @@ using UnityEngine;
 namespace JotunnLib.Configs
 {
     /// <summary>
-    /// Configuration class for custom skills
+    ///     Configuration class for adding custom skills.
     /// </summary>
     public class SkillConfig
     {
-        private string _identifier;
         public string Identifier
         {
             get { return _identifier; }
@@ -32,8 +31,10 @@ namespace JotunnLib.Configs
         public float IncreaseStep { get; set; }
         public Dictionary<string, LocalizationConfig> Localizations { get; private set; } = new Dictionary<string, LocalizationConfig>();
 
+        private string _identifier;
+
         /// <summary>
-        /// Creates a SkillConfig object for mods that previously used SkillInjector
+        ///     Creates a SkillConfig object for mods that previously used SkillInjector
         /// </summary>
         /// <param name="identifier">Unique identifier of the new skill, ex: "com.jotunnlib.testmod.testskill"</param>
         /// <param name="uid">"id" from SkillInjector</param>

--- a/JotunnLib/ConsoleCommands/ClearCommand.cs
+++ b/JotunnLib/ConsoleCommands/ClearCommand.cs
@@ -4,7 +4,7 @@ using JotunnLib.Entities;
 
 namespace JotunnLib.ConsoleCommands
 {
-    class ClearCommand : ConsoleCommand
+    internal class ClearCommand : ConsoleCommand
     {
         public override string Name => "clear";
 

--- a/JotunnLib/ConsoleCommands/HelpCommand.cs
+++ b/JotunnLib/ConsoleCommands/HelpCommand.cs
@@ -3,7 +3,7 @@ using JotunnLib.Entities;
 
 namespace JotunnLib.ConsoleCommands
 {
-    class HelpCommand : ConsoleCommand
+    internal class HelpCommand : ConsoleCommand
     {
         public override string Name => "help";
 

--- a/JotunnLib/Entities/ConsoleCommand.cs
+++ b/JotunnLib/Entities/ConsoleCommand.cs
@@ -1,25 +1,22 @@
-﻿using System.Collections.Generic;
-using UnityEngine;
-
-namespace JotunnLib.Entities
+﻿namespace JotunnLib.Entities
 {
     /// <summary>
-    /// A custom console command
+    ///     A custom console command.
     /// </summary>
     public abstract class ConsoleCommand
     {
         /// <summary>
-        /// The command that the user will need to type in their console to run your command.
+        ///     The command that the user will need to type in their console to run your command.
         /// </summary>
         public abstract string Name { get; }
 
         /// <summary>
-        /// The help text that will be displayed to the user for your command when they type `help` into their console.
+        ///     The help text that will be displayed to the user for your command when they type `help` into their console.
         /// </summary>
         public abstract string Help { get; }
 
         /// <summary>
-        /// The function that will be called when the user runs your console command, with space-delimited arguments.
+        ///     The function that will be called when the user runs your console command, with space-delimited arguments.
         /// </summary>
         /// <param name="args">The arguments the user types, with spaces being the delimiter.</param>
         public abstract void Run(string[] args);

--- a/JotunnLib/Entities/Mock.cs
+++ b/JotunnLib/Entities/Mock.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace JotunnLib.Entities
 {
     /// <summary>
-    /// Helper class for creating Mock for a given vanilla Component
+    ///     Helper class for creating Mock for a given vanilla Component
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public static class Mock<T> where T : Component

--- a/JotunnLib/Events/PlayerPlacedPieceEventArgs.cs
+++ b/JotunnLib/Events/PlayerPlacedPieceEventArgs.cs
@@ -1,31 +1,30 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace JotunnLib.Events
 {
     /// <summary>
-    /// Event args for when a player attempts to place a piece.
+    ///     Event args for when a player attempts to place a piece.
     /// </summary>
     public class PlayerPlacedPieceEventArgs : PlayerEventArgs
     {
         /// <summary>
-        /// The piece the player tried to place
+        ///     The piece the player tried to place.
         /// </summary>
         public Piece Piece { get; set; }
 
         /// <summary>
-        /// The position the piece was placed in
+        ///     The position the piece was placed in.
         /// </summary>
         public Vector3 Position { get; set; }
 
         /// <summary>
-        /// The rotation the piece was placed woth
+        ///     The rotation of the placed piece.
         /// </summary>
         public Quaternion Rotation { get; set; }
 
         /// <summary>
-        /// Whether the piece was sucessfully placed or not. This may be unsuccessful due to player placing the
-        /// piece in invalid locations, or not having enough resources to build it.
+        ///     Whether the piece was sucessfully placed or not. This may be unsuccessful due to player placing the
+        ///     piece in invalid locations, or not having enough resources to build it.
         /// </summary>
         public bool Success { get; set; }
     }

--- a/JotunnLib/Extensions/ItemExtensions.cs
+++ b/JotunnLib/Extensions/ItemExtensions.cs
@@ -60,7 +60,7 @@ namespace JotunnLib
             stringBuilder.AppendLine(self.m_crafterID.ToString(CultureInfo.InvariantCulture));
             stringBuilder.AppendLine(self.m_crafterName);
 
-            return Hashes.ComputeSha256Hash(stringBuilder.ToString());
+            return HashUtils.ComputeSha256Hash(stringBuilder.ToString());
         }
 
         internal static bool RemoveItemFromFile(this ItemDrop.ItemData self, string inventoryId)

--- a/JotunnLib/Extensions/MockExtentions.cs
+++ b/JotunnLib/Extensions/MockExtentions.cs
@@ -48,17 +48,17 @@ namespace JotunnLib
         }
     }
     /// <summary>
-    /// Extension class to facilitate prefab manipulations
+    ///     Extension class to facilitate prefab manipulations
     /// </summary>
     public static class PrefabExtensions
     {
         /// <summary>
-        /// Prefix used by the Mock System to recognize Mock gameObject that must be replaced at some point.
+        ///     Prefix used by the Mock System to recognize Mock gameObject that must be replaced at some point.
         /// </summary>
         public const string MockPrefix = "VLmock_";
 
         /// <summary>
-        /// Will try to find the real vanilla prefab from the given mock
+        ///     Will try to find the real vanilla prefab from the given mock
         /// </summary>
         /// <param name="unityObject"></param>
         /// <param name="mockObjectType"></param>
@@ -76,7 +76,7 @@ namespace JotunnLib
                     // Cut off the suffix in the name to correctly query the original material
                     if (unityObject is Material)
                     {
-                        const string materialInstance = " (Instance)";
+                        const string materialInstance = " (instance)";
                         if (unityObjectName.EndsWith(materialInstance))
                         {
                             unityObjectName = unityObjectName.Substring(0, unityObjectName.Length - materialInstance.Length);
@@ -91,7 +91,7 @@ namespace JotunnLib
         }
 
         /// <summary>
-        /// Will try to find the real vanilla prefab from the given mock
+        ///     Will try to find the real vanilla prefab from the given mock
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="unityObject"></param>
@@ -102,7 +102,7 @@ namespace JotunnLib
         }
 
         /// <summary>
-        /// Will attempt to fix every field that are mocks gameObjects / Components from the given object.
+        ///     Will attempt to fix every field that are mocks gameObjects / Components from the given object.
         /// </summary>
         /// <param name="objectToFix"></param>
         public static void FixReferences(this object objectToFix)
@@ -290,7 +290,7 @@ namespace JotunnLib
         }
 
         /// <summary>
-        /// Fix the components fields of a given gameObject
+        ///     Fix the components fields of a given gameObject
         /// </summary>
         /// <param name="gameObject"></param>
         public static void FixReferences(this GameObject gameObject)
@@ -302,7 +302,7 @@ namespace JotunnLib
         }
 
         /// <summary>
-        /// Will clone all fields from gameObject to objectToClone
+        ///     Will clone all fields from gameObject to objectToClone
         /// </summary>
         /// <param name="gameObject"></param>
         /// <param name="objectToClone"></param>

--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -434,7 +434,7 @@
     <Compile Include="Utils\BoneReorder.cs" />
     <Compile Include="Utils\ConfigurationManagerAttributes.cs" />
     <Compile Include="Utils\EventsHelper.cs" />
-    <Compile Include="Utils\Hashes.cs" />
+    <Compile Include="Utils\HashUtils.cs" />
     <Compile Include="Properties\IgnoreAccessModifiers.cs" />
     <Compile Include="Extensions\MockExtentions.cs" />
     <Compile Include="Extensions\ObjectExtension.cs" />

--- a/JotunnLib/Logger.cs
+++ b/JotunnLib/Logger.cs
@@ -6,21 +6,21 @@ namespace JotunnLib
 {
     /// <summary>
     ///     A namespace wide Logger class, which automatically creates a <see cref="ManualLogSource" />
-    ///     for every namespace from which it is being called
+    ///     for every namespace from which it is being called.
     /// </summary>
     public class Logger
     {
-        private static Logger Instance;
-
-        private readonly Dictionary<string, ManualLogSource> m_logger = new Dictionary<string, ManualLogSource>();
+        private static Logger instance;
+        
+        private readonly Dictionary<string, ManualLogSource> logger = new Dictionary<string, ManualLogSource>();
 
         private Logger() { }
 
         internal static void Init()
         {
-            if (Instance == null)
+            if (instance == null)
             {
-                Instance = new Logger();
+                instance = new Logger();
             }
         }
 
@@ -28,23 +28,23 @@ namespace JotunnLib
         {
             LogDebug("Destroying Logger");
 
-            foreach (var entry in Instance.m_logger)
+            foreach (var entry in instance.logger)
             {
                 BepInEx.Logging.Logger.Sources.Remove(entry.Value);
             }
 
-            Instance.m_logger.Clear();
+            instance.logger.Clear();
         }
 
-        private ManualLogSource GetLogger()
+        private ManualLogSource getLogger()
         {
             var type = new StackFrame(2).GetMethod().DeclaringType;
 
             ManualLogSource ret;
-            if (!m_logger.TryGetValue(type.Namespace, out ret))
+            if (!logger.TryGetValue(type.Namespace, out ret))
             {
                 ret = BepInEx.Logging.Logger.CreateLogSource(type.Namespace);
-                m_logger.Add(type.Namespace, ret);
+                logger.Add(type.Namespace, ret);
             }
 
             return ret;
@@ -52,32 +52,32 @@ namespace JotunnLib
 
         public static void LogFatal(object data)
         {
-            Instance.GetLogger().LogFatal(data);
+            instance.getLogger().LogFatal(data);
         }
 
         public static void LogError(object data)
         {
-            Instance.GetLogger().LogError(data);
+            instance.getLogger().LogError(data);
         }
 
         public static void LogWarning(object data)
         {
-            Instance.GetLogger().LogWarning(data);
+            instance.getLogger().LogWarning(data);
         }
 
         public static void LogMessage(object data)
         {
-            Instance.GetLogger().LogMessage(data);
+            instance.getLogger().LogMessage(data);
         }
 
         public static void LogInfo(object data)
         {
-            Instance.GetLogger().LogInfo(data);
+            instance.getLogger().LogInfo(data);
         }
 
         public static void LogDebug(object data)
         {
-            Instance.GetLogger().LogDebug(data);
+            instance.getLogger().LogDebug(data);
         }
     }
 }

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -6,7 +6,6 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using BepInEx;
 using BepInEx.Configuration;
-using JotunnLib.ConsoleCommands;
 using JotunnLib.Managers;
 using JotunnLib.Utils;
 
@@ -16,9 +15,17 @@ namespace JotunnLib
     [NetworkCompatibilty(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     public class Main : BaseUnityPlugin
     {
-        // Version
+        /// <summary>
+        ///     The current version of the Jotunn library.
+        /// </summary>
         public const string Version = "0.2.0";
+
+        /// <summary>
+        ///     The BepInEx plugin Mod GUID being used.
+        /// </summary>
         public const string ModGuid = "com.bepinex.plugins.jotunnlib";
+
+        internal static GameObject RootObject;
 
         // Load order for managers
         private readonly List<Type> managerTypes = new List<Type>()
@@ -37,12 +44,9 @@ namespace JotunnLib
             typeof(SaveManager),
             typeof(SynchronizationManager)
         };
-
         private readonly List<Manager> managers = new List<Manager>();
 
-        internal static GameObject RootObject;
-
-        private void Awake()
+        internal void Awake()
         {
             // Initialize Logger
             JotunnLib.Logger.Init();
@@ -62,8 +66,6 @@ namespace JotunnLib
                 Logger.LogInfo("Initialized " + manager.GetType().Name);
             }
 
-            InitCommands(); // should that be a manager?
-
             Logger.LogInfo("JotunnLib v" + Version + " loaded successfully");
 
 #if DEBUG
@@ -75,14 +77,14 @@ namespace JotunnLib
 
 
         /// <summary>
-        /// Initialize patches
+        ///     Initialize patches
         /// </summary>
-        public void Start()
+        internal void Start()
         {
-            InitializePatches();
+            initializePatches();
         }
 
-        private void Update()
+        internal void Update()
         {
 #if DEBUG
             if (Input.GetKeyDown(KeyCode.F6))
@@ -101,9 +103,9 @@ namespace JotunnLib
         }
 
         /// <summary>
-        /// Invoke Patch initialization methods
+        ///     Invoke patch initialization methods for all loaded mods.
         /// </summary>
-        private void InitializePatches()
+        private void initializePatches()
         {
             // Reflect through everything
             List<Tuple<MethodInfo, int>> types = new List<Tuple<MethodInfo, int>>();
@@ -140,12 +142,6 @@ namespace JotunnLib
                 Logger.LogInfo($"Applying patches in {tuple.Item1.DeclaringType.Name}.{tuple.Item1.Name}");
                 tuple.Item1.Invoke(null, null);
             }
-        }
-
-        private void InitCommands()
-        {
-            CommandManager.Instance.RegisterConsoleCommand(new HelpCommand());
-            CommandManager.Instance.RegisterConsoleCommand(new ClearCommand());
         }
     }
 }

--- a/JotunnLib/Manager.cs
+++ b/JotunnLib/Manager.cs
@@ -3,22 +3,22 @@
 namespace JotunnLib
 {
     /// <summary>
-    /// The base class for all the library's various Managers
+    ///     The base class for all the library's various Managers
     /// </summary>
     public abstract class Manager : MonoBehaviour
     {
         /// <summary>
-        /// Initialize manager class after all manager scripts have been added to the root game object
+        ///     Initialize manager class after all manager scripts have been added to the root game object
         /// </summary>
         internal virtual void Init() { }
 
         /// <summary>
-        /// Load any data registered by mods into the game
+        ///     Load any data registered by mods into the game
         /// </summary>
         internal virtual void Load() { }
 
         /// <summary>
-        /// Register any data from user mods
+        ///     Register any data from user mods
         /// </summary>
         internal virtual void Register() { }
     }

--- a/JotunnLib/Managers/CommandManager.cs
+++ b/JotunnLib/Managers/CommandManager.cs
@@ -1,26 +1,39 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using UnityEngine;
 using JotunnLib.Entities;
+using JotunnLib.ConsoleCommands;
 
 namespace JotunnLib.Managers
 {
+    /// <summary>
+    ///     Handles loading of all custom console and chat commands.
+    /// </summary>
     public class CommandManager : Manager
     {
+        /// <summary>
+        ///     The singleton instance of this manager.
+        /// </summary>
         public static CommandManager Instance { get; private set; }
 
+        /// <summary>
+        ///     The console commands that are built-in to Valheim. These cannot be changed or overriden, and
+        ///     no other commands can be declared with the same names as these.
+        /// </summary>
         public static ReadOnlyCollection<string> DefaultConsoleCommands => _defaultConsoleCommands.AsReadOnly();
+
+        /// <summary>
+        ///     The "dev" console commands that are built-in to Valheim. These cannot be changed or overriden, and
+        ///     no other commands can be declared with the same names as these.
+        /// </summary>
+        public static ReadOnlyCollection<string> DefaultCheatConsoleCommands => _defaultCheatConsoleCommands.AsReadOnly();
 
         private static List<string> _defaultConsoleCommands = new List<string>()
         {
             // "help" command not included since we want to overwrite it
             
-            // Basic commands
+            // Basic (non-dev) commands
             "kick", "ban", "unban", "banned", "ping", "lodbias", "info", "devcommands"
         };
-
-        public static ReadOnlyCollection<string> DefaultCheatConsoleCommands => _defaultCheatConsoleCommands.AsReadOnly();
-
         private static readonly List<string> _defaultCheatConsoleCommands = new List<string>()
         {
             "genloc", "debugmode", "spawn", "pos", "goto", "exploremap", "resetmap", "killall", "tame",
@@ -29,34 +42,40 @@ namespace JotunnLib.Managers
             "resetcharacter", "removedrops", "setkey", "resetkeys", "listkeys", "players", "dpsdebug"
         };
 
+        /// <summary>
+        ///     A list of all the custom console commands that have been added to the game through this manager,
+        ///     either by Jotunn or by mods using Jotunn.
+        /// </summary>
         public ReadOnlyCollection<ConsoleCommand> ConsoleCommands => _consoleCommands.AsReadOnly();
 
         private List<ConsoleCommand> _consoleCommands = new List<ConsoleCommand>();
 
-        private void Awake()
+        /// <summary>
+        ///     Initialize console commands that come with Jotunn.
+        /// </summary>
+        internal override void Init()
         {
-            if (Instance != null)
-            {
-                Logger.LogError("Error, two instances of singleton: " + this.GetType().Name);
-                return;
-            }
-
-            Instance = this;
+            RegisterConsoleCommand(new HelpCommand());
+            RegisterConsoleCommand(new ClearCommand());
         }
 
+        /// <summary>
+        ///     Adds a new console command to Valheim.
+        /// </summary>
+        /// <param name="cmd">The console command to add</param>
         public void RegisterConsoleCommand(ConsoleCommand cmd)
         {
             // Cannot override default command
             if (_defaultConsoleCommands.Contains(cmd.Name))
             {
-                Logger.LogError("Cannot override default command: " + cmd.Name);
+                Logger.LogError($"Cannot override default command: {cmd.Name}");
                 return;
             }
 
             // Cannot have two commands with same name
             if (_consoleCommands.Exists(c => c.Name == cmd.Name))
             {
-                Logger.LogError("Cannot have two console commands with same name: " + cmd.Name);
+                Logger.LogError($"Cannot have two console commands with same name: {cmd.Name}");
                 return;
             }
 

--- a/JotunnLib/Managers/EventManager.cs
+++ b/JotunnLib/Managers/EventManager.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine;
 using JotunnLib.Events;
 
 namespace JotunnLib.Managers
@@ -14,11 +13,11 @@ namespace JotunnLib.Managers
         public static event EventHandler<PlayerEventArgs> PlayerSpawned;
         public static event EventHandler<PlayerPlacedPieceEventArgs> PlayerPlacedPiece;
 
-        private void Awake()
+        internal void Awake()
         {
             if (Instance != null)
             {
-                Logger.LogError("Error, two instances of singleton: " + this.GetType().Name);
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType().Name}");
                 return;
             }
 

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -44,7 +44,7 @@ namespace JotunnLib.Managers
         {
             if (Instance != null)
             {
-                Logger.LogError($"Two instances of singleton {GetType()}");
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType()}");
                 return;
             }
 
@@ -272,7 +272,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Create a new button (Valheim style)
+        ///     Create a new button (Valheim style).
         /// </summary>
         /// <param name="text"></param>
         /// <param name="parent"></param>
@@ -351,7 +351,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Get sprite low level fashion from sactx-2048x2048-Uncompressed-UIAtlas-a5f4e704_0 atlas
+        ///     Get sprite low level fashion from sactx-2048x2048-Uncompressed-UIAtlas-a5f4e704_0 atlas.
         /// </summary>
         /// <param name="rect">Rect on atlas texture</param>
         /// <param name="pivot">pivot</param>
@@ -359,7 +359,7 @@ namespace JotunnLib.Managers
         /// <param name="extrude"></param>
         /// <param name="meshType"></param>
         /// <param name="slice"></param>
-        /// <returns></returns>
+        /// <returns>The newly created sprite</returns>
         public Sprite CreateSpriteFromAtlas(Rect rect, Vector2 pivot, float pixelsPerUnit = 50f, uint extrude = 0,
             SpriteMeshType meshType = SpriteMeshType.FullRect, Vector4 slice = new Vector4())
         {
@@ -368,7 +368,7 @@ namespace JotunnLib.Managers
 
         /// <summary>
         ///     Get sprite low level fashion from sactx-2048x2048-Uncompressed-UIAtlas-a5f4e704 atlas (not much used ingame or old
-        ///     textures)
+        ///     textures).
         /// </summary>
         /// <param name="rect">Rect on atlas texture</param>
         /// <param name="pivot">pivot</param>
@@ -376,7 +376,7 @@ namespace JotunnLib.Managers
         /// <param name="extrude"></param>
         /// <param name="meshType"></param>
         /// <param name="slice"></param>
-        /// <returns></returns>
+        /// <returns>The newly created sprite</returns>
         public Sprite CreateSpriteFromAtlas2(Rect rect, Vector2 pivot, float pixelsPerUnit = 50f, uint extrude = 0,
             SpriteMeshType meshType = SpriteMeshType.FullRect, Vector4 slice = new Vector4())
         {
@@ -384,10 +384,10 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Get a sprite by name
+        ///     Get a sprite by name.
         /// </summary>
         /// <param name="spriteName"></param>
-        /// <returns></returns>
+        /// <returns>The sprite with given name</returns>
         public Sprite GetSprite(string spriteName)
         {
             if (Sprites.ContainsKey(spriteName))
@@ -408,7 +408,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Apply Valheim style to an inputfield component
+        ///     Apply Valheim style to an inputfield component.
         /// </summary>
         /// <param name="field"></param>
         public void ApplyInputFieldStyle(InputField field)
@@ -423,7 +423,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Apply Valheim style to a toggle
+        ///     Apply Valheim style to a toggle.
         /// </summary>
         /// <param name="toggle"></param>
         public void ApplyToogleStyle(Toggle toggle)

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -8,16 +8,16 @@ namespace JotunnLib.Managers
     public class InputManager : Manager
     {
         public static InputManager Instance { get; private set; }
+        internal static Dictionary<string, ButtonConfig> Buttons = new Dictionary<string, ButtonConfig>();
 
         public EventHandler InputRegister;
-        internal static Dictionary<string, ButtonConfig> Buttons = new Dictionary<string, ButtonConfig>();
         private bool inputsRegistered = false;
 
         private void Awake()
         {
             if (Instance != null)
             {
-                Logger.LogError("Error, two instances of singleton: " + this.GetType().Name);
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType().Name}");
                 return;
             }
 

--- a/JotunnLib/Managers/ItemManager.cs
+++ b/JotunnLib/Managers/ItemManager.cs
@@ -16,14 +16,14 @@ namespace JotunnLib.Managers
         internal readonly List<CustomStatusEffect> StatusEffects = new List<CustomStatusEffect>();
 
         /// <summary>
-        /// Event that get fired after the ObjectDB get init and before its filled with custom items.
-        /// Your code will execute once unless you resub, the event get cleared after each fire.
+        ///     Event that get fired after the ObjectDB get init and before its filled with custom items.
+        ///     Your code will execute once unless you resub, the event get cleared after each fire.
         /// </summary>
         public static Action OnBeforeCustomItemsAdded;
 
         /// <summary>
-        /// Event that get fired after the ObjectDB get init and filled with custom items.
-        /// Your code will execute once unless you resub, the event get cleared after each fire.
+        ///     Event that get fired after the ObjectDB get init and filled with custom items.
+        ///     Your code will execute once unless you resub, the event get cleared after each fire.
         /// </summary>
         public static Action OnAfterInit;
 
@@ -31,7 +31,7 @@ namespace JotunnLib.Managers
         {
             if (Instance != null)
             {
-                Logger.LogError($"Two instances of singleton {GetType()}");
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType()}");
 
                 return;
             }
@@ -41,9 +41,9 @@ namespace JotunnLib.Managers
 
         internal override void Init()
         {
-            On.ObjectDB.CopyOtherDB += RegisterCustomDataFejd;
-            On.ObjectDB.Awake += RegisterCustomData;
-            On.Player.Load += ReloadKnownRecipes;
+            On.ObjectDB.CopyOtherDB += registerCustomDataFejd;
+            On.ObjectDB.Awake += registerCustomData;
+            On.Player.Load += reloadKnownRecipes;
         }
 
         //TODO: dont know if still needed, please check
@@ -74,7 +74,7 @@ namespace JotunnLib.Managers
                 PrefabManager.Instance.AddPrefab(customItem.ItemPrefab);
                 Items.Add(customItem);
 
-                //PrefabManager.Instance.NetworkRegister(customItem.ItemPrefab);
+                //PrefabManager.instance.NetworkRegister(customItem.ItemPrefab);
                 //customItem.ItemPrefab.NetworkRegister();
 
                 return true;
@@ -97,7 +97,7 @@ namespace JotunnLib.Managers
             return true;
         }
 
-        private void RegisterCustomItems(ObjectDB objectDB)
+        private void registerCustomItems(ObjectDB objectDB)
         {
             Logger.LogInfo($"---- Adding custom items to {objectDB} ----");
 
@@ -134,7 +134,7 @@ namespace JotunnLib.Managers
             objectDB.UpdateItemHashes();
         }
 
-        private void RegisterCustomRecipes(ObjectDB objectDB)
+        private void registerCustomRecipes(ObjectDB objectDB)
         {
             Logger.LogInfo($"---- Adding custom recipes to {objectDB} ----");
 
@@ -170,7 +170,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void RegisterCustomStatusEffects(ObjectDB objectDB)
+        private void registerCustomStatusEffects(ObjectDB objectDB)
         {
             Logger.LogInfo($"---- Adding custom status effects to {objectDB} ----");
 
@@ -197,7 +197,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void RegisterCustomDataFejd(On.ObjectDB.orig_CopyOtherDB orig, ObjectDB self, ObjectDB other)
+        private void registerCustomDataFejd(On.ObjectDB.orig_CopyOtherDB orig, ObjectDB self, ObjectDB other)
         {
             orig(self, other);
 
@@ -209,7 +209,7 @@ namespace JotunnLib.Managers
                 OnBeforeCustomItemsAdded.SafeInvoke();
                 OnBeforeCustomItemsAdded = null;
 
-                RegisterCustomItems(self);
+                registerCustomItems(self);
 
                 self.UpdateItemHashes();
 
@@ -218,7 +218,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void RegisterCustomData(On.ObjectDB.orig_Awake orig, ObjectDB self)
+        private void registerCustomData(On.ObjectDB.orig_Awake orig, ObjectDB self)
         {
             orig(self);
 
@@ -230,9 +230,9 @@ namespace JotunnLib.Managers
                 OnBeforeCustomItemsAdded.SafeInvoke();
                 OnBeforeCustomItemsAdded = null;
 
-                RegisterCustomItems(self);
-                RegisterCustomRecipes(self);
-                RegisterCustomStatusEffects(self);
+                registerCustomItems(self);
+                registerCustomRecipes(self);
+                registerCustomStatusEffects(self);
 
                 self.UpdateItemHashes();
 
@@ -244,7 +244,7 @@ namespace JotunnLib.Managers
             OnItemsRegistered?.Invoke(null, EventArgs.Empty);
         }
 
-        private void ReloadKnownRecipes(On.Player.orig_Load orig, Player self, ZPackage pkg)
+        private void reloadKnownRecipes(On.Player.orig_Load orig, Player self, ZPackage pkg)
         {
             orig(self, pkg);
 

--- a/JotunnLib/Managers/LocalizationManager.cs
+++ b/JotunnLib/Managers/LocalizationManager.cs
@@ -18,12 +18,12 @@ namespace JotunnLib.Managers
         public const char TokenFirstChar = '$';
 
         /// <summary>
-        ///     Default language of the game
+        ///     Default language of the game.
         /// </summary>
         public const string DefaultLanguage = "English";
 
         /// <summary>
-        ///     Name of the folder that will hold the custom .json translations files
+        ///     Name of the folder that will hold the custom .json translations files.
         /// </summary>
         public const string TranslationsFolderName = "Translations";
 
@@ -33,29 +33,32 @@ namespace JotunnLib.Managers
         public const string CommunityTranslationFileName = "community_translation.json";
 
         /// <summary>
-        ///     Call into unity's DoQuoteLineSplit
+        ///     The singleton instance of this manager.
+        /// </summary>
+        public static LocalizationManager Instance { get; private set; }
+
+        /// <summary>
+        ///     Call into unity's DoQuoteLineSplit.
         /// </summary>
         internal static Func<StringReader, List<List<string>>> DoQuoteLineSplit;
 
         /// <summary>
-        ///     Dictionary holding all localizations
+        ///     Dictionary holding all localizations.
         /// </summary>
         internal Dictionary<string, Dictionary<string, string>> Localizations = new Dictionary<string, Dictionary<string, string>>();
 
-        private bool registered;
-        public static LocalizationManager Instance { get; private set; }
-
         /// <summary>
-        ///     Event for plugins to register their localizations via code
+        ///     Event for plugins to register their localizations via code.
         /// </summary>
         public event EventHandler LocalizationRegister;
 
+        private bool registered;
 
         private void Awake()
         {
             if (Instance != null)
             {
-                Logger.LogError("Error, two instances of singleton: " + GetType().Name);
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType().Name}");
                 return;
             }
 
@@ -63,7 +66,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Initialize localization manager
+        ///     Initialize localization manager.
         /// </summary>
         internal override void Init()
         {
@@ -106,7 +109,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Register all plugin's localizations
+        ///     Register all plugin's localizations.
         /// </summary>
         internal override void Register()
         {
@@ -120,14 +123,14 @@ namespace JotunnLib.Managers
 
             Logger.LogInfo("---- Registering custom localizations ----");
 
-            AddLanguageFilesFromPluginFolder();
+            addLanguageFilesFromPluginFolder();
 
             LocalizationRegister?.Invoke(null, EventArgs.Empty);
             registered = true;
         }
 
         /// <summary>
-        ///     Load the localization into Valheim's buffers
+        ///     Load the localization into Valheim's buffers.
         /// </summary>
         /// <param name="localization"></param>
         /// <param name="language"></param>
@@ -140,11 +143,11 @@ namespace JotunnLib.Managers
             }
 
             Logger.LogDebug($"Adding tokens for language {language}");
-            AddTokens(localization, language);
+            addTokens(localization, language);
         }
 
         /// <summary>
-        ///     Registers a new translation for a word for the current language
+        ///     Registers a new translation for a word for the current language.
         /// </summary>
         /// <param name="key">Key to translate</param>
         /// <param name="text">Translation</param>
@@ -155,7 +158,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Registers a new Localization for a language
+        ///     Registers a new Localization for a language.
         /// </summary>
         /// <param name="localization">The localization for a language</param>
         public void RegisterLocalization(string language, Dictionary<string, string> localization)
@@ -191,9 +194,9 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Search for and add localization files
+        ///     Search for and add localization files.
         /// </summary>
-        private void AddLanguageFilesFromPluginFolder()
+        private void addLanguageFilesFromPluginFolder()
         {
             // First search for the community translation
             var communityTranslationsFilePaths = new List<string>();
@@ -230,9 +233,8 @@ namespace JotunnLib.Managers
             }
         }
 
-
         /// <summary>
-        ///     Add a token and its value to the specified language (default to English)
+        ///     Add a token and its value to the specified language (default to "English").
         /// </summary>
         /// <param name="token">token / key</param>
         /// <param name="value">value that will be printed in the game</param>
@@ -242,7 +244,7 @@ namespace JotunnLib.Managers
         {
             if (token[0] != TokenFirstChar)
             {
-                throw new Exception($"Token first char should be {TokenFirstChar} ! (token : {token})");
+                throw new Exception($"Token first char should be '{TokenFirstChar}'! (token found: '{token}')");
             }
 
             Dictionary<string, string> languageDict = null;
@@ -255,13 +257,13 @@ namespace JotunnLib.Managers
                     {
                         if (pair.Key == token)
                         {
-                            throw new Exception($"Token named {token} already exist !");
+                            throw new Exception($"Token named {token} already exist!");
                         }
                     }
                 }
             }
 
-            languageDict ??= GetLanguageDict(language);
+            languageDict ??= getLanguageDict(language);
 
             var tokenWithoutFirstChar = token.Substring(1);
             languageDict.Remove(tokenWithoutFirstChar);
@@ -270,7 +272,7 @@ namespace JotunnLib.Managers
 
 
         /// <summary>
-        ///     Add a token and its value to the English language
+        ///     Add a token and its value to the "English" language.
         /// </summary>
         /// <param name="token">token / key</param>
         /// <param name="value">value that will be printed in the game</param>
@@ -282,7 +284,7 @@ namespace JotunnLib.Managers
 
 
         /// <summary>
-        ///     Add a file via absolute path
+        ///     Add a file via absolute path.
         /// </summary>
         /// <param name="path">Absolute path to file</param>
         /// <param name="isJson">Is the language file a json file</param>
@@ -310,7 +312,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Add a language file (that match the game format)
+        ///     Add a language file (that match the game format).
         /// </summary>
         /// <param name="fileContent">Entire file as string</param>
         public void Add(string fileContent)
@@ -320,13 +322,13 @@ namespace JotunnLib.Managers
                 throw new NullReferenceException($"param {nameof(fileContent)} is null");
             }
 
-            LoadLanguageFile(fileContent);
+            loadLanguageFile(fileContent);
         }
 
         /// <summary>
-        ///     Add a json language file (match crowdin format)
+        ///     Add a json language file (match crowdin format).
         /// </summary>
-        /// <param name="language">Language for the json file, example : "English"</param>
+        /// <param name="language">Language for the json file, for example, "English"</param>
         /// <param name="fileContent">Entire file as string</param>
         public void AddJson(string language, string fileContent)
         {
@@ -335,14 +337,14 @@ namespace JotunnLib.Managers
                 throw new NullReferenceException($"param {nameof(fileContent)} is null");
             }
 
-            LoadJsonLanguageFile(language, fileContent);
+            loadJsonLanguageFile(language, fileContent);
         }
 
         /// <summary>
-        ///     Load unity style language file
+        ///     Load Unity style language file.
         /// </summary>
         /// <param name="fileContent"></param>
-        private void LoadLanguageFile(string fileContent)
+        private void loadLanguageFile(string fileContent)
         {
             var stringReader = new StringReader(fileContent);
             var languages = stringReader.ReadLine().Split(',');
@@ -364,7 +366,7 @@ namespace JotunnLib.Managers
                                 tokenValue = keyAndValues[1];
                             }
 
-                            var languageDict = GetLanguageDict(language);
+                            var languageDict = getLanguageDict(language);
                             languageDict[token]= tokenValue;
                         }
                     }
@@ -373,11 +375,11 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Get the dictionary for a specific language
+        ///     Get the dictionary for a specific language.
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        private Dictionary<string, string> GetLanguageDict(string language)
+        private Dictionary<string, string> getLanguageDict(string language)
         {
             if (!Localizations.ContainsKey(language))
             {
@@ -388,13 +390,13 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Load community translation file
+        ///     Load community translation file.
         /// </summary>
         /// <param name="language"></param>
         /// <param name="fileContent"></param>
-        private void LoadJsonLanguageFile(string language, string fileContent)
+        private void loadJsonLanguageFile(string language, string fileContent)
         {
-            var languageDict = GetLanguageDict(language);
+            var languageDict = getLanguageDict(language);
 
             var json = (IDictionary<string, object>) SimpleJson.SimpleJson.DeserializeObject(fileContent);
 
@@ -409,11 +411,11 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        ///     Add tokens to the respective localization
+        ///     Add tokens to the respective localization.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="language"></param>
-        private void AddTokens(Localization self, string language)
+        private void addTokens(Localization self, string language)
         {
             if (Localizations.TryGetValue(language, out var tokens))
             {

--- a/JotunnLib/Managers/MockManager.cs
+++ b/JotunnLib/Managers/MockManager.cs
@@ -8,10 +8,13 @@ using UnityEngine;
 namespace JotunnLib.Managers
 {
     /// <summary>
-    /// Handles all logic to do with managing mocked prefabs added into the game.
+    ///     Handles all logic to do with managing mocked prefabs added into the game.
     /// </summary>
     class MockManager : Manager
     {
+        /// <summary>
+        ///     The singleton instance of this manager.
+        /// </summary>
         public static MockManager Instance { get; private set; }
 
         internal GameObject MockPrefabContainer;
@@ -20,7 +23,7 @@ namespace JotunnLib.Managers
         {
             if (Instance != null)
             {
-                Logger.LogError($"Two instances of singleton {GetType()}");
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType()}");
                 return;
             }
 
@@ -33,7 +36,7 @@ namespace JotunnLib.Managers
             MockPrefabContainer.transform.parent = Main.RootObject.transform;
             MockPrefabContainer.SetActive(false);
 
-            On.ObjectDB.Awake += RemoveMockPrefabs;
+            On.ObjectDB.Awake += removeMockPrefabs;
         }
 
         internal T CreateMockedPrefab<T>(string prefabName) where T : Component
@@ -64,7 +67,7 @@ namespace JotunnLib.Managers
 
         }
 
-        private void RemoveMockPrefabs(On.ObjectDB.orig_Awake orig, ObjectDB self)
+        private void removeMockPrefabs(On.ObjectDB.orig_Awake orig, ObjectDB self)
         {
             orig(self);
             var isValid = self.IsValid();

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -5,16 +5,16 @@ using UnityEngine;
 
 namespace JotunnLib.Managers
 {
+    /// <summary>
+    ///     Handles all logic to do with adding custom Pieces and PieceTables to the game.
+    /// </summary>
     public class PieceManager : Manager
     {
+        /// <summary>
+        ///     The singleton instance of this manager.
+        /// </summary>
         public static PieceManager Instance { get; private set; }
-        //public event EventHandler PieceTableRegister;
-        //public event EventHandler PieceRegister;
-        //private bool loaded = false;
 
-        public event EventHandler OnPiecesRegistered;
-        public event EventHandler OnPieceTablesRegistered;
-        internal GameObject PieceTableContainer;
         internal readonly Dictionary<string, PieceTable> PieceTables = new Dictionary<string, PieceTable>();
         internal readonly Dictionary<string, string> PieceTableNameMap = new Dictionary<string, string>()
         {
@@ -22,13 +22,17 @@ namespace JotunnLib.Managers
             { "Hammer", "_HammerPieceTable" },
             { "Hoe", "_HoePieceTable" }
         };
+
+        public event EventHandler OnPiecesRegistered;
+        public event EventHandler OnPieceTablesRegistered;
+        internal GameObject PieceTableContainer;
         internal List<CustomPiece> Pieces = new List<CustomPiece>();
 
         private void Awake()
         {
             if (Instance != null)
             {
-                Logger.LogError($"Two instances of singleton {GetType()}");
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType()}");
                 return;
             }
 
@@ -54,8 +58,8 @@ namespace JotunnLib.Managers
             }
 
             // Setup Hooks
-            On.ObjectDB.Awake += RegisterCustomData;
-            On.Player.Load += ReloadKnownRecipes;
+            On.ObjectDB.Awake += registerCustomData;
+            On.Player.Load += reloadKnownRecipes;
         }
 
         //TODO: Dont know if needed anymore
@@ -186,7 +190,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void RegisterInObjectDB(ObjectDB objectDB)
+        private void registerInObjectDB(ObjectDB objectDB)
         {
             Logger.LogInfo($"---- Adding custom pieces to {objectDB} ----");
 
@@ -212,7 +216,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void RegisterCustomData(On.ObjectDB.orig_Awake orig, ObjectDB self)
+        private void registerCustomData(On.ObjectDB.orig_Awake orig, ObjectDB self)
         {
             orig(self);
 
@@ -221,7 +225,7 @@ namespace JotunnLib.Managers
 
             if (isValid)
             {
-                RegisterInObjectDB(self);
+                registerInObjectDB(self);
             }
 
             // Fire event that everything is added and registered
@@ -229,7 +233,7 @@ namespace JotunnLib.Managers
             OnPiecesRegistered?.Invoke(null, EventArgs.Empty);
         }
 
-        private void ReloadKnownRecipes(On.Player.orig_Load orig, Player self, ZPackage pkg)
+        private void reloadKnownRecipes(On.Player.orig_Load orig, Player self, ZPackage pkg)
         {
             orig(self, pkg);
 

--- a/JotunnLib/Managers/SaveManager.cs
+++ b/JotunnLib/Managers/SaveManager.cs
@@ -7,10 +7,10 @@ namespace JotunnLib.Managers
 {
     internal class SaveManager : Manager
     {
-        internal static SaveManager Instance { get; private set; }
-
         internal const string PlayerPrefix = "player_";
         internal const string EntrySeparator = ".";
+
+        internal static SaveManager Instance { get; private set; }
 
         internal readonly char[] InvalidFileNameChars = Path.GetInvalidFileNameChars();
 
@@ -32,24 +32,24 @@ namespace JotunnLib.Managers
         {
             Directory.CreateDirectory(Paths.CustomItemDataFolder);
 
-            On.Container.Awake += AddToCache;
-            On.Container.OnDestroyed += RemoveFromCache;
+            On.Container.Awake += addToCache;
+            On.Container.OnDestroyed += removeFromCache;
 
-            IL.Inventory.MoveAll += FixMoveAllPerformance;
-            On.Inventory.Save += SaveModdedItems;
-            On.Inventory.Load += AddBackCustomItems;
+            IL.Inventory.MoveAll += fixMoveAllPerformance;
+            On.Inventory.Save += saveModdedItems;
+            On.Inventory.Load += addBackCustomItems;
         }
 
-        private static bool OptimizedRemoveItem(Inventory fromInventory, ItemDrop.ItemData item)
+        private static bool optimizedRemoveItem(Inventory fromInventory, ItemDrop.ItemData item)
         {
             return fromInventory.m_inventory.Remove(item);
         }
 
-        private static void FixMoveAllPerformance(ILContext il)
+        private static void fixMoveAllPerformance(ILContext il)
         {
             var cursor = new ILCursor(il);
 
-            var optimizedRemoveItemMethodReference = il.Import(typeof(SaveManager).GetMethod(nameof(SaveManager.OptimizedRemoveItem), ReflectionHelper.AllBindingFlags));
+            var optimizedRemoveItemMethodReference = il.Import(typeof(SaveManager).GetMethod(nameof(SaveManager.optimizedRemoveItem), ReflectionHelper.AllBindingFlags));
 
             if (cursor.TryGotoNext(i => i.MatchCallOrCallvirt<Inventory>(nameof(Inventory.RemoveItem))))
             {
@@ -70,7 +70,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void AddToCache(On.Container.orig_Awake orig, Container self)
+        private void addToCache(On.Container.orig_Awake orig, Container self)
         {
             orig(self);
 
@@ -80,7 +80,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void RemoveFromCache(On.Container.orig_OnDestroyed orig, Container self)
+        private void removeFromCache(On.Container.orig_OnDestroyed orig, Container self)
         {
             orig(self);
 
@@ -90,7 +90,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void SaveModdedItems(On.Inventory.orig_Save orig, Inventory self, ZPackage pkg)
+        private void saveModdedItems(On.Inventory.orig_Save orig, Inventory self, ZPackage pkg)
         {
             orig(self, pkg);
 
@@ -123,7 +123,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private void AddBackCustomItems(On.Inventory.orig_Load orig, Inventory self, ZPackage pkg)
+        private void addBackCustomItems(On.Inventory.orig_Load orig, Inventory self, ZPackage pkg)
         {
             orig(self, pkg);
 

--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -5,23 +5,24 @@ using UnityEngine;
 namespace JotunnLib.Managers
 {
     /// <summary>
-    /// Handles all logic that has to do with skills, and registering custom skills
+    ///     Handles all logic that has to do with skills, and adding custom skills.
     /// </summary>
     public class SkillManager : Manager
     {
         /// <summary>
-        /// Global singleton instance of the manager
+        ///     Global singleton instance of the manager.
         /// </summary>
         public static SkillManager Instance { get; private set; }
 
         internal Dictionary<Skills.SkillType, SkillConfig> Skills = new Dictionary<Skills.SkillType, SkillConfig>();
+        
         // FIXME: Deprecate
         private int nextSkillId = 1000;
         private void Awake()
         {
             if (Instance != null)
             {
-                Logger.LogError("Error, two instances of singleton: " + this.GetType().Name);
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType().Name}");
                 return;
             }
 
@@ -29,9 +30,9 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        /// DEPRECATED DUE TO POSSIBLE CONFLICT ISSUE, see: <see href="https://github.com/jotunnlib/jotunnlib/issues/18">GitHub Issue</see>
-        /// <para/>
-        /// Register a new skill with given parameters, and registers translations for it in the current localization
+        ///     DEPRECATED DUE TO POSSIBLE CONFLICT ISSUE, see: <see href="https://github.com/jotunnlib/jotunnlib/issues/18">GitHub Issue</see>.
+        ///     <para/>
+        ///     Register a new skill with given parameters, and registers translations for it in the current localization.
         /// </summary>
         /// <param name="name">Name of the new skill</param>
         /// <param name="description">Description of the new skill</param>
@@ -71,7 +72,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        /// Register a new skill with given SkillConfig object, and registers translations for it in the current localization
+        ///     Register a new skill with given SkillConfig object, and registers translations for it in the current localization.
         /// </summary>
         /// <param name="skillConfig">SkillConfig object representing new skill to register</param>
         /// <returns>The SkillType of the newly registered skill</returns>
@@ -97,7 +98,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        /// Register a new skill with given parameters, and registers translations for it in the current localization
+        ///     Register a new skill with given parameters, and registers translations for it in the current localization.
         /// </summary>
         /// <param name="identifer">Unique identifier of the new skill, ex: "com.jotunnlib.testmod.testskill"</param>
         /// <param name="name">Name of the new skill</param>
@@ -124,7 +125,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        /// Gets a custom skill with given SkillType
+        ///     Gets a custom skill with given SkillType.
         /// </summary>
         /// <param name="skillType">SkillType to look for</param>
         /// <returns>Custom skill with given SkillType</returns>
@@ -159,7 +160,7 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
-        /// Gets a custom skill with given skill identifier
+        ///     Gets a custom skill with given skill identifier.
         /// </summary>
         /// <param name="identifier">String indentifer of SkillType to look for</param>
         /// <returns>Custom skill with given SkillType</returns>

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -12,21 +12,21 @@ namespace JotunnLib.Managers
 
         internal override void Init()
         {
-            On.ZNetScene.Awake += RegisterAllToZNetScene;
+            On.ZNetScene.Awake += registerAllToZNetScene;
         }
 
         private void Awake()
         {
             if (Instance != null)
             {
-                Logger.LogError($"Two instances of singleton {GetType()}");
+                Logger.LogError($"Cannot have multiple instances of singleton: {GetType()}");
                 return;
             }
 
             Instance = this;
         }
 
-        public void RegisterAllToZNetScene(On.ZNetScene.orig_Awake orig, ZNetScene self)
+        public void registerAllToZNetScene(On.ZNetScene.orig_Awake orig, ZNetScene self)
         {
             orig(self);
             

--- a/JotunnLib/Patches/SkillsPatches.cs
+++ b/JotunnLib/Patches/SkillsPatches.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace JotunnLib.Patches
 {
-    class SkillsPatches 
+    internal class SkillsPatches 
     {
         [PatchInit(0)]
         public static void Init()

--- a/JotunnLib/Patches/ZNetPatches.cs
+++ b/JotunnLib/Patches/ZNetPatches.cs
@@ -4,7 +4,7 @@ using JotunnLib.Utils;
 
 namespace JotunnLib.Patches
 {
-    public class ZNetPatches
+    internal class ZNetPatches
     {
         [PatchInit(0)]
         public static void Init()

--- a/JotunnLib/Patches/ZoneSystemPatches.cs
+++ b/JotunnLib/Patches/ZoneSystemPatches.cs
@@ -6,7 +6,7 @@ using JotunnLib.Utils;
 
 namespace JotunnLib.Patches
 {
-    class ZoneSystemPatches
+    internal class ZoneSystemPatches
     {
         [PatchInit(0)]
         public static void Init()
@@ -21,7 +21,7 @@ namespace JotunnLib.Patches
 
             Logger.LogDebug("----> ZoneSystem Awake");
 
-            // ZoneManager.Instance.Register();
+            // ZoneManager.instance.Register();
         }
 
         private static bool ZoneSystem_SpawnZone(On.ZoneSystem.orig_SpawnZone orig, ZoneSystem self, Vector2i zoneID, ZoneSystem.SpawnMode mode, out GameObject root)

--- a/JotunnLib/Utils/AssetUtils.cs
+++ b/JotunnLib/Utils/AssetUtils.cs
@@ -8,12 +8,12 @@ using System.Linq;
 namespace JotunnLib.Utils
 {
     /// <summary>
-    /// Util functions related to loading assets at runtime.
+    ///     Util functions related to loading assets at runtime.
     /// </summary>
     public static class AssetUtils
     {
         /// <summary>
-        /// Loads a <see cref="Texture2D"/> from file at runtime.
+        ///     Loads a <see cref="Texture2D"/> from file at runtime.
         /// </summary>
         /// <param name="texturePath">Texture path relative to "plugins" BepInEx folder</param>
         /// <returns>Texture2D loaded, or null if invalid path</returns>
@@ -33,7 +33,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Loads a <see cref="Sprite"/> from file at runtime.
+        ///     Loads a <see cref="Sprite"/> from file at runtime.
         /// </summary>
         /// <param name="texturePath">Texture path relative to "plugins" BepInEx folder</param>
         /// <returns>Texture2D loaded, or null if invalid path</returns>
@@ -50,7 +50,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Loads a mesh from a .obj file at runtime.
+        ///     Loads a mesh from a .obj file at runtime.
         /// </summary>
         /// <param name="meshPath">Mesh path relative to "plugins" BepInEx folder</param>
         /// <returns>Texture2D loaded, or null if invalid path</returns>
@@ -67,7 +67,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Loads an asset bundle at runtime.
+        ///     Loads an asset bundle at runtime.
         /// </summary>
         /// <param name="bundlePath">Asset bundle path relative to "plugins" BepInEx folder</param>
         /// <returns>AssetBundle loaded, or null if invalid path</returns>
@@ -84,7 +84,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        ///  Load an assembly-embedded <see cref="AssetBundle" />
+        ///     Load an assembly-embedded <see cref="AssetBundle" />
         /// </summary>
         /// <param name="bundleName">Name of the bundle</param>
         /// <returns></returns>

--- a/JotunnLib/Utils/BepInExUtils.cs
+++ b/JotunnLib/Utils/BepInExUtils.cs
@@ -4,10 +4,10 @@ using BepInEx;
 
 namespace JotunnLib.Utils
 {
-    public class BepInExUtils
+    internal class BepInExUtils
     {
         /// <summary>
-        ///     Get a dictionary of loaded plugins which depend on JotunnLib
+        ///     Get a dictionary of loaded plugins which depend on JotunnLib.
         /// </summary>
         /// <returns></returns>
         internal static Dictionary<string, BaseUnityPlugin> GetDependentPlugins(bool includeJotunnLib = false)

--- a/JotunnLib/Utils/BoneReorder.cs
+++ b/JotunnLib/Utils/BoneReorder.cs
@@ -5,25 +5,25 @@ using JotunnLib.Managers;
 namespace JotunnLib.Utils
 {
     /// <summary>
-    /// Original code from https://github.com/GoldenJude
+    ///     Original code from https://github.com/GoldenJude.
     /// </summary>
     public static class BoneReorder
     {
-        private static bool UtilityChanged = false,
-            ChestChanged = false,
-            HelmetChanged = false,
-            LegChanged = false,
-            ShoulderChanged = false;
-
-        private static bool Applied = false;
+        private static bool utilityChanged = false,
+            chestChanged = false,
+            helmetChanged = false,
+            legChanged = false,
+            shoulderChanged = false,
+            applied = false;
         
         /// <summary>
-        /// Corrects any bone disorder caused by unity incorrectly importing ripped assets.
-        /// Once enabled, bone reordering will occur whenever the equipment changes. If one plug-in requests application of reordering, it will be applied globally for all EquipmentChanged events.
+        ///     Corrects any bone disorder caused by unity incorrectly importing ripped assets.
+        ///     Once enabled, bone reordering will occur whenever the equipment changes.
+        ///     If one plug-in requests application of reordering, it will be applied globally for all EquipmentChanged events.
         /// </summary>
         public static void ApplyOnEquipmentChanged()
         {
-            if (!Applied)
+            if (!applied)
             {
                 ItemManager.OnAfterInit += () =>
                 {
@@ -34,36 +34,36 @@ namespace JotunnLib.Utils
                     On.VisEquipment.SetLegEquiped += VisEquipmentOnSetLegEquiped;
                 };
 
-                Applied = true;
+                applied = true;
             }
         }
 
         /// <summary>
-        /// The state of reordering bones OnEquipmentChanged.
+        ///     The state of reordering bones OnEquipmentChanged.
         /// </summary>
         /// <returns>Returns true when bone reordering is enabled.</returns>
         public static bool IsReorderingEnabled()
         {
-            return Applied;
+            return applied;
         }
 
         private static bool VisEquipmentOnSetLegEquiped(On.VisEquipment.orig_SetLegEquiped orig, VisEquipment self, int hash)
         {
             var changed = self.m_currentLegItemHash == hash;
-            if (changed) LegChanged = false;
-            else LegChanged = true;
+            if (changed) legChanged = false;
+            else legChanged = true;
             var ret = orig(self, hash);
-            if (LegChanged && self.m_legItemInstances != null) ReorderBones(self, hash, self.m_legItemInstances);
+            if (legChanged && self.m_legItemInstances != null) ReorderBones(self, hash, self.m_legItemInstances);
             return ret;
         }
 
         private static bool VisEquipmentOnSetHelmetEquiped(On.VisEquipment.orig_SetHelmetEquiped orig, VisEquipment self, int hash, int hairhash)
         {
             var changed = self.m_currentHelmetItemHash == hash;
-            if (changed) HelmetChanged = false;
-            else HelmetChanged = true;
+            if (changed) helmetChanged = false;
+            else helmetChanged = true;
             var ret = orig(self, hash, hairhash);
-            if (HelmetChanged && self.m_helmetItemInstance != null)
+            if (helmetChanged && self.m_helmetItemInstance != null)
                 ReorderBones(self, hash, new List<GameObject>{self.m_helmetItemInstance}); //This is a single object instead of a collection, because reasons?
             return ret;
         }
@@ -71,36 +71,36 @@ namespace JotunnLib.Utils
         private static bool VisEquipmentOnSetChestEquiped(On.VisEquipment.orig_SetChestEquiped orig, VisEquipment self, int hash)
         {
             var changed = self.m_currentChestItemHash == hash;
-            if (changed) ChestChanged = false;
-            else ChestChanged = true;
+            if (changed) chestChanged = false;
+            else chestChanged = true;
             var ret = orig(self, hash);
-            if (ChestChanged && self.m_chestItemInstances != null) ReorderBones(self, hash, self.m_chestItemInstances);
+            if (chestChanged && self.m_chestItemInstances != null) ReorderBones(self, hash, self.m_chestItemInstances);
             return ret;
         }
 
         private static bool VisEquipmentOnSetShoulderEquiped(On.VisEquipment.orig_SetShoulderEquiped orig, VisEquipment self, int hash, int variant)
         {
             var changed = self.m_currentShoulderItemHash == hash;
-            if (changed) ShoulderChanged = false;
-            else ShoulderChanged = true;
+            if (changed) shoulderChanged = false;
+            else shoulderChanged = true;
             var ret = orig(self, hash, variant);
-            if(ShoulderChanged && self.m_shoulderItemInstances != null) ReorderBones(self, hash, self.m_shoulderItemInstances);
+            if(shoulderChanged && self.m_shoulderItemInstances != null) ReorderBones(self, hash, self.m_shoulderItemInstances);
             return ret;
         }
         
         private static bool VisEquipmentOnSetUtilityEquiped(On.VisEquipment.orig_SetUtilityEquiped orig, VisEquipment self, int hash)
         {
             var changed = self.m_currentUtilityItemHash == hash;
-            if (changed) UtilityChanged = false;
-            else UtilityChanged = true;
+            if (changed) utilityChanged = false;
+            else utilityChanged = true;
             var ret = orig(self, hash);
-            if(UtilityChanged && self.m_utilityItemInstances != null) ReorderBones(self, hash, self.m_utilityItemInstances);
+            if(utilityChanged && self.m_utilityItemInstances != null) ReorderBones(self, hash, self.m_utilityItemInstances);
             return ret;
         }
 
         /// <summary>
-        /// Reorders bone ordering caused by importing ripped assets into unity.
-        /// It effectively matches the bone ordering from the ItemPrefab (itemPrefabHash parameter)
+        ///     Reorders bone ordering caused by importing ripped assets into unity.
+        ///     It effectively matches the bone ordering from the ItemPrefab (itemPrefabHash parameter).
         /// </summary>
         /// <param name="visEquipment"></param>
         /// <param name="itemPrefabHash"></param>
@@ -110,8 +110,8 @@ namespace JotunnLib.Utils
             Logger.LogInfo($"Reordering bones...");
             Transform skeletonRoot = visEquipment.transform.Find("Visual").Find("Armature").Find("Hips");
             GameObject itemPrefab = ObjectDB.instance.GetItemPrefab(itemPrefabHash);
-            if(!skeletonRoot) Logger.LogInfo($"{skeletonRoot} is null.");
-            if(!itemPrefab) Logger.LogInfo($"{itemPrefab} is null.");
+            if (!skeletonRoot) Logger.LogInfo($"{skeletonRoot} is null.");
+            if (!itemPrefab) Logger.LogInfo($"{itemPrefab} is null.");
             int childCount = itemPrefab.transform.childCount;
             int num = 0;
             for (var i = 0; i < childCount; i++)
@@ -152,7 +152,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Returns a list of bone names, given a SkinnedMeshRenderer
+        ///     Returns a list of bone names, given a SkinnedMeshRenderer.
         /// </summary>
         /// <param name="skinnedMeshRenderer"></param>
         /// <returns></returns>
@@ -168,7 +168,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Returns a transform matching the given name within the transforms children.
+        ///     Returns a transform matching the given name within the transforms children.
         /// </summary>
         /// <param name="transform"></param>
         /// <param name="name"></param>

--- a/JotunnLib/Utils/ConfigurationManagerAttributes.cs
+++ b/JotunnLib/Utils/ConfigurationManagerAttributes.cs
@@ -1,28 +1,28 @@
 ﻿/// <summary>
-/// Class that specifies how a setting should be displayed inside the ConfigurationManager settings window.
-/// 
-/// Usage:
-/// This class template has to be copied inside the plugin's project and referenced by its code directly.
-/// make a new instance, assign any fields that you want to override, and pass it as a tag for your setting.
-/// 
-/// If a field is null (default), it will be ignored and won't change how the setting is displayed.
-/// If a field is non-null (you assigned a value to it), it will override default behavior.
+///     Class that specifies how a setting should be displayed inside the ConfigurationManager settings window.
+///     
+///     Usage:
+///     This class template has to be copied inside the plugin's project and referenced by its code directly.
+///     make a new instance, assign any fields that you want to override, and pass it as a tag for your setting.
+///     
+///     If a field is null (default), it will be ignored and won't change how the setting is displayed.
+///     If a field is non-null (you assigned a value to it), it will override default behavior.
 /// </summary>
 /// 
 /// <example> 
-/// Here's an example of overriding order of settings and marking one of the settings as advanced:
-/// <code>
-/// // Override IsAdvanced and Order
-/// Config.AddSetting("X", "1", 1, new ConfigDescription("", null, new ConfigurationManagerAttributes { IsAdvanced = true, Order = 3 }));
-/// // Override only Order, IsAdvanced stays as the default value assigned by ConfigManager
-/// Config.AddSetting("X", "2", 2, new ConfigDescription("", null, new ConfigurationManagerAttributes { Order = 1 }));
-/// Config.AddSetting("X", "3", 3, new ConfigDescription("", null, new ConfigurationManagerAttributes { Order = 2 }));
-/// </code>
+///     Here's an example of overriding order of settings and marking one of the settings as advanced:
+///     <code>
+///         // Override IsAdvanced and Order
+///         Config.AddSetting("X", "1", 1, new ConfigDescription("", null, new ConfigurationManagerAttributes { IsAdvanced = true, Order = 3 }));
+///         // Override only Order, IsAdvanced stays as the default value assigned by ConfigManager
+///         Config.AddSetting("X", "2", 2, new ConfigDescription("", null, new ConfigurationManagerAttributes { Order = 1 }));
+///         Config.AddSetting("X", "3", 3, new ConfigDescription("", null, new ConfigurationManagerAttributes { Order = 2 }));
+///     </code>
 /// </example>
 /// 
 /// <remarks> 
-/// You can read more and see examples in the readme at https://github.com/BepInEx/BepInEx.ConfigurationManager
-/// You can optionally remove fields that you won't use from this class, it's the same as leaving them null.
+///     You can read more and see examples in the readme at https://github.com/BepInEx/BepInEx.ConfigurationManager
+///     You can optionally remove fields that you won't use from this class, it's the same as leaving them null.
 /// </remarks>
 #pragma warning disable 0169, 0414, 0649
 public sealed class ConfigurationManagerAttributes
@@ -33,61 +33,61 @@ public sealed class ConfigurationManagerAttributes
     public bool? ShowRangeAsPercent;
 
     /// <summary>
-    /// Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).
-    /// See below for a deeper explanation. Using a custom drawer will cause many of the other fields to do nothing.
+    ///     Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).
+    ///     See below for a deeper explanation. Using a custom drawer will cause many of the other fields to do nothing.
     /// </summary>
     public System.Action<BepInEx.Configuration.ConfigEntryBase> CustomDrawer;
 
     /// <summary>
-    /// Show this setting in the settings screen at all? If false, don't show.
+    ///     Show this setting in the settings screen at all? If false, don't show.
     /// </summary>
     public bool? Browsable;
 
     /// <summary>
-    /// Category the setting is under. Null to be directly under the plugin.
+    ///     Category the setting is under. Null to be directly under the plugin.
     /// </summary>
     public string Category;
 
     /// <summary>
-    /// If set, a "Default" button will be shown next to the setting to allow resetting to default.
+    ///     If set, a "Default" button will be shown next to the setting to allow resetting to default.
     /// </summary>
     public object DefaultValue;
 
     /// <summary>
-    /// Force the "Reset" button to not be displayed, even if a valid DefaultValue is available. 
+    ///     Force the "Reset" button to not be displayed, even if a valid DefaultValue is available. 
     /// </summary>
     public bool? HideDefaultButton;
 
     /// <summary>
-    /// Force the setting name to not be displayed. Should only be used with a <see cref="CustomDrawer"/> to get more space.
-    /// Can be used together with <see cref="HideDefaultButton"/> to gain even more space.
+    ///     Force the setting name to not be displayed. Should only be used with a <see cref="CustomDrawer"/> to get more space.
+    ///     Can be used together with <see cref="HideDefaultButton"/> to gain even more space.
     /// </summary>
     public bool? HideSettingName;
 
     /// <summary>
-    /// Optional description shown when hovering over the setting.
-    /// Not recommended, provide the description when creating the setting instead.
+    ///     Optional description shown when hovering over the setting.
+    ///     Not recommended, provide the description when creating the setting instead.
     /// </summary>
     public string Description;
 
     /// <summary>
-    /// Name of the setting.
+    ///     Name of the setting.
     /// </summary>
     public string DispName;
 
     /// <summary>
-    /// Order of the setting on the settings list relative to other settings in a category.
-    /// 0 by default, higher number is higher on the list.
+    ///     Order of the setting on the settings list relative to other settings in a category.
+    ///     0 by default, higher number is higher on the list.
     /// </summary>
     public int? Order;
 
     /// <summary>
-    /// Only show the value, don't allow editing it.
+    ///     Only show the value, don't allow editing it.
     /// </summary>
     public bool? ReadOnly;
 
     /// <summary>
-    /// If true, don't show the setting by default. User has to turn on showing advanced settings or search for it.
+    ///     If true, don't show the setting by default. User has to turn on showing advanced settings or search for it.
     /// </summary>
     public bool? IsAdvanced;
 
@@ -120,12 +120,12 @@ public sealed class ConfigurationManagerAttributes
     }
 
     /// <summary>
-    /// Custom converter from setting type to string for the built-in editor textboxes.
+    ///     Custom converter from setting type to string for the built-in editor textboxes.
     /// </summary>
     public System.Func<object, string> ObjToStr;
 
     /// <summary>
-    /// Custom converter from string to setting type for the built-in editor textboxes.
+    ///     Custom converter from string to setting type for the built-in editor textboxes.
     /// </summary>
     public System.Func<string, object> StrToObj;
 

--- a/JotunnLib/Utils/EventsHelper.cs
+++ b/JotunnLib/Utils/EventsHelper.cs
@@ -3,12 +3,12 @@
 namespace JotunnLib.Utils
 {
     /// <summary>
-    /// Helper class for C# Events
+    ///     Helper class for C# Events.
     /// </summary>
     public static class EventsHelper
     {
         /// <summary>
-        /// Try catch the delegate chain so that it doesnt break on the first failing Delegate
+        ///     Try catch the delegate chain so that it doesnt break on the first failing Delegate.
         /// </summary>
         /// <param name="events"></param>
         public static void SafeInvoke(this Action events)
@@ -32,7 +32,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Try catch the delegate chain so that it doesnt break on the first failing Delegate
+        ///     Try catch the delegate chain so that it doesnt break on the first failing Delegate.
         /// </summary>
         /// <typeparam name="TArg1"></typeparam>
         /// <param name="events"></param>

--- a/JotunnLib/Utils/HashUtils.cs
+++ b/JotunnLib/Utils/HashUtils.cs
@@ -3,7 +3,10 @@ using System.Text;
 
 namespace JotunnLib.Utils
 {
-    public static class Hashes
+    /// <summary>
+    ///     A util class for computing various hashes
+    /// </summary>
+    public static class HashUtils
     {
         public static string ComputeSha256Hash(string rawData)
         {

--- a/JotunnLib/Utils/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility.cs
@@ -13,9 +13,9 @@ namespace JotunnLib.Utils
     public class ModCompatibility
     {
         /// <summary>
-        /// Stores the last server message
+        ///     Stores the last server message.
         /// </summary>
-        private static string LastServerMessage = "";
+        private static string lastServerMessage = "";
 
         private static int getVersionTrigger = 0;
 
@@ -35,13 +35,13 @@ namespace JotunnLib.Utils
         private static void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadMode)
         {
             // Show message box if there is a message to show
-            if (!string.IsNullOrEmpty(LastServerMessage) && scene.name == "start")
+            if (!string.IsNullOrEmpty(lastServerMessage) && scene.name == "start")
             {
                 var panel = GUIManager.Instance.CreateWoodpanel(GUIManager.PixelFix.transform, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
                     new Vector2(0f, 0f), 500, 500);
                 panel.SetActive(true);
 
-                var remote = new MessageData(LastServerMessage);
+                var remote = new MessageData(lastServerMessage);
                 var local = new MessageData(AddModuleVersions(Version.GetVersionString()));
 
                 var text = new GameObject("Text", typeof(RectTransform), typeof(Text), typeof(Outline));
@@ -68,7 +68,7 @@ namespace JotunnLib.Utils
                     Object.Destroy(panel);
                 });
 
-                LastServerMessage = "";
+                lastServerMessage = "";
             }
         }
 
@@ -124,7 +124,7 @@ namespace JotunnLib.Utils
 
 
         /// <summary>
-        /// Add module versions to string
+        ///     Add module versions to string.
         /// </summary>
         /// <param name="valheimVersion"></param>
         /// <returns></returns>
@@ -153,7 +153,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Get module 
+        ///     Get module.
         /// </summary>
         /// <returns></returns>
         internal static IEnumerable<Tuple<string, System.Version, CompatibilityLevel, VersionStrictness>> GetEnforcedMods()
@@ -171,7 +171,7 @@ namespace JotunnLib.Utils
         }
 
         /// <summary>
-        /// Store server's message
+        ///     Store server's message.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="data"></param>
@@ -179,12 +179,12 @@ namespace JotunnLib.Utils
         {
             if (ZNet.instance.IsClientInstance())
             {
-                LastServerMessage = data;
+                lastServerMessage = data;
             }
         }
 
         /// <summary>
-        /// Deserialize version string into a usable format
+        ///     Deserialize version string into a usable format.
         /// </summary>
         private class MessageData
         {

--- a/JotunnLib/Utils/PatchInitAttribute.cs
+++ b/JotunnLib/Utils/PatchInitAttribute.cs
@@ -9,14 +9,21 @@ using System;
 namespace JotunnLib.Utils
 {
     /// <summary>
-    /// Priority attribute for PatchInitalizer
-    /// negative - early
-    /// zero - neutral
-    /// positive - late
+    ///     Priority attribute for PatchInitalizer.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class PatchInitAttribute: Attribute
+    public class PatchInitAttribute : Attribute
     {
+        /// <summary>
+        ///     The patch priority.
+        ///     <para>
+        ///         negative - early
+        ///         <br />
+        ///         zero - neutral
+        ///         <br />
+        ///         positive - late
+        ///     </para>
+        /// </summary>
         public int Priority { get; set; }
 
         public PatchInitAttribute(int priority)

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -13,7 +13,7 @@ using BepInEx.Configuration;
 
 namespace TestMod
 {
-    [BepInPlugin("com.bepinex.plugins.jotunnlib.testmod", "JotunnLib Test Mod", "0.1.0")]
+    [BepInPlugin("com.jotunn.testmod", "JotunnLib Test Mod", "0.1.0")]
     [BepInDependency(JotunnLib.Main.ModGuid)]
     [NetworkCompatibilty(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     class TestMod : BaseUnityPlugin
@@ -23,11 +23,9 @@ namespace TestMod
         public Skills.SkillType TestSkillType = 0;
 
         private bool showMenu = false;
-        private Sprite testSkillSprite;
         private bool showGUIButton = false;
-
-        private GameObject TestButton;
-        private GameObject TestPanel;
+        private Sprite testSkillSprite;
+        private GameObject testButton, testPanel;
 
         // Init handlers
         private void Awake()
@@ -76,7 +74,7 @@ namespace TestMod
 
             if (showGUIButton)
             {
-                if (TestPanel == null)
+                if (testPanel == null)
                 {
                     if (GUIManager.Instance == null)
                     {
@@ -89,16 +87,16 @@ namespace TestMod
                         Logger.LogError("GUIManager pixelfix is null");
                         return;
                     }
-                    TestPanel = GUIManager.Instance.CreateWoodpanel(GUIManager.PixelFix.transform,new Vector2(0.5f,0.5f), new Vector2(0.5f,0.5f), new Vector2(0,0), 850, 600);
+                    testPanel = GUIManager.Instance.CreateWoodpanel(GUIManager.PixelFix.transform,new Vector2(0.5f,0.5f), new Vector2(0.5f,0.5f), new Vector2(0,0), 850, 600);
 
-                    GUIManager.Instance.CreateButton("A Test Button - long dong schlongsen text", TestPanel.transform, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
+                    GUIManager.Instance.CreateButton("A Test Button - long dong schlongsen text", testPanel.transform, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
                         new Vector2(0, 0), 250, 100).SetActive(true);
-                    if (TestPanel == null)
+                    if (testPanel == null)
                     {
                         return;
                     }
                 }
-                TestPanel.SetActive(!TestPanel.activeSelf);
+                testPanel.SetActive(!testPanel.activeSelf);
                 showGUIButton = false;
             }
         }


### PR DESCRIPTION
Closes #49

Naming conventions for project specified in CONTRIBUTING file. Refactored most classes to adhere to these conventions. This includes:
- Using lowerCamelCase for private/local vars/methods
- Using UpperCamelCase for public/internal vars/methods
- Moved command initialization from Jotunn Main into CommandManager
- Added documentation to the majority of all public methods/vars