### PR TITLE
fix: create MMHOOK dlls from unpublicized dlls

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -64,6 +64,11 @@ jobs:
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/
 
+      - name: remove old hash, publicized dlls and mmhook dlls
+        run: |
+          rm -rf ~/VHINSTALL/valheim_server_Data/Managed/publicized_assemblies
+          rm -rf ~/VHINSTALL/BepInEx/plugins/MMHOOK
+
       - name: Set references to DLLs
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><VALHEIM_INSTALL>$HOME/VHINSTALL/</VALHEIM_INSTALL></PropertyGroup></Project>" > Environment.props

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,6 +56,11 @@ jobs:
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/
 
+      - name: remove old hash, publicized dlls and mmhook dlls
+        run: |
+          rm -rf ~/VHINSTALL/valheim_server_Data/Managed/publicized_assemblies
+          rm -rf ~/VHINSTALL/BepInEx/plugins/MMHOOK
+
       - name: Set references to DLLs
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><VALHEIM_INSTALL>$HOME/VHINSTALL/</VALHEIM_INSTALL></PropertyGroup></Project>" > Environment.props

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -70,6 +70,11 @@ jobs:
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/
 
+      - name: remove old hash, publicized dlls and mmhook dlls
+        run: |
+          rm -rf ~/VHINSTALL/valheim_server_Data/Managed/publicized_assemblies
+          rm -rf ~/VHINSTALL/BepInEx/plugins/MMHOOK
+
       - name: Set references to DLLs
         run: |
           echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"Current\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"><PropertyGroup><VALHEIM_INSTALL>$HOME/VHINSTALL/</VALHEIM_INSTALL></PropertyGroup></Project>" > Environment.props

--- a/JotunnBuildTask/AssemblyPublicizer.cs
+++ b/JotunnBuildTask/AssemblyPublicizer.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Mono.Cecil;
 
 namespace JotunnBuildTask
@@ -13,13 +15,13 @@ namespace JotunnBuildTask
         /// </summary>
         /// <param name="file"></param>
         /// <returns></returns>
-        public static bool PublicizeDll(string file, string ValheimPath)
+        public static bool PublicizeDll(string file, string ValheimPath, TaskLoggingHelper Log)
         {
             var outputPath = Path.Combine(Path.GetDirectoryName(file), GenerateMMHook.PublicizedAssemblies);
 
             if (!File.Exists(file))
             {
-                Console.WriteLine($"File {file} not found.");
+                Log.LogMessage(MessageImportance.High, $"File {file} not found.");
                 return false;
             }
 
@@ -50,7 +52,7 @@ namespace JotunnBuildTask
             }
             catch (Exception exception)
             {
-                Console.WriteLine($"{exception.Message}");
+                Log.LogMessage(MessageImportance.High, $"{exception.Message}");
                 return false;
             }
 
@@ -95,8 +97,8 @@ namespace JotunnBuildTask
             }
             catch (Exception exception)
             {
-                Console.WriteLine($"Could not write file {outputFilename}.");
-                Console.WriteLine(exception.Message);
+                Log.LogMessage(MessageImportance.High, $"Could not write file {outputFilename}.");
+                Log.LogMessage(MessageImportance.High, exception.Message);
                 return false;
             }
 

--- a/JotunnBuildTask/GenerateMMHook.cs
+++ b/JotunnBuildTask/GenerateMMHook.cs
@@ -46,12 +46,13 @@ namespace JotunnBuildTask
                 }
             }
 
+            // Try to publicize
             if (!AssemblyPublicizer.PublicizeDll(file, ValheimPath))
             {
                 return false;
             }
 
-            string publicizedFile = Path.Combine(Path.GetDirectoryName(file), PublicizedAssemblies,
+            /*string publicizedFile = Path.Combine(Path.GetDirectoryName(file), PublicizedAssemblies,
                 $"{Path.GetFileNameWithoutExtension(file)}_{Publicized}{Path.GetExtension(file)}");
 
             // only write the hash to file if HookGen was successful
@@ -59,9 +60,17 @@ namespace JotunnBuildTask
             {
                 File.WriteAllText(hashFilePath, hash);
                 return true;
+            }*/
+
+            // Try to generate HookGen
+            if (!InvokeHookgen(file, Path.Combine(outputFolder, $"{Mmhook}_{Path.GetFileName(file)}"), hash))
+            {
+                return false;
             }
 
-            return false;
+            // Write current hash to file if all previous actions succeeded
+            File.WriteAllText(hashFilePath, hash);
+            return true;
         }
 
         /// <summary>
@@ -90,12 +99,12 @@ namespace JotunnBuildTask
                 ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, ValheimServerData, Managed));
             }
             ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, UnstrippedCorlib));
-            /*
-            foreach (var dir in ((BaseAssemblyResolver) modder.AssemblyResolver)?.GetSearchDirectories())
+            
+            /*foreach (var dir in ((BaseAssemblyResolver) modder.AssemblyResolver)?.GetSearchDirectories())
             {
                 Log.LogMessage(MessageImportance.High,$"Searching in {dir}");
-            }
-            */
+            }*/
+            
             modder.Read();
 
             modder.MapDependencies();

--- a/JotunnBuildTask/GenerateMMHook.cs
+++ b/JotunnBuildTask/GenerateMMHook.cs
@@ -47,7 +47,7 @@ namespace JotunnBuildTask
             }
 
             // Try to publicize
-            if (!AssemblyPublicizer.PublicizeDll(file, ValheimPath))
+            if (!AssemblyPublicizer.PublicizeDll(file, ValheimPath, Log))
             {
                 return false;
             }
@@ -63,14 +63,14 @@ namespace JotunnBuildTask
             }*/
 
             // Try to generate HookGen
-            if (!InvokeHookgen(file, Path.Combine(outputFolder, $"{Mmhook}_{Path.GetFileName(file)}"), hash))
+            if (InvokeHookgen(file, Path.Combine(outputFolder, $"{Mmhook}_{Path.GetFileName(file)}"), hash))
             {
-                return false;
+                // Only write if 
+                File.WriteAllText(hashFilePath, hash);
+                return true;
             }
 
-            // Write current hash to file if all previous actions succeeded
-            File.WriteAllText(hashFilePath, hash);
-            return true;
+            return false;
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace JotunnBuildTask
 
             if (File.Exists(output))
             {
-                Console.WriteLine($"Clearing {output}");
+                Log.LogMessage(MessageImportance.High, $"Clearing {output}");
                 File.Delete(output);
             }
 
@@ -126,7 +126,7 @@ namespace JotunnBuildTask
                 mOut.Write(output);
             }
 
-            Console.WriteLine($"Finished writing {output}");
+            Log.LogMessage(MessageImportance.High, $"Finished writing {output}");
 
             return true;
         }

--- a/JotunnBuildTask/GenerateMMHook.cs
+++ b/JotunnBuildTask/GenerateMMHook.cs
@@ -103,11 +103,13 @@ namespace JotunnBuildTask
             }
             ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, UnstrippedCorlib));
             
+            /*
             foreach (var dir in ((BaseAssemblyResolver) modder.AssemblyResolver)?.GetSearchDirectories())
             {
                 Log.LogMessage(MessageImportance.High,$"Searching in {dir}");
             }
-            
+            */
+
             modder.Read();
 
             modder.MapDependencies();

--- a/JotunnBuildTask/GenerateMMHook.cs
+++ b/JotunnBuildTask/GenerateMMHook.cs
@@ -33,6 +33,9 @@ namespace JotunnBuildTask
         /// <param name="outputFolder">output file name</param>
         private bool HashAndCompare(string file, string outputFolder)
         {
+
+            Log.LogMessage(MessageImportance.High, $"Processing {file}");
+
             var hash = MD5HashFile(file);
 
             string hashFilePath = Path.Combine(outputFolder, Path.GetFileName(file) + ".hash");
@@ -100,10 +103,10 @@ namespace JotunnBuildTask
             }
             ((BaseAssemblyResolver)modder.AssemblyResolver)?.AddSearchDirectory(Path.Combine(ValheimPath, UnstrippedCorlib));
             
-            /*foreach (var dir in ((BaseAssemblyResolver) modder.AssemblyResolver)?.GetSearchDirectories())
+            foreach (var dir in ((BaseAssemblyResolver) modder.AssemblyResolver)?.GetSearchDirectories())
             {
                 Log.LogMessage(MessageImportance.High,$"Searching in {dir}");
-            }*/
+            }
             
             modder.Read();
 

--- a/JotunnBuildTask/GenerateMMHook.cs
+++ b/JotunnBuildTask/GenerateMMHook.cs
@@ -116,6 +116,8 @@ namespace JotunnBuildTask
             }
 
             HookGenerator hookGenerator = new HookGenerator(modder, Path.GetFileName(output));
+            
+            hookGenerator.HookPrivate = true;
 
             using (ModuleDefinition mOut = hookGenerator.OutputModule)
             {

--- a/JotunnDoc/JotunnDoc.csproj
+++ b/JotunnDoc/JotunnDoc.csproj
@@ -61,32 +61,32 @@
     <Reference Include="assembly_valheim_publicized">
       <HintPath>$(VALHEIM_INSTALL)\valheim_Data\Managed\publicized_assemblies\assembly_valheim_publicized.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_googleanalytics_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_googleanalytics">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_guiutils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_guiutils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_lux_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_lux">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_postprocessing_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_postprocessing">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_simplemeshcombine_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_simplemeshcombine">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_steamworks_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_steamworks">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_sunshafts_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_sunshafts">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_utils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_utils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_valheim_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_valheim">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx, Version=5.4.5.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JotunnLib/BuildProps/JotunnLib.props
+++ b/JotunnLib/BuildProps/JotunnLib.props
@@ -61,40 +61,40 @@
       <Private>false</Private>
       <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\HarmonyXInterop.dll</HintPath>
     </Reference>
-    <Reference Include="MMHOOK_assembly_googleanalytics_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_googleanalytics">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_guiutils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_guiutils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_lux_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_lux">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_postprocessing_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_postprocessing">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_simplemeshcombine_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_simplemeshcombine">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_steamworks_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_steamworks">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_sunshafts_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_sunshafts">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_utils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_utils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_valheim_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_valheim">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Mono.Security">

--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -82,40 +82,40 @@
       <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\HarmonyXInterop.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_googleanalytics_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_googleanalytics">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_guiutils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_guiutils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_lux_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_lux">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_postprocessing_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_postprocessing">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_simplemeshcombine_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_simplemeshcombine">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_steamworks_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_steamworks">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_sunshafts_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_sunshafts">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_utils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_utils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_valheim_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_valheim">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Mono.Security">

--- a/TestMod/TestMod.csproj
+++ b/TestMod/TestMod.csproj
@@ -70,40 +70,40 @@
       <HintPath>$(VALHEIM_INSTALL)\valheim_Data\Managed\publicized_assemblies\assembly_valheim_publicized.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_googleanalytics_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_googleanalytics">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_googleanalytics.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_guiutils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_guiutils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_guiutils.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_lux_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_lux">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_lux.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_postprocessing_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_postprocessing">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_postprocessing.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_simplemeshcombine_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_simplemeshcombine">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_simplemeshcombine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_steamworks_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_steamworks">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_steamworks.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_sunshafts_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_sunshafts">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_sunshafts.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_utils_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_utils">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MMHOOK_assembly_valheim_publicized">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim_publicized.dll</HintPath>
+    <Reference Include="MMHOOK_assembly_valheim">
+      <HintPath>$(VALHEIM_INSTALL)\BepInEx\plugins\MMHOOK\MMHOOK_assembly_valheim.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx, Version=5.4.5.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
fix: create MMHOOK dlls from unpublicized dlls - delete MMHOOK folder in BepInEx Plugins manually once