### PR TITLE
Actively synchronized admin list

### DIFF
--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -45,7 +45,7 @@ namespace Jotunn
             RootObject = new GameObject("_JotunnRoot");
             GameObject.DontDestroyOnLoad(RootObject);
 
-            managers = new List<IManager>() 
+            managers = new List<IManager>()
             {
                 LocalizationManager.Instance,
                 CommandManager.Instance,
@@ -82,9 +82,12 @@ namespace Jotunn
             { // Set a breakpoint here to break on F6 key press
             }
 #endif
-            if (ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance())
+            if (ZNet.instance != null)
             {
-                SynchronizationManager.Instance.AdminListUpdate();
+                if (ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance())
+                {
+                    SynchronizationManager.Instance.AdminListUpdate();
+                }
             }
         }
 

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -82,6 +82,10 @@ namespace Jotunn
             { // Set a breakpoint here to break on F6 key press
             }
 #endif
+            if (ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance())
+            {
+                SynchronizationManager.Instance.AdminListUpdate();
+            }
         }
 
         private void OnGUI()

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -375,6 +375,10 @@ namespace Jotunn.Managers
                 {
                     UnlockConfigurationEntries();
                 }
+                else
+                {
+                    LockConfigurationEntries();
+                }
             }
 
             // Server Receive

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -20,6 +20,8 @@ namespace Jotunn.Managers
         private BaseUnityPlugin configurationManager;
         internal bool configurationManagerWindowShown;
         private static SynchronizationManager _instance;
+        private static Dictionary<string, bool> lastAdminStates = new Dictionary<string, bool>();
+        private double m_lastLoadCheckTime;
 
         /// <summary>
         ///     Event, triggered after server configuration is applied to client
@@ -56,6 +58,8 @@ namespace Jotunn.Managers
             On.ZNet.RPC_PeerInfo += ZNet_RPC_PeerInfo;
 
             On.Menu.IsVisible += Menu_IsVisible;
+            On.SyncedList.Load += SyncedList_Load;
+            On.SyncedList.Save += SyncedList_Save;
 
             // Find Configuration manager plugin and add to DisplayingWindowChanged event
             if (!configurationManager)
@@ -85,6 +89,89 @@ namespace Jotunn.Managers
         private bool Menu_IsVisible(On.Menu.orig_IsVisible orig)
         {
             return orig() | configurationManagerWindowShown;
+        }
+
+        private void SyncedList_Save(On.SyncedList.orig_Save orig, SyncedList self)
+        {
+            orig(self);
+
+            // Check if it really is the admin list
+            if (self == ZNet.instance.m_adminList)
+            {
+                SynchronizeAdminStatus();
+            }
+        }
+
+        private void SyncedList_Load(On.SyncedList.orig_Load orig, SyncedList self)
+        {
+            orig(self);
+
+            // Check if it really is the admin list
+            if (self == ZNet.instance.m_adminList)
+            {
+                SynchronizeAdminStatus();
+            }
+        }
+
+        private void SynchronizeAdminStatus()
+        {
+            if (ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance())
+            {
+                foreach (var entry in ZNet.instance.m_adminList.m_list)
+                {
+                    // Admin state added, but not in cache list yet
+                    if (!lastAdminStates.ContainsKey(entry))
+                    {
+                        // Send RPC, new entry found
+                        SendAdminStateToClient(entry, true);
+
+                        lastAdminStates.Add(entry, true);
+                    }
+                    // Admin state added and already in cache list
+                    else
+                    {
+                        if (lastAdminStates[entry] == false)
+                        {
+                            // Send RPC, new entry found
+                            SendAdminStateToClient(entry, true);
+                        }
+                    }
+                }
+
+                foreach (var entry in lastAdminStates.Keys.ToList())
+                {
+                    // Admin state removed
+                    if (!ZNet.instance.m_adminList.Contains(entry))
+                    {
+                        // If cached state is true
+                        if (lastAdminStates[entry])
+                        {
+                            // Send RPC, new entry found
+                            SendAdminStateToClient(entry, false);
+                        }
+
+                        lastAdminStates.Remove(entry);
+                    }
+                }
+            }
+        }
+
+        private void SendAdminStateToClient(string entry, bool admin)
+        {
+            var clientId = ZNet.instance.m_peers.FirstOrDefault(x => x.m_socket.GetHostName() == entry)?.m_uid;
+            if (clientId != null)
+            {
+                ZRoutedRpc.instance.InvokeRoutedRPC((long) clientId, nameof(RPC_Jotunn_IsAdmin), admin);
+            }
+        }
+
+        internal void AdminListUpdate()
+        {
+            if (Time.realtimeSinceStartup - this.m_lastLoadCheckTime <= 10.0f)
+            {
+                ZNet.instance.m_adminList.GetList();
+                m_lastLoadCheckTime = Time.realtimeSinceStartup;
+            }
         }
 
         /// <summary>

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -117,7 +117,8 @@ namespace Jotunn.Managers
         {
             if (ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance())
             {
-                foreach (var entry in ZNet.instance.m_adminList.m_list)
+                List<string> adminListCopy = ZNet.instance.m_adminList.m_list.ToList();
+                foreach (var entry in adminListCopy)
                 {
                     // Admin state added, but not in cache list yet
                     if (!lastAdminStates.ContainsKey(entry))
@@ -141,7 +142,7 @@ namespace Jotunn.Managers
                 foreach (var entry in lastAdminStates.Keys.ToList())
                 {
                     // Admin state removed
-                    if (!ZNet.instance.m_adminList.Contains(entry))
+                    if (!adminListCopy.Contains(entry))
                     {
                         // If cached state is true
                         if (lastAdminStates[entry])
@@ -161,13 +162,14 @@ namespace Jotunn.Managers
             var clientId = ZNet.instance.m_peers.FirstOrDefault(x => x.m_socket.GetHostName() == entry)?.m_uid;
             if (clientId != null)
             {
-                ZRoutedRpc.instance.InvokeRoutedRPC((long) clientId, nameof(RPC_Jotunn_IsAdmin), admin);
+                Logger.LogMessage($"Sending admin status to {entry}/{clientId} ({(admin ? "is admin" : "is no admin")})");
+                ZRoutedRpc.instance.InvokeRoutedRPC((long)clientId, nameof(RPC_Jotunn_IsAdmin), admin);
             }
         }
 
         internal void AdminListUpdate()
         {
-            if (Time.realtimeSinceStartup - this.m_lastLoadCheckTime <= 10.0f)
+            if (Time.realtimeSinceStartup - this.m_lastLoadCheckTime >= 10.0f)
             {
                 ZNet.instance.m_adminList.GetList();
                 m_lastLoadCheckTime = Time.realtimeSinceStartup;
@@ -252,7 +254,7 @@ namespace Jotunn.Managers
 
                     if (cx.SettingType == typeof(KeyCode))
                     {
-                        ZInput.instance.Setbutton($"{buttonName}!{plugin.Value.Info.Metadata.GUID}", (KeyCode) cx.BoxedValue);
+                        ZInput.instance.Setbutton($"{buttonName}!{plugin.Value.Info.Metadata.GUID}", (KeyCode)cx.BoxedValue);
                     }
                 }
             }


### PR DESCRIPTION
Changing the admin list on the server will be propagated to the respective clients within 10sec.
Reacts on outside file changes and ZNet.instance.m_adminList.Add/Remove (it is sent after SyncedList.Save is called)

takes care of #234 and #235