### PR TITLE
CommandManager gather vanilla commands automatically

### DIFF
--- a/JotunnLib/ConsoleCommands/HelpCommand.cs
+++ b/JotunnLib/ConsoleCommands/HelpCommand.cs
@@ -11,9 +11,9 @@ namespace Jotunn.ConsoleCommands
 
         public override void Run(string[] args)
         {
-            Console.instance.Print("Available commands:");
+            Console.instance.Print("Available custom commands:");
 
-            foreach (ConsoleCommand cmd in CommandManager.Instance.ConsoleCommands)
+            foreach (ConsoleCommand cmd in CommandManager.Instance.CustomCommands)
             {
                 Console.instance.Print(cmd.Name + " - " + cmd.Help);
             }


### PR DESCRIPTION
Also update public facing lists with more accurate names, also not sure what was the purpose of two different list, because of this also as a side effect the `AddConsoleCommand` method was not checking if someone was trying to override a cheat command