### PR TITLE
fix: Modded items were being saved into wrong folder

### DIFF
--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -444,7 +444,6 @@
     <Compile Include="Utils\PatchInitAttribute.cs" />
     <Compile Include="Utils\Paths.cs" />
     <Compile Include="Utils\ReflectionHelper.cs" />
-    <Compile Include="Utils\ReflectionUtils.cs" />
     <Compile Include="Utils\AssetUtils.cs" />
     <Compile Include="Utils\SimpleJson.cs" />
     <Compile Include="Utils\WeightedList.cs" />

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -11,7 +11,7 @@ using JotunnLib.Utils;
 
 namespace JotunnLib
 {
-    [BepInPlugin(ModGuid, "JotunnLib", Version)]
+    [BepInPlugin(ModGuid, ModName, Version)]
     [NetworkCompatibilty(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor)]
     public class Main : BaseUnityPlugin
     {
@@ -19,6 +19,11 @@ namespace JotunnLib
         ///     The current version of the Jotunn library.
         /// </summary>
         public const string Version = "0.2.0";
+
+        /// <summary>
+        ///     The name of the library.
+        /// </summary>
+        public const string ModName = "JotunnLib";
 
         /// <summary>
         ///     The BepInEx plugin Mod GUID being used.

--- a/JotunnLib/Utils/Paths.cs
+++ b/JotunnLib/Utils/Paths.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using UnityEngine;
 
 namespace JotunnLib.Utils
 {
@@ -10,9 +9,7 @@ namespace JotunnLib.Utils
             get
             {
                 var saveDataPath = global::Utils.GetSaveDataPath();
-                const string jotunnLibFolder = nameof(Main);
-
-                return Path.Combine(saveDataPath, jotunnLibFolder);
+                return Path.Combine(saveDataPath, Main.ModName);
             }
         }
 


### PR DESCRIPTION
fix: Modded items were being saved into "Main" folder instead of correct folder. Changed to use library name for save dir instead.
This should be merged after #72, since it seems one of the changes from there made its way into this branch :(