### PR TITLE
fix: skill IncreaseStep will now default to 1.0f

### DIFF
--- a/JotunnLib/Configs/SkillConfig.cs
+++ b/JotunnLib/Configs/SkillConfig.cs
@@ -35,7 +35,7 @@ namespace JotunnLib.Configs
 
         public string Description { get; set; }
         public Sprite Icon { get; set; }
-        public float IncreaseStep { get; set; }
+        public float IncreaseStep { get; set; } = 1.0f;
 
         public string IconPath
         {


### PR DESCRIPTION
Fixes issue mentioned on the Discord with `RaiseSkill()` not doing anything. The IncreaseStep modifier defaulted to 0 for some reason 🤦‍♂️