### PR TITLE
Feat/jules/keyhintenhancements

### DIFF
--- a/JotunnLib/Configs/KeyHintConfig.cs
+++ b/JotunnLib/Configs/KeyHintConfig.cs
@@ -15,6 +15,12 @@ namespace Jotunn.Configs
         public string Item { get; set; } = null;
 
         /// <summary>
+        ///     If not null the KeyHint will also be bound to a specific <see cref="global::Piece"/>
+        ///     which must be selected for building.
+        /// </summary>
+        public string Piece { get; set; } = null;
+
+        /// <summary>
         ///     Array of <see cref="ButtonConfig"/>s used for this key hint.
         /// </summary>
         public ButtonConfig[] ButtonConfigs { get; set; } = new ButtonConfig[0];
@@ -37,6 +43,17 @@ namespace Jotunn.Configs
         public static List<KeyHintConfig> ListFromJson(string json)
         {
             return SimpleJson.SimpleJson.DeserializeObject<List<KeyHintConfig>>(json);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            string ret = Item;
+            if (!string.IsNullOrEmpty(Piece))
+            {
+                ret = $"{ret}!{Piece}";
+            }
+            return ret;
         }
     }
 }

--- a/JotunnLib/Configs/KeyHintConfig.cs
+++ b/JotunnLib/Configs/KeyHintConfig.cs
@@ -51,7 +51,7 @@ namespace Jotunn.Configs
             string ret = Item;
             if (!string.IsNullOrEmpty(Piece))
             {
-                ret = $"{ret}!{Piece}";
+                ret = $"{ret}:{Piece}";
             }
             return ret;
         }

--- a/JotunnLib/Documentation/tutorials/inputs.md
+++ b/JotunnLib/Documentation/tutorials/inputs.md
@@ -84,3 +84,41 @@ The resulting KeyHints look like this
 ![Custom Key Hints](../images/data/EvilSwordKeyHints.png)
 
 Note that all texts are tokenized and translated ingame. The translations are also provided by Jötunn. Read the [tutorial on Localizations](localization.md) for more information on that topic.
+
+### Other use cases
+
+It is also possible to have "empty" KeyHints which override the vanilla hints to none or KeyHints per item and building piece for tools.
+
+```cs
+// Override "default" KeyHint with an empty config
+KeyHintConfig KHC_base = new KeyHintConfig
+{
+    Item = "BlueprintTestRune"
+};
+GUIManager.Instance.AddKeyHint(KHC_base);
+
+// Add custom KeyHints for specific pieces
+KeyHintConfig KHC_make = new KeyHintConfig
+{
+    Item = "BlueprintTestRune",
+    Piece = "make_testblueprint",
+    ButtonConfigs = new[]
+    {
+        // Override vanilla "Attack" key text
+        new ButtonConfig { Name = "Attack", HintToken = "$bprune_make" }
+    }
+};
+GUIManager.Instance.AddKeyHint(KHC_make);
+
+KeyHintConfig KHC_piece = new KeyHintConfig
+{
+    Item = "BlueprintTestRune",
+    Piece = "piece_testblueprint",
+    ButtonConfigs = new[]
+    {
+        // Override vanilla "Attack" key text
+        new ButtonConfig { Name = "Attack", HintToken = "$bprune_piece" }
+    }
+};
+GUIManager.Instance.AddKeyHint(KHC_piece);
+```

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -437,7 +437,7 @@ namespace Jotunn.Managers
         /// <returns>true if the custom key hint config was added to the manager.</returns>
         public bool AddKeyHint(KeyHintConfig hintConfig)
         {
-            if (hintConfig.Item == null || hintConfig.ButtonConfigs.Length == 0)
+            if (hintConfig.Item == null)
             {
                 Logger.LogWarning($"Key hint config {hintConfig} is not valid");
                 return false;
@@ -502,23 +502,23 @@ namespace Jotunn.Managers
             catch (Exception) { }
 
             // Try to get a KeyHint for the item and piece selected or just the item without a piece
-            KeyHintConfig keyHint = null;
+            KeyHintConfig hintConfig = null;
             if (!string.IsNullOrEmpty(pieceName))
             {
-                KeyHints.TryGetValue($"{prefabName}!{pieceName}", out keyHint);
+                KeyHints.TryGetValue($"{prefabName}:{pieceName}", out hintConfig);
             }
-            if (keyHint == null)
+            if (hintConfig == null)
             {
-                KeyHints.TryGetValue(prefabName, out keyHint);
+                KeyHints.TryGetValue(prefabName, out hintConfig);
             }
-            if (keyHint == null)
+            if (hintConfig == null)
             {
                 return;
             }
 
             // Display the Keyhint instead the vanilla one
-            var hint = KeyHintContainer.Find(keyHint.Item)?.gameObject;
-            if (hint == null)
+            var hintObject = KeyHintContainer.Find(hintConfig.ToString())?.gameObject;
+            if (hintObject == null)
             {
                 return;
             }
@@ -527,7 +527,7 @@ namespace Jotunn.Managers
             self.m_combatHints.SetActive(false);
                     
             // Update bound keys
-            foreach (var buttonConfig in keyHint.ButtonConfigs)
+            foreach (var buttonConfig in hintConfig.ButtonConfigs)
             {
                 string key = ZInput.instance.GetBoundKeyString(buttonConfig.Name);
                 if (key[0].Equals(LocalizationManager.TokenFirstChar))
@@ -537,12 +537,12 @@ namespace Jotunn.Managers
 
                 if (string.IsNullOrEmpty(buttonConfig.Axis) || !buttonConfig.Axis.Equals("Mouse ScrollWheel"))
                 {
-                    hint.transform.Find($"Keyboard/{buttonConfig.Name}/key_bkg/Key")?.gameObject?.SetText(key);
+                    hintObject.transform.Find($"Keyboard/{buttonConfig.Name}/key_bkg/Key")?.gameObject?.SetText(key);
                 }
             }
 
-            hint.SetActive(true);
-            hint.GetComponent<UIInputHint>()?.Update();
+            hintObject.SetActive(true);
+            hintObject.GetComponent<UIInputHint>()?.Update();
         }
 
         /// <summary>

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -69,10 +69,6 @@ namespace TestMod
             SynchronizationManager.ConfigurationSynchronized += () =>
             {
                 Jotunn.Logger.LogMessage("Config sync event received");
-                var prefab = PrefabManager.Instance.GetPrefab("BlueprintTestRune").GetComponent<ItemDrop>();
-                prefab.m_itemData.m_shared.m_name = "Hnglblarf";
-                this.Config.TryGetEntry<int>("JotunnTest", "IntegerValue1", out var cfg);
-                prefab.m_itemData.m_shared.m_weight = (float)cfg.Value;
             };
 
             // Get current version for the mod compatibility test

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -164,9 +164,15 @@ namespace TestMod
                     {
                         bez = item.m_shared.m_name;
                     }
+
+                    Piece piece = Player.m_localPlayer.m_buildPieces?.GetSelectedPiece();
+                    if (piece != null)
+                    {
+                        bez = bez + "!" + piece.name;
+                    }
                 }
 
-                GUI.Label(new Rect(10, 10, 100, 25), bez);
+                GUI.Label(new Rect(10, 10, 500, 25), bez);
             }
         }
 

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -168,7 +168,7 @@ namespace TestMod
                     Piece piece = Player.m_localPlayer.m_buildPieces?.GetSelectedPiece();
                     if (piece != null)
                     {
-                        bez = bez + "!" + piece.name;
+                        bez = bez + ":" + piece.name;
                     }
                 }
 
@@ -423,13 +423,53 @@ namespace TestMod
                 });
             PieceManager.Instance.AddPiece(placebp);
 
-            // Add localizations
+            // Add localizations from the asset bundle
             var textAssets = blueprintRuneBundle.LoadAllAssets<TextAsset>();
             foreach (var textAsset in textAssets)
             {
                 var lang = textAsset.name.Replace(".json", null);
                 LocalizationManager.Instance.AddJson(lang, textAsset.ToString());
             }
+
+            // Override "default" KeyHint with an empty config
+            KeyHintConfig KHC_base = new KeyHintConfig
+            {
+                Item = "BlueprintTestRune"
+            };
+            GUIManager.Instance.AddKeyHint(KHC_base);
+
+            // Add custom KeyHints for specific pieces
+            KeyHintConfig KHC_make = new KeyHintConfig
+            {
+                Item = "BlueprintTestRune",
+                Piece = "make_testblueprint",
+                ButtonConfigs = new[]
+                {
+                    // Override vanilla "Attack" key text
+                    new ButtonConfig { Name = "Attack", HintToken = "$bprune_make" }
+                }
+            };
+            GUIManager.Instance.AddKeyHint(KHC_make);
+
+            KeyHintConfig KHC_piece = new KeyHintConfig
+            {
+                Item = "BlueprintTestRune",
+                Piece = "piece_testblueprint",
+                ButtonConfigs = new[]
+                {
+                    // Override vanilla "Attack" key text
+                    new ButtonConfig { Name = "Attack", HintToken = "$bprune_piece" }
+                }
+            };
+            GUIManager.Instance.AddKeyHint(KHC_piece);
+
+            // Add additional localization manually
+            LocalizationManager.Instance.AddLocalization(new LocalizationConfig("English")
+            {
+                Translations = {
+                    {"bprune_make", "Capture Blueprint"}, {"bprune_piece", "Place Blueprint"}
+                }
+            });
 
             // Don't forget to unload the bundle to free the resources
             blueprintRuneBundle.Unload(false);


### PR DESCRIPTION
Allow KeyHints per item and piece. Allow "empty" KeyHints (to disable the vanilla KeyHint). Create KeyHints on the fly when the GameObject does not exist (add dynamic hints ingame).

#86 