### PR TITLE
fixed DragWindowCntrl not respecting screen borders sometimes

### DIFF
--- a/JotunnLib/Unity/Assets/Scripts/DragWindowCntrl.cs
+++ b/JotunnLib/Unity/Assets/Scripts/DragWindowCntrl.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using UnityEngine.EventSystems;
 
 namespace Jotunn.GUI
@@ -6,27 +7,20 @@ namespace Jotunn.GUI
     /// <summary>
     ///     Simple dragging <see cref="MonoBehaviour"/>
     /// </summary>
-    public class DragWindowCntrl : MonoBehaviour
+    public class DragWindowCntrl : MonoBehaviour, IBeginDragHandler, IDragHandler
     {
         /// <summary>
-        ///     Add this MonoBehaviour to a GameObject and register the EventTrigger for it
+        ///     Add this MonoBehaviour to a GameObject
         /// </summary>
         /// <param name="go"></param>
+        [Obsolete("Use gameObject.AddComponent<DragWindowCntrl>() instead")]
         public static void ApplyDragWindowCntrl(GameObject go)
         {
-            DragWindowCntrl drag = go.AddComponent<DragWindowCntrl>();
-            EventTrigger trigger = go.AddComponent<EventTrigger>();
-            EventTrigger.Entry beginDragEntry = new EventTrigger.Entry();
-            beginDragEntry.eventID = EventTriggerType.BeginDrag;
-            beginDragEntry.callback.AddListener((_) => { drag.BeginDrag(); });
-            trigger.triggers.Add(beginDragEntry);
-            EventTrigger.Entry dragEntry = new EventTrigger.Entry();
-            dragEntry.eventID = EventTriggerType.Drag;
-            dragEntry.callback.AddListener((_) => { drag.Drag(); });
-            trigger.triggers.Add(dragEntry);
+            go.AddComponent<DragWindowCntrl>();
         }
 
         private RectTransform window;
+
         //delta drag
         private Vector2 delta;
 
@@ -38,39 +32,29 @@ namespace Jotunn.GUI
         /// <summary>
         ///     BeginDrag event trigger
         /// </summary>
-        public void BeginDrag()
+        public void OnBeginDrag(PointerEventData eventData)
         {
             delta = Input.mousePosition - window.position;
         }
+
         /// <summary>
         ///     Drag event trigger
         /// </summary>
-        public void Drag()
+        public void OnDrag(PointerEventData eventData)
         {
-            Vector2 newPos = (Vector2)Input.mousePosition - delta;
-            Vector2 Transform = new Vector2(window.rect.width * transform.root.lossyScale.x, window.rect.height * transform.root.lossyScale.y);
-            Vector2 OffsetMin, OffsetMax;
-            OffsetMin.x = newPos.x - window.pivot.x * Transform.x;
-            OffsetMin.y = newPos.y - window.pivot.y * Transform.y;
-            OffsetMax.x = newPos.x + (1 - window.pivot.x) * Transform.x;
-            OffsetMax.y = newPos.y + (1 - window.pivot.y) * Transform.y;
-            if (OffsetMin.x < 0)
-            {
-                newPos.x = window.pivot.x * Transform.x;
-            }
-            else if (OffsetMax.x > Screen.width)
-            {
-                newPos.x = Screen.width - (1 - window.pivot.x) * Transform.x;
-            }
-            if (OffsetMin.y < 0)
-            {
-                newPos.y = window.pivot.y * Transform.y;
-            }
-            else if (OffsetMax.y > Screen.height)
-            {
-                newPos.y = Screen.height - (1 - window.pivot.y) * Transform.y;
-            }
-            window.position = newPos;
+            Vector2 pos = eventData.position - delta;
+            Rect rect = window.rect;
+            Vector2 lossyScale = window.lossyScale;
+
+            float minX = rect.width / 2f * lossyScale.x;
+            float maxX = Screen.width - minX;
+            float minY = rect.height / 2f * lossyScale.y;
+            float maxY = Screen.height - minY;
+
+            pos.x = Mathf.Clamp(pos.x, minX, maxX);
+            pos.y = Mathf.Clamp(pos.y, minY, maxY);
+
+            transform.position = pos;
         }
     }
 }


### PR DESCRIPTION
DragWindowCntrl hasn't respected Valheim's GUI Scale setting nor different screen sizes except default.
Also marked `ApplyDragWindowCntrl` as obsolete because `AddComponent<DragWindowCntrl>()` is sufficient now.