### PR TITLE
Added slider to InGameConfig

### DIFF
--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -427,12 +427,19 @@ namespace Jotunn.GUI
                             slider.gameObject.SetActive(true);
                             slider.minValue = acceptableValueRange.MinValue;
                             slider.maxValue = acceptableValueRange.MaxValue;
+                            slider.value = configBoundInt.Value;
                             slider.onValueChanged.AddListener(value => inputField.text = ((int)value).ToString(CultureInfo.CurrentCulture));
+                            inputField.onValueChanged.AddListener(text =>
+                            {
+                                if (int.TryParse(text, out var value))
+                                {
+                                    slider.value = value;
+                                }
+                            });
                         }
-                        go.transform.Find("Input").GetComponent<InputField>().onValueChanged.AddListener(x =>
+                        inputField.onValueChanged.AddListener(x =>
                         {
-                            go.transform.Find("Input").GetComponent<InputField>().textComponent.color =
-                                go.GetComponent<ConfigBoundInt>().IsValid() ? Color.white : Color.red;
+                            inputField.textComponent.color = configBoundInt.IsValid() ? Color.white : Color.red;
                         });
                         preferredHeight += go.GetHeight();
                     }
@@ -463,7 +470,15 @@ namespace Jotunn.GUI
                             slider.gameObject.SetActive(true);
                             slider.minValue = acceptableValueRange.MinValue;
                             slider.maxValue = acceptableValueRange.MaxValue;
+                            slider.value = configBoundFloat.Value;
                             slider.onValueChanged.AddListener(value => inputField.text = value.ToString(CultureInfo.CurrentCulture));
+                            inputField.onValueChanged.AddListener(text =>
+                            {
+                                if (float.TryParse(text, out var value))
+                                {
+                                    slider.value = value;
+                                }
+                            });
                         }
                         inputField.onValueChanged.AddListener(x =>
                         {
@@ -498,7 +513,15 @@ namespace Jotunn.GUI
                             slider.gameObject.SetActive(true);
                             slider.minValue = (float) acceptableValueRange.MinValue;
                             slider.maxValue = (float) acceptableValueRange.MaxValue;
+                            slider.value = (float) configBoundDouble.Value;
                             slider.onValueChanged.AddListener(value => inputField.text = value.ToString(CultureInfo.CurrentCulture));
+                            inputField.onValueChanged.AddListener(text =>
+                            {
+                                if (double.TryParse(text, out var value))
+                                {
+                                    slider.value = (float) value;
+                                }
+                            });
                         }
                         inputField.onValueChanged.AddListener(x =>
                         {

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -813,10 +813,8 @@ namespace Jotunn.GUI
             // create the slider
             var slider = DefaultControls.CreateSlider(GUIManager.Instance.ValheimControlResources);
             slider.transform.SetParent(field.transform, false);
-            ((RectTransform)slider.transform).pivot = new Vector2(1, 0.5f);
-            var inputFieldWidth = ((RectTransform)inputField.transform).sizeDelta.x;
-            ((RectTransform)slider.transform).anchoredPosition = new Vector2(-inputFieldWidth / 2f - 10f, 0);
-            ((RectTransform)slider.transform).sizeDelta = new Vector2(120, 30);
+            ((RectTransform)slider.transform).anchoredPosition = new Vector2(0, -25);
+            ((RectTransform)slider.transform).sizeDelta = new Vector2(140, 30);
             GUIManager.Instance.ApplySliderStyle(slider.GetComponent<Slider>());
             slider.SetActive(false);
 

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -476,7 +476,7 @@ namespace Jotunn.GUI
                             {
                                 if (float.TryParse(text, out var value))
                                 {
-                                    slider.value = value;
+                                    slider.value = Mathf.Round(value*1000f)/1000f;
                                 }
                             });
                         }
@@ -519,7 +519,7 @@ namespace Jotunn.GUI
                             {
                                 if (double.TryParse(text, out var value))
                                 {
-                                    slider.value = (float) value;
+                                    slider.value = Mathf.Round((float)value*1000f)/1000f;
                                 }
                             });
                         }

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -416,11 +416,19 @@ namespace Jotunn.GUI
                             entryAttributes.EntryColor,
                             description + (entryAttributes.IsAdminOnly ? $"{Environment.NewLine}(Server side setting)" : ""),
                             entryAttributes.DescriptionColor, innerWidth);
-                        go.AddComponent<ConfigBoundInt>()
-                            .SetData(mod.Value.Info.Metadata.GUID, entry.Key.Section, entry.Key.Key);
-                        go.transform.Find("Input").GetComponent<InputField>().characterValidation =
-                            InputField.CharacterValidation.Integer;
-                        SetProperties(go.GetComponent<ConfigBoundInt>(), entry);
+                        var configBoundInt = go.AddComponent<ConfigBoundInt>();
+                        var inputField = go.transform.Find("Input").GetComponent<InputField>();
+                        configBoundInt.SetData(mod.Value.Info.Metadata.GUID, entry.Key.Section, entry.Key.Key);
+                        inputField.characterValidation = InputField.CharacterValidation.Integer;
+                        SetProperties(configBoundInt, entry);
+                        if (configBoundInt.Clamp is AcceptableValueRange<int> acceptableValueRange)
+                        {
+                            var slider = go.GetComponentInChildren<Slider>(true);
+                            slider.gameObject.SetActive(true);
+                            slider.minValue = acceptableValueRange.MinValue;
+                            slider.maxValue = acceptableValueRange.MaxValue;
+                            slider.onValueChanged.AddListener(value => inputField.text = ((int)value).ToString(CultureInfo.CurrentCulture));
+                        }
                         go.transform.Find("Input").GetComponent<InputField>().onValueChanged.AddListener(x =>
                         {
                             go.transform.Find("Input").GetComponent<InputField>().textComponent.color =
@@ -444,15 +452,22 @@ namespace Jotunn.GUI
                             entryAttributes.EntryColor,
                             description + (entryAttributes.IsAdminOnly ? $"{Environment.NewLine}(Server side setting)" : ""),
                             entryAttributes.DescriptionColor, innerWidth);
-                        go.AddComponent<ConfigBoundFloat>()
-                            .SetData(mod.Value.Info.Metadata.GUID, entry.Key.Section, entry.Key.Key);
-                        go.transform.Find("Input").GetComponent<InputField>().characterValidation =
-                            InputField.CharacterValidation.Decimal;
-                        SetProperties(go.GetComponent<ConfigBoundFloat>(), entry);
-                        go.transform.Find("Input").GetComponent<InputField>().onValueChanged.AddListener(x =>
+                        var configBoundFloat = go.AddComponent<ConfigBoundFloat>();
+                        var inputField = go.transform.Find("Input").GetComponent<InputField>();
+                        configBoundFloat.SetData(mod.Value.Info.Metadata.GUID, entry.Key.Section, entry.Key.Key);
+                        inputField.characterValidation = InputField.CharacterValidation.Decimal;
+                        SetProperties(configBoundFloat, entry);
+                        if (configBoundFloat.Clamp is AcceptableValueRange<float> acceptableValueRange)
                         {
-                            go.transform.Find("Input").GetComponent<InputField>().textComponent.color =
-                                go.GetComponent<ConfigBoundFloat>().IsValid() ? Color.white : Color.red;
+                            var slider = go.GetComponentInChildren<Slider>(true);
+                            slider.gameObject.SetActive(true);
+                            slider.minValue = acceptableValueRange.MinValue;
+                            slider.maxValue = acceptableValueRange.MaxValue;
+                            slider.onValueChanged.AddListener(value => inputField.text = value.ToString(CultureInfo.CurrentCulture));
+                        }
+                        inputField.onValueChanged.AddListener(x =>
+                        {
+                            inputField.textComponent.color = configBoundFloat.IsValid() ? Color.white : Color.red;
                         });
                         preferredHeight += go.GetHeight();
                     }
@@ -472,15 +487,22 @@ namespace Jotunn.GUI
                             entryAttributes.EntryColor,
                             description + (entryAttributes.IsAdminOnly ? $"{Environment.NewLine}(Server side setting)" : ""),
                             entryAttributes.DescriptionColor, innerWidth);
-                        go.AddComponent<ConfigBoundDouble>()
-                            .SetData(mod.Value.Info.Metadata.GUID, entry.Key.Section, entry.Key.Key);
-                        go.transform.Find("Input").GetComponent<InputField>().characterValidation =
-                            InputField.CharacterValidation.Decimal;
-                        SetProperties(go.GetComponent<ConfigBoundDouble>(), entry);
-                        go.transform.Find("Input").GetComponent<InputField>().onValueChanged.AddListener(x =>
+                        var configBoundDouble =go.AddComponent<ConfigBoundDouble>();
+                        var inputField = go.transform.Find("Input").GetComponent<InputField>();
+                        configBoundDouble.SetData(mod.Value.Info.Metadata.GUID, entry.Key.Section, entry.Key.Key);
+                        inputField.characterValidation = InputField.CharacterValidation.Decimal;
+                        SetProperties(configBoundDouble, entry);
+                        if (configBoundDouble.Clamp is AcceptableValueRange<double> acceptableValueRange)
                         {
-                            go.transform.Find("Input").GetComponent<InputField>().textComponent.color =
-                                go.GetComponent<ConfigBoundDouble>().IsValid() ? Color.white : Color.red;
+                            var slider = go.GetComponentInChildren<Slider>(true);
+                            slider.gameObject.SetActive(true);
+                            slider.minValue = (float) acceptableValueRange.MinValue;
+                            slider.maxValue = (float) acceptableValueRange.MaxValue;
+                            slider.onValueChanged.AddListener(value => inputField.text = value.ToString(CultureInfo.CurrentCulture));
+                        }
+                        inputField.onValueChanged.AddListener(x =>
+                        {
+                            inputField.textComponent.color = configBoundDouble.IsValid() ? Color.white : Color.red;
                         });
                         preferredHeight += go.GetHeight();
                     }
@@ -764,6 +786,16 @@ namespace Jotunn.GUI
             placeholder.GetComponent<Text>().color = Color.gray;
             placeholder.transform.SetParent(field.transform, false);
             placeholder.GetComponent<RectTransform>().anchoredPosition = new Vector2(5, 0);
+
+            // create the slider
+            var slider = DefaultControls.CreateSlider(GUIManager.Instance.ValheimControlResources);
+            slider.transform.SetParent(field.transform, false);
+            ((RectTransform)slider.transform).pivot = new Vector2(1, 0.5f);
+            var inputFieldWidth = ((RectTransform)inputField.transform).sizeDelta.x;
+            ((RectTransform)slider.transform).anchoredPosition = new Vector2(-inputFieldWidth / 2f - 10f, 0);
+            ((RectTransform)slider.transform).sizeDelta = new Vector2(120, 30);
+            GUIManager.Instance.ApplySliderStyle(slider.GetComponent<Slider>());
+            slider.SetActive(false);
 
             // set the preferred height on the layout element
             result.GetComponent<LayoutElement>().preferredHeight = result.GetComponent<RectTransform>().rect.height;

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -1725,5 +1725,34 @@ namespace Jotunn.Managers
                 image.pixelsPerUnitMultiplier = GUIInStart ? 2f : 1f;
             }
         }
+
+        /// <summary>
+        ///     Apply Valheim style to a <see cref="Slider"/> component.
+        /// </summary>
+        /// <param name="slider"></param>
+        public void ApplySliderStyle(Slider slider)
+        {
+            slider.handleRect.sizeDelta = new Vector2(40, 10);
+
+            if (slider.fillRect && slider.fillRect.TryGetComponent<Image>(out var image))
+            {
+                image.sprite = GetSprite("UISprite");
+                image.color = ValheimOrange;
+            }
+
+            if (slider.handleRect && slider.handleRect.transform.parent)
+            {
+                RectTransform handleSlideArea = (RectTransform)slider.handleRect.transform.parent;
+                handleSlideArea.offsetMin = new Vector2(5f, handleSlideArea.offsetMin.y);
+                handleSlideArea.offsetMax = new Vector2(-5f, handleSlideArea.offsetMax.y);
+            }
+
+            if (slider.handleRect && slider.fillRect.transform.parent)
+            {
+                RectTransform fillArea = (RectTransform)slider.fillRect.transform.parent;
+                fillArea.offsetMin = new Vector2(5f, fillArea.offsetMin.y);
+                fillArea.offsetMax = new Vector2(-5f, fillArea.offsetMax.y);
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -98,3 +98,5 @@ These people have been integral to pushing JVL out of the door, and without them
 *blaxxun#9098*: [github](https://github.com/blaxxun-boop) - Creator of the superb [ServerSync](https://github.com/blaxxun-boop/ServerSync) mod which Jötunn adapted
 
 *Tekla#1012*: [github](https://github.com/T3kla/ValMods/wiki)
+
+*Margmas#9562*: [github](https://github.com/MSchmoecker), [thunderstore](https://valheim.thunderstore.io/package/MSchmoecker/), [nexus](https://www.nexusmods.com/users/111418768)


### PR DESCRIPTION
Displays a slider to int, float and double fields if a `AcceptableValueRange<type>` is present. The slider is spawned for every InputField but only activated if needed. Also adds a basic `ApplySliderStyle` to GUIManager.

![grafik](https://user-images.githubusercontent.com/39767545/135257300-63a91bf6-c992-4c4b-90b6-c7d043a3840a.png)