### PR TITLE
chore: Updated release actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,34 +1,34 @@
 on:
   push:
     branches:
-      - main
+      - prod
 
 jobs:
   build_docs:
     runs-on: ubuntu-latest
     name: Builds documentation and publishes to GitHub Pages
     steps:
-    # Checkout repo
-    - uses: actions/checkout@v1
-      name: Checkout repo
+      # Checkout repo
+      - uses: actions/checkout@v1
+        name: Checkout repo
 
-    # Install NuGet
-    - uses: nuget/setup-nuget@v1
-      name: Install NuGet
+      # Install NuGet
+      - uses: nuget/setup-nuget@v1
+        name: Install NuGet
 
-    # Install NuGet dependencies
-    - name: Install NuGet dependencies
-      run: nuget restore JotunnLib.sln
+      # Install NuGet dependencies
+      - name: Install NuGet dependencies
+        run: nuget restore JotunnLib.sln
 
-    # Build docs
-    - uses: nikeee/docfx-action@v1.0.0
-      name: Build documentation
-      with:
-        args: JotunnLib/docfx.json
+      # Build docs
+      - uses: nikeee/docfx-action@v1.0.0
+        name: Build documentation
+        with:
+          args: JotunnLib/docfx.json
 
-    # Publish generated site using GitHub Pages
-    - uses: maxheld83/ghpages@master
-      name: Publish documentation to GitHub Pages
-      env:
-        BUILD_DIR: JotunnLib/_site # docfx's default output directory is _site
-        GH_PAT: ${{ secrets.GH_PAT }} # See https://github.com/maxheld83/ghpages
+      # Publish generated site using GitHub Pages
+      - uses: maxheld83/ghpages@master
+        name: Publish documentation to GitHub Pages
+        env:
+          BUILD_DIR: JotunnLib/_site # docfx's default output directory is _site
+          GH_PAT: ${{ secrets.GH_PAT }} # See https://github.com/maxheld83/ghpages

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,8 +1,7 @@
-name: Create DLL on merge to main
+name: Create DLL on merge to dev
 "on":
   push:
     branches:
-      - main
       - dev
 jobs:
   build_merge:
@@ -72,10 +71,10 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Determine Version
-        id:   gitversion
+        id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.7
         with:
           useConfigFile: true
@@ -99,8 +98,8 @@ jobs:
         with:
           name: JotunnLib-${{ steps.date.outputs.date }}.dll
           path: JotunnLib/bin/Release/net462/JotunnLib.dll
-            
+
       - uses: actions/upload-artifact@v2
         with:
           name: JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg
-          path: JotunnLib/bin/Release/JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg            
+          path: JotunnLib/bin/Release/JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=VERSION_NUMBER::${VERSION:1}
 
       - name: Install SteamCMD
         uses: CyberAndrii/setup-steamcmd@v1
@@ -67,6 +69,26 @@ jobs:
       - name: Set references to DLLs
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><VALHEIM_INSTALL>$HOME/VHINSTALL/</VALHEIM_INSTALL></PropertyGroup></Project>" > Environment.props
+
+      - name: Set JotunnLib version
+        run: |
+          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><Version>${{ steps.get_version.outputs.VERSION_NUMBER }}-0</Version></PropertyGroup></Project>" > JotunnLib/BuildProps/version.props
+
+      - name: Reset DoPrebuild.props
+        run: |
+          echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><ExecutePrebuild>true</ExecutePrebuild></PropertyGroup></Project>" > JotunnLib/BuildProps/DoPrebuild.props
+
+      - name: Update GitVersion.yml
+        run: |
+          cat JotunnLib/GitVersion.yml | sed '4s/.*/next-version: ${{ steps.get_version.outputs.VERSION_NUMBER }}/' > JotunnLib/GitVersion_temp.yml && mv JotunnLib/GitVersion_temp.yml JotunnLib/GitVersion.yml
+
+      - name: Push version update to prod
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add JotunnLib/GitVersion.yml
+          git commit -m "deploy: Released ${{ steps.get_version.outputs.VERSION }}"
+          git push https://${{ secrets.PUSH_TO_PROTECTED_BRANCH }}@github.com/Valheim-Modding/Jotunn HEAD:prod
 
       # Build DLLs
       - name: Build solution

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -98,6 +98,12 @@ jobs:
           msbuild JotunnLib.sln /p:Configuration=Debug
           mv JotunnLib/bin/Debug/net462/JotunnLib.dll JotunnLib-DEBUG-${{ steps.get_version.outputs.VERSION }}.dll
 
+      - name: Pack
+        run: dotnet pack -c Release
+
+      - name: Publish the package to Nuget
+        run: dotnet nuget push "*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -89,6 +89,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add JotunnLib/GitVersion.yml
+          git add JotunnLib/BuildProps/version.props
           git commit -m "deploy: Released ${{ steps.get_version.outputs.VERSION }}"
           git push https://${{ secrets.PUSH_TO_PROTECTED_BRANCH }}@github.com/Valheim-Modding/Jotunn HEAD:prod
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
           echo ::set-output name=VERSION_NUMBER::${VERSION:1}
+          echo ::set-output name=VERSION_NEXT_NUMBER::${$(echo $VERSION_NUMBER | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}')}
 
       - name: Install SteamCMD
         uses: CyberAndrii/setup-steamcmd@v1
@@ -78,9 +79,10 @@ jobs:
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><ExecutePrebuild>true</ExecutePrebuild></PropertyGroup></Project>" > JotunnLib/BuildProps/DoPrebuild.props
 
-      - name: Update GitVersion.yml
+      - name: Update GitVersion.yml and version.props
         run: |
-          cat JotunnLib/GitVersion.yml | sed '4s/.*/next-version: ${{ steps.get_version.outputs.VERSION_NUMBER }}/' > JotunnLib/GitVersion_temp.yml && mv JotunnLib/GitVersion_temp.yml JotunnLib/GitVersion.yml
+          cat JotunnLib/GitVersion.yml | sed '4s/.*/next-version: ${{ steps.get_version.outputs.VERSION_NEXT_NUMBER }}/' > JotunnLib/GitVersion_temp.yml && mv JotunnLib/GitVersion_temp.yml JotunnLib/GitVersion.yml
+          cat JotunnLib/BuildProps/version.props  | sed '4s#.*#    <Version>${{ steps.get_version.outputs.VERSION_NUMBER }}</Version>#' > JotunnLib/BuildProps/version_temp.props && mv JotunnLib/BuildProps/version_temp.props JotunnLib/BuildProps/version.props
 
       - name: Push version update to prod
         run: |

--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -5,7 +5,7 @@
     <Id>JotunnLib</Id>
     <PackageId>JotunnLib</PackageId>
     <Authors>Valheim-Modding team</Authors>
-    <Description>Jotunn, the Valheim Lib</Description>
+    <Description>Jötunn (/ˈjɔːtʊn/, "giant") Lib is a modding library for Valheim, with the goal of making the lives of mod developers easier.</Description>
     <projectUrl>https://github.com/Valheim-Modding/</projectUrl>
     <PackageIcon>images\JVL_Logo_128x128.png</PackageIcon>
     <iconUrl>https://github.com/Valheim-Modding/Jotunn/raw/dev/resources/JVL_Logo.gif</iconUrl>
@@ -450,7 +450,7 @@
   <Target Name="JotunnPostBuildTaskWin" Condition="'$(OS)' == 'Windows_NT'" AfterTargets="Build">
     <Exec Command="powershell.exe -ExecutionPolicy RemoteSigned -File &quot;$(SolutionDir)publish.ps1&quot; -Target &quot;$(ConfigurationName)&quot; -TargetPath &quot;$(TargetDir.TrimEnd('\'))&quot; -TargetAssembly &quot;$(TargetFileName)&quot; -ValheimPath &quot;$(VALHEIM_INSTALL.TrimEnd('\'))&quot;" />
   </Target>
-  
+
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Valheim-Modding</PackageProjectUrl>
@@ -459,13 +459,13 @@
     <PackageTags>Valheim Modding Library</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Updated release actions to publish to NuGet on tag pushes (release from GitHub itself). Closes #89 

Changelog:
- Updated `docs.yaml` to publish on push to `prod`
- Updated `tag-release.yml` with auto-versioning and NuGet publishing support
- Updated .csproj description for JotunnLib