### PR TITLE
prevent crash when plugin info instance is null

### DIFF
--- a/JotunnLib/Utils/BepInExUtils.cs
+++ b/JotunnLib/Utils/BepInExUtils.cs
@@ -15,7 +15,7 @@ namespace Jotunn.Utils
         {
             var result = new Dictionary<string, BaseUnityPlugin>();
 
-            var plugins = BepInEx.Bootstrap.Chainloader.PluginInfos.Select(x => x.Value.Instance).ToArray();
+            var plugins = BepInEx.Bootstrap.Chainloader.PluginInfos.Select(x => x.Value.Instance).Where(x => x != null).ToArray();
 
             foreach (var plugin in plugins)
             {


### PR DESCRIPTION
Ran into a situation where Instance was null. I have to look into what caused this later, but I guess this should be checked anyway.