### PR TITLE
chore: Removed Load/Register conventions from managers, refactored methods to conform to naming conventions

### DIFF
--- a/JotunnLib/Manager.cs
+++ b/JotunnLib/Manager.cs
@@ -11,15 +11,5 @@ namespace JotunnLib
         ///     Initialize manager class after all manager scripts have been added to the root game object
         /// </summary>
         internal virtual void Init() { }
-
-        /// <summary>
-        ///     Load any data registered by mods into the game
-        /// </summary>
-        internal virtual void Load() { }
-
-        /// <summary>
-        ///     Register any data from user mods
-        /// </summary>
-        internal virtual void Register() { }
     }
 }

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -67,7 +67,7 @@ namespace JotunnLib.Managers
             GUIContainer.AddComponent<GuiScaler>().UpdateScale();
 
 
-            CreatePixelFix();
+            createPixelFix();
 
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
         }
@@ -77,7 +77,7 @@ namespace JotunnLib.Managers
             if (scene.name == "start" && !GUIInStart)
             {
                 GUIContainer.SetActive(true);
-                CreatePixelFix();
+                createPixelFix();
                 GUIInStart = true;
             }
 
@@ -100,7 +100,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        private static void CreatePixelFix()
+        private void createPixelFix()
         {
             PixelFix = new GameObject("GUIFix", typeof(RectTransform), typeof(GuiPixelFix));
             PixelFix.layer = UILayer; // UI

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -57,7 +57,7 @@ namespace JotunnLib.Managers
             }
         }
 
-        internal override void Register()
+        internal void Register()
         {
             if (inputsRegistered)
             {
@@ -68,7 +68,7 @@ namespace JotunnLib.Managers
             inputsRegistered = true;
         }
 
-        public void RegisterButton(string name, ButtonConfig button)
+        public void AddButton(string name, ButtonConfig button)
         {
             if (Buttons.ContainsKey(name))
             {
@@ -79,7 +79,7 @@ namespace JotunnLib.Managers
             Buttons.Add(name, button);
         }
 
-        public void RegisterButton(
+        public void AddButton(
             string name,
             KeyCode key,
             float repeatDelay = 0.0f,
@@ -100,7 +100,7 @@ namespace JotunnLib.Managers
             });
         }
 
-        public void RegisterButton(
+        public void AddButton(
             string name,
             string axis,
             bool inverted = false,
@@ -124,18 +124,17 @@ namespace JotunnLib.Managers
         }
 
 
-        private static void ZInput_Reset(On.ZInput.orig_Reset orig, ZInput self)
+        private void ZInput_Reset(On.ZInput.orig_Reset orig, ZInput self)
         {
             orig(self);
             Logger.LogDebug("----> ZInput Reset");
-            InputManager.Instance.Load(self);
+            Load(self);
         }
 
-        private static void ZInput_Initialize(On.ZInput.orig_Initialize orig)
+        private void ZInput_Initialize(On.ZInput.orig_Initialize orig)
         {
             Logger.LogDebug("----> ZInput Initialize");
-            InputManager.Instance.Register();
-            
+            Register();
             orig();
         }
 

--- a/JotunnLib/Managers/LocalizationManager.cs
+++ b/JotunnLib/Managers/LocalizationManager.cs
@@ -111,15 +111,12 @@ namespace JotunnLib.Managers
         /// <summary>
         ///     Register all plugin's localizations.
         /// </summary>
-        internal override void Register()
+        internal void Register()
         {
             if (registered)
             {
                 return;
             }
-
-            //why?
-            //Localizations.Clear();
 
             Logger.LogInfo("---- Registering custom localizations ----");
 
@@ -144,17 +141,6 @@ namespace JotunnLib.Managers
 
             Logger.LogDebug($"Adding tokens for language {language}");
             addTokens(localization, language);
-        }
-
-        /// <summary>
-        ///     Registers a new translation for a word for the current language.
-        /// </summary>
-        /// <param name="key">Key to translate</param>
-        /// <param name="text">Translation</param>
-        [Obsolete("Use either `RegisterLocalization(string language, Dictionary<string, string> localization)` or `RegisterLocalizationConfig(LocalizationConfig config)` instead", true)]
-        public void RegisterTranslation(string key, string text)
-        {
-            Localization.instance.AddWord(key, text);
         }
 
         /// <summary>
@@ -188,7 +174,7 @@ namespace JotunnLib.Managers
         /// </summary>
         /// <param name="self"></param>
         /// <param name="config"></param>
-        public void RegisterLocalizationConfig(LocalizationConfig config)
+        public void AddLocalization(LocalizationConfig config)
         {
             RegisterLocalization(config.Language, config.Translations);
         }
@@ -270,7 +256,6 @@ namespace JotunnLib.Managers
             languageDict.Add(tokenWithoutFirstChar, value);
         }
 
-
         /// <summary>
         ///     Add a token and its value to the "English" language.
         /// </summary>
@@ -281,7 +266,6 @@ namespace JotunnLib.Managers
         {
             AddToken(token, value, DefaultLanguage, forceReplace);
         }
-
 
         /// <summary>
         ///     Add a file via absolute path.
@@ -301,21 +285,20 @@ namespace JotunnLib.Managers
                 var language = Path.GetFileName(Path.GetDirectoryName(path));
                 AddJson(language, fileContent);
 
-                Logger.LogInfo($"Added json language file {Path.GetFileName(path)}");
+                Logger.LogInfo($"Added json language file: {Path.GetFileName(path)}");
             }
             else
             {
-                Add(fileContent);
-
-                Logger.LogInfo($"Added language file {Path.GetFileName(path)}");
+                AddLanguageFile(fileContent);
+                Logger.LogInfo($"Added language file: {Path.GetFileName(path)}");
             }
         }
 
         /// <summary>
-        ///     Add a language file (that match the game format).
+        ///     Add a language file that matches Valheim's language format.
         /// </summary>
         /// <param name="fileContent">Entire file as string</param>
-        public void Add(string fileContent)
+        public void AddLanguageFile(string fileContent)
         {
             if (fileContent == null)
             {

--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -39,20 +39,14 @@ namespace JotunnLib.Managers
         /// <param name="increaseStep"></param>
         /// <param name="icon">Icon for the skill</param>
         /// <returns>The SkillType of the newly registered skill</returns>
-        [System.Obsolete("Use `RegisterSkill(SkillConfig config)` instead. This method could potentially break user saves.", true)]
-        public Skills.SkillType RegisterSkill(
+        [System.Obsolete("Use `AddSkill(SkillConfig config)` instead. This method could potentially break user saves.", true)]
+        public Skills.SkillType AddSkill(
             string name,
             string description,
             float increaseStep = 1f,
             Sprite icon = null,
             bool createLocalizations = true)
         {
-            if (createLocalizations)
-            {
-                LocalizationManager.Instance.RegisterTranslation("skill_" + nextSkillId, name);
-                LocalizationManager.Instance.RegisterTranslation("skill_" + nextSkillId + "_description", description);
-            }
-
             SkillConfig skillConfig = new SkillConfig()
             {
                 Identifier = name + nextSkillId.ToString(),
@@ -62,8 +56,14 @@ namespace JotunnLib.Managers
                 Icon = icon
             };
 
-            LocalizationManager.Instance.RegisterTranslation("skill_" + skillConfig.UID, skillConfig.Name);
-            LocalizationManager.Instance.RegisterTranslation("skill_" + skillConfig.UID + "_description", skillConfig.Description);
+            if (createLocalizations)
+            {
+                LocalizationManager.Instance.RegisterLocalization("English", new Dictionary<string, string>()
+                {
+                    { "skill_" + skillConfig.UID, skillConfig.Name },
+                    { "skill_" + skillConfig.UID + "_description", skillConfig.Description }
+                });
+            }
 
             Skills.Add(skillConfig.UID, skillConfig);
             nextSkillId++;
@@ -76,7 +76,7 @@ namespace JotunnLib.Managers
         /// </summary>
         /// <param name="skillConfig">SkillConfig object representing new skill to register</param>
         /// <returns>The SkillType of the newly registered skill</returns>
-        public Skills.SkillType RegisterSkill(SkillConfig skillConfig, bool registerLocalizations = true)
+        public Skills.SkillType AddSkill(SkillConfig skillConfig, bool registerLocalizations = true)
         {
             if (string.IsNullOrEmpty(skillConfig.Identifier))
             {
@@ -90,7 +90,7 @@ namespace JotunnLib.Managers
             {
                 foreach (var translation in skillConfig.Localizations.Values)
                 {
-                    LocalizationManager.Instance.RegisterLocalizationConfig(translation);
+                    LocalizationManager.Instance.AddLocalization(translation);
                 }
             }
 
@@ -106,7 +106,7 @@ namespace JotunnLib.Managers
         /// <param name="increaseStep"></param>
         /// <param name="icon">Icon for the skill</param>
         /// <returns>The SkillType of the newly registered skill</returns>
-        public Skills.SkillType RegisterSkill(
+        public Skills.SkillType AddSkill(
             string identifer,
             string name,
             string description,
@@ -114,7 +114,7 @@ namespace JotunnLib.Managers
             Sprite icon = null,
             bool registerLocalizations = true)
         {
-            return RegisterSkill(new SkillConfig()
+            return AddSkill(new SkillConfig()
             {
                 Identifier = identifer,
                 Name = name,

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -118,8 +118,8 @@ namespace TestMod
         // Add custom key bindings
         private void registerInputs(object sender, EventArgs e)
         {
-            InputManager.Instance.RegisterButton("TestMod_Menu", KeyCode.Insert);
-            InputManager.Instance.RegisterButton("GUIManagerTest", KeyCode.F8);
+            InputManager.Instance.AddButton("TestMod_Menu", KeyCode.Insert);
+            InputManager.Instance.AddButton("GUIManagerTest", KeyCode.F8);
         }
 
         // Load assets
@@ -289,7 +289,7 @@ namespace TestMod
         void registerLocalization(object sender, EventArgs e)
         {
             // Add translations for the custom item in addClonedItems
-            LocalizationManager.Instance.RegisterLocalizationConfig(new LocalizationConfig("English")
+            LocalizationManager.Instance.AddLocalization(new LocalizationConfig("English")
             {
                 Translations =
                 {
@@ -299,7 +299,7 @@ namespace TestMod
             });
 
             // Add translations for the custom piece in addEmptyItems
-            LocalizationManager.Instance.RegisterLocalizationConfig(new LocalizationConfig("English")
+            LocalizationManager.Instance.AddLocalization(new LocalizationConfig("English")
             {
                 Translations =
                 {
@@ -325,7 +325,7 @@ namespace TestMod
             // Test adding a skill with a texture
             Texture2D testSkillTex = AssetUtils.LoadTexture("TestMod/Assets/test_tex.jpg");
             Sprite testSkillSprite = Sprite.Create(testSkillTex, new Rect(0f, 0f, testSkillTex.width, testSkillTex.height), Vector2.zero);
-            TestSkillType = SkillManager.Instance.RegisterSkill("com.jotunnlib.testmod.testskill", "TestingSkill", "A nice testing skill!", 1f, testSkillSprite);
+            TestSkillType = SkillManager.Instance.AddSkill("com.jotunnlib.testmod.testskill", "TestingSkill", "A nice testing skill!", 1f, testSkillSprite);
         }
 
         // Create some sample configuration values to check server sync


### PR DESCRIPTION
Closes #54

- Removed Load/Register conventions from managers
- Refactored methods to conform to naming conventions
- Refactored manager methods from old `RegisterThing(...)` naming convention to new `AddThing(...)` convention