### PR TITLE
Make prebuild task optional

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -85,6 +85,10 @@ jobs:
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}</Version></PropertyGroup></Project>" > JotunnLib/BuildProps/version.props
 
+      - name: Reset DoPrebuild.props
+        run: |
+          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><ExecutePrebuild>true</ExecutePrebuild></PropertyGroup></Project>" > JotunnLib/BuildProps/DoPrebuild.props
+
       # Build DLLs
       - name: Build solution
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set JotunnLib version
         run: |
-          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}</Version></PropertyGroup></Project>" > JotunnLib/version.props
+          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}</Version></PropertyGroup></Project>" > JotunnLib/BuildProps/version.props
 
       # Build DLLs
       - name: Build solution

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set JotunnLib version
         run: |
-          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}</Version></PropertyGroup></Project>" > JotunnLib/version.props
+          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}</Version></PropertyGroup></Project>" > JotunnLib/BuildProps/version.props
 
       # Build DLLs
       - name: Build solution

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}</Version></PropertyGroup></Project>" > JotunnLib/BuildProps/version.props
 
+      - name: Reset DoPrebuild.props
+        run: |
+          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><ExecutePrebuild>true</ExecutePrebuild></PropertyGroup></Project>" > JotunnLib/BuildProps/DoPrebuild.props
+
       # Build DLLs
       - name: Build solution
         run: |

--- a/JotunnBuildTask/GenerateMMHook.cs
+++ b/JotunnBuildTask/GenerateMMHook.cs
@@ -6,8 +6,6 @@ using Mono.Cecil;
 using MonoMod;
 using MonoMod.RuntimeDetour.HookGen;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
-using MonoMod.RuntimeDetour;
 using TypeAttributes = Mono.Cecil.TypeAttributes;
 
 namespace JotunnBuildTask

--- a/JotunnLib/BuildProps/DoPrebuild.props
+++ b/JotunnLib/BuildProps/DoPrebuild.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+	  <ExecutePrebuild>true</ExecutePrebuild>
+  </PropertyGroup>
+</Project>

--- a/JotunnLib/BuildProps/JotunnBuildTask.props
+++ b/JotunnLib/BuildProps/JotunnBuildTask.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="DoPrebuild.props" />
+  <UsingTask TaskName="GenerateMMHook" AssemblyFile="$(SolutionDir)JotunnBuildTask\bin\$(ConfigurationName)\JotunnBuildTask.dll"/>
+  <Target Name="JotunnBuildTask" AfterTargets="BeforeBuild" Condition="'$(ExecutePrebuild)' == 'true'" >
+    <Message Importance="High" Text="Executing JotunnLib Prebuild Task creating MMHOOK dlls"/> 
+    <GenerateMMHook ValheimPath="$(VALHEIM_INSTALL)" />
+  </Target>
+  <Target Name="NoJotunnBuildTask" AfterTargets="BeforeBuild" Condition="'$(ExecutePrebuild)' == 'false'" >
+    <Message Importance="High" Text="Skipping MMHOOK dll generation"/>
+  </Target>
+</Project>

--- a/JotunnLib/BuildProps/JotunnLib.props
+++ b/JotunnLib/BuildProps/JotunnLib.props
@@ -408,7 +408,11 @@
   </ItemGroup>
   <UsingTask TaskName="GenerateMMHook" AssemblyFile="JotunnBuildTask.dll" />
 
-	<Target Name="JotunnBuildTask" AfterTargets="BeforeBuild">
-		<GenerateMMHook ValheimPath="$(VALHEIM_INSTALL)" />
-	</Target>
+  <Target Name="JotunnBuildTask" AfterTargets="BeforeBuild" Condition="'$(ExecutePrebuild)' == 'true'" >
+    <Message Importance="High" Text="Executing JotunnLib Prebuild Task creating MMHOOK dlls"/> 
+    <GenerateMMHook ValheimPath="$(VALHEIM_INSTALL)" />
+  </Target>
+  <Target Name="NoJotunnBuildTask" AfterTargets="BeforeBuild" Condition="'$(ExecutePrebuild)' == 'false'" >
+    <Message Importance="High" Text="Skipping MMHOOK dll generation"/>
+  </Target>
 </Project>

--- a/JotunnLib/BuildProps/version.props
+++ b/JotunnLib/BuildProps/version.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?> 
+<Project>
+  <PropertyGroup>
+    <Version>0.2.0</Version>
+  </PropertyGroup>
+</Project>

--- a/JotunnLib/JotunnBuildTask.props
+++ b/JotunnLib/JotunnBuildTask.props
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GenerateMMHook" AssemblyFile="$(SolutionDir)JotunnBuildTask\bin\$(ConfigurationName)\JotunnBuildTask.dll"/>
-</Project>

--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -444,13 +444,9 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
-  <Import Project="version.props" Condition="Exists('version.props')" />
+  <Import Project="BuildProps\version.props" Condition="Exists('BuildProps\version.props')" />
   <Import Project="..\Environment.props" />
-  <Import Project="JotunnBuildTask.props" />
-  <Target Name="JotunnBuildTask" BeforeTargets="BeforeBuild">
-    <Message Text="Generating MMHook assemblies" Importance="high" />
-    <GenerateMMHook ValheimPath="$(VALHEIM_INSTALL)" />
-  </Target>
+  <Import Project="BuildProps\JotunnBuildTask.props" />
   <Target Name="JotunnPostBuildTaskWin" Condition="'$(OS)' == 'Windows_NT'" AfterTargets="Build">
     <Exec Command="powershell.exe -ExecutionPolicy RemoteSigned -File &quot;$(SolutionDir)publish.ps1&quot; -Target &quot;$(ConfigurationName)&quot; -TargetPath &quot;$(TargetDir.TrimEnd('\'))&quot; -TargetAssembly &quot;$(TargetFileName)&quot; -ValheimPath &quot;$(VALHEIM_INSTALL.TrimEnd('\'))&quot;" />
   </Target>
@@ -487,7 +483,7 @@
     <Content Include="$(SolutionDir)JotunnBuildTask\bin\$(ConfigurationName)\MonoMod.RuntimeDetour.dll" Pack="true" PackagePath="build" />
     <Content Include="$(SolutionDir)JotunnBuildTask\bin\$(ConfigurationName)\MonoMod.RuntimeDetour.HookGen.exe" Pack="true" PackagePath="build" />
     <Content Include="$(SolutionDir)JotunnBuildTask\bin\$(ConfigurationName)\MonoMod.Utils.dll" Pack="true" PackagePath="build" />
-    <Content Include="$(SolutionDir)JotunnLib\JotunnLib.props" Pack="true" PackagePath="build" />
+    <Content Include="$(SolutionDir)JotunnLib\BuildProps\JotunnLib.props" Pack="true" PackagePath="build" />
     <Content Include="$(SolutionDir)resources\JVL_Logo_128x128.png" Pack="true" PackagePath="images" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- moved JotunnLib props files into BuildProps folder
- removed duplicate calls for the build task
- added DoPrebuild.props, with the ExecutePrebuild defined inside (**true**(default)/false). Prebuild task will only be called if true. 
**Be sure not to push DoPrebuild.props to the server!**
Either add it to your local excludes or revert the file before pushing.