### PR TITLE
fix: Fix Dropdown width setting

### DIFF
--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -180,6 +180,12 @@ namespace Jotunn.Managers
         private static int InputBlockRequests;
 
         /// <summary>
+        ///     The difference in width between a Dropdown and its contents, to allow
+        ///     room for the selection indicator.
+        /// </summary>
+        private const float DropdownContentOffset = 50f;
+
+        /// <summary>
         ///     Block all input except GUI
         /// </summary>
         /// <param name="state">Indicator if the input should be blocked or released</param>
@@ -1082,11 +1088,13 @@ namespace Jotunn.Managers
             // Optionally set width and height
             if (width > 0f)
             {
+                float contentWidth = width - DropdownContentOffset;
+                dropdown.SetWidth(width);
                 dropdownComponent.captionText.gameObject.SetMiddleLeft();
-                dropdownComponent.captionText.gameObject.SetWidth(width);
+                dropdownComponent.captionText.gameObject.SetWidth(contentWidth);
                 dropdownComponent.captionText.GetComponent<RectTransform>()
                     .anchoredPosition = new Vector3(10f, 0f);
-                dropdownComponent.itemText.gameObject.SetWidth(width);
+                dropdownComponent.itemText.gameObject.SetWidth(contentWidth);
             }
 
             if (height > 0f)


### PR DESCRIPTION
Dropdown width now affects the outer dropdown component, and the inner
components are sized a little smaller to accommodate the selection
indicator.

Fixes #320