### PR TITLE
Improved controller navigation in mod settings

### DIFF
--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -264,6 +264,23 @@ namespace Jotunn.GUI
                     yield return CreateContent(mod, Configs[mod.Key]);
                 }
             }
+
+            // Connect OK and Back's Navigation
+            var okButton = ok.GetComponent<Button>();
+            var backButton = back.GetComponent<Button>();
+
+            var okNavigation = okButton.navigation;
+            var backNavigation = backButton.navigation;
+
+            okNavigation.selectOnLeft = backButton;
+            backNavigation.selectOnRight = okButton;
+
+            // These don't seem to work, leaving in to show intention
+            okNavigation.selectOnUp = Configs.Values.Last().gameObject.GetComponent<Selectable>();
+            backNavigation.selectOnUp = Configs.Values.Last().gameObject.GetComponent<Selectable>();
+
+            okButton.navigation = okNavigation;
+            backButton.navigation = backNavigation;
         }
         
         private class EscBehaviour : MonoBehaviour

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -49,6 +49,11 @@ namespace Jotunn.GUI
         ///     Our own mod config tabs
         /// </summary>
         private static readonly Dictionary<string, RectTransform> Configs = new Dictionary<string, RectTransform>();
+
+        /// <summary>
+        ///     Navigation with mode set to None
+        /// </summary>
+        private static readonly Navigation NavigationNone = new Navigation() { mode = Navigation.Mode.None };
         
         /// <summary>
         ///     Hook into settings setup
@@ -680,9 +685,9 @@ namespace Jotunn.GUI
             field.GetComponent<Image>().sprite = GUIManager.Instance.GetSprite("text_field");
             field.GetComponent<Image>().type = Image.Type.Sliced;
             field.transform.SetParent(result.transform, false);
-
+            SetNavigationNone(field);
             var inputField = field.GetComponent<InputField>();
-
+            
             var text = new GameObject("Text", typeof(RectTransform), typeof(Text), typeof(Outline)).SetMiddleLeft().SetHeight(label.GetTextHeight() + 6f)
                 .SetWidth(130f);
             inputField.textComponent = text.GetComponent<Text>();
@@ -709,6 +714,7 @@ namespace Jotunn.GUI
             ((RectTransform)slider.transform).anchoredPosition = new Vector2(0, -25);
             ((RectTransform)slider.transform).sizeDelta = new Vector2(140, 30);
             GUIManager.Instance.ApplySliderStyle(slider.GetComponent<Slider>());
+            SetNavigationNone(slider);
             slider.SetActive(false);
 
             // Add SelectableConfig and pass field as target
@@ -760,6 +766,7 @@ namespace Jotunn.GUI
             field.GetComponent<Image>().sprite = GUIManager.Instance.GetSprite("text_field");
             field.GetComponent<Image>().type = Image.Type.Sliced;
             field.transform.SetParent(layout.transform, false);
+            SetNavigationNone(field);
 
             var inputField = field.GetComponent<InputField>();
 
@@ -787,9 +794,10 @@ namespace Jotunn.GUI
             var button = new GameObject("Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(ButtonSfx))
                 .SetUpperRight().SetSize(30f, label.GetTextHeight() + 6f);
             button.transform.SetParent(layout.transform, false);
-
+            SetNavigationNone(button);
 
             // Add SelectableConfig and pass ColorPicker button as target
+
             result.AddComponent<SelectableConfig>().InteractionTarget = button;
 
             // Image
@@ -842,6 +850,7 @@ namespace Jotunn.GUI
 
             // and now the toggle itself
             var toggle = GUIManager.Instance.CreateToggle(result.transform, 20f, 20f).SetUpperRight();
+            SetNavigationNone(toggle);
 
             // Add SelectableConfig and pass toggle as target
             result.AddComponent<SelectableConfig>().InteractionTarget = toggle;
@@ -888,6 +897,11 @@ namespace Jotunn.GUI
             // Create label and keybind button
             var result = GUIManager.Instance.CreateKeyBindField(labelname, parent, width, 4f);
 
+            // Setup keybind button for controller navigation
+            var button = result.transform.Find("Button").gameObject;
+            SetNavigationNone(button);
+            result.AddComponent<SelectableConfig>().InteractionTarget = button;
+
             // Create description text
             var idx = 0;
             var lastPosition = new Vector2(0, -result.GetComponent<RectTransform>().rect.height - 3f);
@@ -927,6 +941,11 @@ namespace Jotunn.GUI
             // Create label and keybind button
             var result = GUIManager.Instance.CreateKeyBindField(labelname, parent, width, 24f);
 
+            // Setup keybind button for controller navigation
+            var button = result.transform.Find("Button").gameObject;
+            SetNavigationNone(button);
+            result.AddComponent<SelectableConfig>().InteractionTarget = button;
+
             // Create description text
             var idx = 0;
             var lastPosition = new Vector2(0, -result.GetComponent<RectTransform>().rect.height - 3f);
@@ -952,7 +971,18 @@ namespace Jotunn.GUI
             return result;
         }
 
-
+        /// <summary>
+        /// Sets Selectable Component navigation mode to None
+        /// </summary>
+        /// <param name="go">Game Object with a Selectable Component to be set to navigation mode None</param>
+        private static void SetNavigationNone(GameObject go)
+        {
+            var selectable = go.GetComponent<Selectable>();
+            if (selectable != null)
+            {
+                selectable.navigation = NavigationNone;
+            }
+        }
         // Helper classes 
 
         /// <summary>

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -1455,6 +1455,7 @@ namespace Jotunn.GUI
                 } while (anyKeyDown);
 
                 var buttonName = Entry.GetBoundButtonName();
+                GUIManager.BlockInput(true);
                 Settings.instance.OpenBindDialog(buttonName);
                 On.ZInput.EndBindKey += ZInput_EndBindKey;
             }
@@ -1468,6 +1469,8 @@ namespace Jotunn.GUI
                         SetValue(new KeyboardShortcut(key, KeysToCheck.Where(Input.GetKey).ToArray()));
                         ZInput.m_binding.m_key = key;
                         On.ZInput.EndBindKey -= ZInput_EndBindKey;
+
+                        GUIManager.BlockInput(false);
                         return true;
                     }
                 }

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -711,6 +711,10 @@ namespace Jotunn.GUI
             GUIManager.Instance.ApplySliderStyle(slider.GetComponent<Slider>());
             slider.SetActive(false);
 
+            // Add SelectableConfig and pass field as target
+            var selectable = result.AddComponent<SelectableConfig>();
+            selectable.InteractionTarget = slider;
+
             // set the preferred height on the layout element
             result.GetComponent<LayoutElement>().preferredHeight = result.GetComponent<RectTransform>().rect.height;
             return result;
@@ -784,6 +788,10 @@ namespace Jotunn.GUI
                 .SetUpperRight().SetSize(30f, label.GetTextHeight() + 6f);
             button.transform.SetParent(layout.transform, false);
 
+
+            // Add SelectableConfig and pass ColorPicker button as target
+            result.AddComponent<SelectableConfig>().InteractionTarget = button;
+
             // Image
             var image = button.GetComponent<Image>();
             var sprite = GUIManager.Instance.GetSprite("UISprite");
@@ -833,7 +841,10 @@ namespace Jotunn.GUI
             result.SetWidth(width);
 
             // and now the toggle itself
-            GUIManager.Instance.CreateToggle(result.transform, 20f, 20f).SetUpperRight();
+            var toggle = GUIManager.Instance.CreateToggle(result.transform, 20f, 20f).SetUpperRight();
+
+            // Add SelectableConfig and pass toggle as target
+            result.AddComponent<SelectableConfig>().InteractionTarget = toggle;
 
             // create the label text element
             var label = GUIManager.Instance.CreateText(labelname, result.transform, new Vector2(0, 1), new Vector2(0, 1), new Vector2(0, 0),
@@ -876,7 +887,7 @@ namespace Jotunn.GUI
         {
             // Create label and keybind button
             var result = GUIManager.Instance.CreateKeyBindField(labelname, parent, width, 4f);
-            
+
             // Create description text
             var idx = 0;
             var lastPosition = new Vector2(0, -result.GetComponent<RectTransform>().rect.height - 3f);

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -1415,11 +1415,11 @@ namespace Jotunn.GUI
             {
                 Button.onClick.AddListener(() =>
                 {
-                    StartCoroutine(nameof(CheckForKeysDown));
+                    StartCoroutine(nameof(CheckForKeysDownAndUp));
                 });
             }
 
-            private IEnumerator CheckForKeysDown()
+            private IEnumerator CheckForKeysDownAndUp()
             {
                 var anyKeyDown = false;
                 do
@@ -1427,7 +1427,7 @@ namespace Jotunn.GUI
                     anyKeyDown = false;
                     foreach (KeyCode key in Enum.GetValues(typeof(KeyCode)))
                     {
-                        if (Input.GetKeyDown(key))
+                        if (Input.GetKeyDown(key) || Input.GetKey(key))
                         {
                             anyKeyDown = true;
                         }

--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -714,7 +714,6 @@ namespace Jotunn.GUI
             ((RectTransform)slider.transform).anchoredPosition = new Vector2(0, -25);
             ((RectTransform)slider.transform).sizeDelta = new Vector2(140, 30);
             GUIManager.Instance.ApplySliderStyle(slider.GetComponent<Slider>());
-            SetNavigationNone(slider);
             slider.SetActive(false);
 
             // Add SelectableConfig and pass field as target
@@ -794,7 +793,6 @@ namespace Jotunn.GUI
             var button = new GameObject("Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(ButtonSfx))
                 .SetUpperRight().SetSize(30f, label.GetTextHeight() + 6f);
             button.transform.SetParent(layout.transform, false);
-            SetNavigationNone(button);
 
             // Add SelectableConfig and pass ColorPicker button as target
 
@@ -850,7 +848,6 @@ namespace Jotunn.GUI
 
             // and now the toggle itself
             var toggle = GUIManager.Instance.CreateToggle(result.transform, 20f, 20f).SetUpperRight();
-            SetNavigationNone(toggle);
 
             // Add SelectableConfig and pass toggle as target
             result.AddComponent<SelectableConfig>().InteractionTarget = toggle;
@@ -899,7 +896,6 @@ namespace Jotunn.GUI
 
             // Setup keybind button for controller navigation
             var button = result.transform.Find("Button").gameObject;
-            SetNavigationNone(button);
             result.AddComponent<SelectableConfig>().InteractionTarget = button;
 
             // Create description text
@@ -943,7 +939,6 @@ namespace Jotunn.GUI
 
             // Setup keybind button for controller navigation
             var button = result.transform.Find("Button").gameObject;
-            SetNavigationNone(button);
             result.AddComponent<SelectableConfig>().InteractionTarget = button;
 
             // Create description text
@@ -1333,12 +1328,33 @@ namespace Jotunn.GUI
 
             public void Start()
             {
-                var buttonName = Entry.GetBoundButtonName();
                 Button.onClick.AddListener(() =>
                 {
-                    Settings.instance.OpenBindDialog(buttonName);
-                    On.ZInput.EndBindKey += ZInput_EndBindKey;
+                    StartCoroutine(nameof(CheckForKeysDown));
                 });
+            }
+
+            private IEnumerator CheckForKeysDown()
+            {
+                var anyKeyDown = false;
+                do
+                {
+                    anyKeyDown = false;
+                    foreach (KeyCode key in Enum.GetValues(typeof(KeyCode)))
+                    {
+                        if (Input.GetKeyDown(key))
+                        {
+                            anyKeyDown = true;
+                        }
+                    }
+                    if (anyKeyDown)
+                        yield return null;
+
+                } while (anyKeyDown);
+
+                var buttonName = Entry.GetBoundButtonName();
+                Settings.instance.OpenBindDialog(buttonName);
+                On.ZInput.EndBindKey += ZInput_EndBindKey;
             }
 
             private bool ZInput_EndBindKey(On.ZInput.orig_EndBindKey orig, ZInput self)
@@ -1397,12 +1413,33 @@ namespace Jotunn.GUI
 
             public void Start()
             {
-                var buttonName = Entry.GetBoundButtonName();
                 Button.onClick.AddListener(() =>
                 {
-                    Settings.instance.OpenBindDialog(buttonName);
-                    On.ZInput.EndBindKey += ZInput_EndBindKey;
+                    StartCoroutine(nameof(CheckForKeysDown));
                 });
+            }
+
+            private IEnumerator CheckForKeysDown()
+            {
+                var anyKeyDown = false;
+                do
+                {
+                    anyKeyDown = false;
+                    foreach (KeyCode key in Enum.GetValues(typeof(KeyCode)))
+                    {
+                        if (Input.GetKeyDown(key))
+                        {
+                            anyKeyDown = true;
+                        }
+                    }
+                    if (anyKeyDown)
+                        yield return null;
+
+                } while (anyKeyDown);
+
+                var buttonName = Entry.GetBoundButtonName();
+                Settings.instance.OpenBindDialog(buttonName);
+                On.ZInput.EndBindKey += ZInput_EndBindKey;
             }
 
             private bool ZInput_EndBindKey(On.ZInput.orig_EndBindKey orig, ZInput self)

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -1141,6 +1141,10 @@ namespace Jotunn.Managers
 
             bindString.transform.SetParent(button.transform, false);
 
+            
+            // Add SelectableConfig and pass button as target
+            input.AddComponent<SelectableConfig>().InteractionTarget = button;
+
             return input;
         }
 

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -1141,10 +1141,6 @@ namespace Jotunn.Managers
 
             bindString.transform.SetParent(button.transform, false);
 
-            
-            // Add SelectableConfig and pass button as target
-            input.AddComponent<SelectableConfig>().InteractionTarget = button;
-
             return input;
         }
 

--- a/JotunnLib/Unity/Assets/Scripts/SelectableConfig.cs
+++ b/JotunnLib/Unity/Assets/Scripts/SelectableConfig.cs
@@ -28,13 +28,13 @@ namespace Jotunn.GUI
                     _interactionTarget = value;
                     interactionTargetSubmitHandler = handler;
                     var selectable = value.GetComponent<Selectable>();
-                    this.transition = selectable.transition;
-                    this.spriteState = selectable.spriteState;
-                    this.navigation = selectable.navigation;
-                    this.interactable = selectable.interactable;
-                    this.image = selectable.image;
-                    this.colors = selectable.colors;
-                    this.animationTriggers = selectable.animationTriggers;
+                    transition = selectable.transition;
+                    spriteState = selectable.spriteState;
+                    navigation = selectable.navigation;
+                    interactable = selectable.interactable;
+                    image = selectable.image;
+                    colors = selectable.colors;
+                    animationTriggers = selectable.animationTriggers;
                     targetGraphic = selectable.targetGraphic;
                     selectable.OnDeselect(new BaseEventData(EventSystem.current));
 

--- a/JotunnLib/Unity/Assets/Scripts/SelectableConfig.cs
+++ b/JotunnLib/Unity/Assets/Scripts/SelectableConfig.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Jotunn.GUI
+{
+    /// <summary>
+    ///     Monobehaviour to handle make subentries in mod settings selectable, and pass controller button presses to appropriate
+    ///     GameObject.
+    /// </summary>
+    public class SelectableConfig : Selectable, ISubmitHandler
+    {
+        /// <summary>
+        ///     GameObject to receive OnSubmit call
+        /// </summary>
+        public GameObject InteractionTarget { 
+            get
+            {
+                return _interactionTarget;
+            } 
+            set
+            {
+                var handler = value.GetComponent<ISubmitHandler>();
+                if(handler != null)
+                {
+                    _interactionTarget = value;
+                    interactionTargetSubmitHandler = handler;
+                    var selectable = value.GetComponent<Selectable>();
+                    this.transition = selectable.transition;
+                    this.spriteState = selectable.spriteState;
+                    this.navigation = selectable.navigation;
+                    this.interactable = selectable.interactable;
+                    this.image = selectable.image;
+                    this.colors = selectable.colors;
+                    this.animationTriggers = selectable.animationTriggers;
+                    targetGraphic = selectable.targetGraphic;
+                    selectable.OnDeselect(new BaseEventData(EventSystem.current));
+
+
+                } else
+                {
+                    Debug.LogError("GameObject '" + gameObject.name + "' does not have a component that implements ISubmitHandler");
+                }
+            }
+        }
+
+        private GameObject _interactionTarget;
+        private ISubmitHandler interactionTargetSubmitHandler;
+
+        /// <summary>
+        ///     Handler for OnSubmit. Passes OnSubmit call and eventData to InteractionTarget
+        /// </summary>
+        /// <param name="eventData">OnSubmit Event Data</param>
+        public void OnSubmit(BaseEventData eventData)
+        {
+            if (InteractionTarget != null)
+            {
+                interactionTargetSubmitHandler.OnSubmit(eventData);
+            }
+        }
+
+        //public override void OnSelect(BaseEventData eventData)
+        //{
+        //    base.OnSelect(eventData);
+        //    InteractionTarget.GetComponent<Selectable>().OnSelect(eventData);
+        //}
+
+        //public override void OnDeselect(BaseEventData eventData)
+        //{
+        //    base.OnDeselect(eventData);
+        //    InteractionTarget.GetComponent<Selectable>().OnDeselect(eventData);
+        //}
+    }
+}

--- a/JotunnLib/Unity/Assets/Scripts/SelectableConfig.cs
+++ b/JotunnLib/Unity/Assets/Scripts/SelectableConfig.cs
@@ -23,7 +23,6 @@ namespace Jotunn.GUI
             set
             {
                 var handler = value.GetComponent<ISubmitHandler>();
-                if(handler != null)
                 {
                     _interactionTarget = value;
                     interactionTargetSubmitHandler = handler;
@@ -39,9 +38,6 @@ namespace Jotunn.GUI
                     selectable.OnDeselect(new BaseEventData(EventSystem.current));
 
 
-                } else
-                {
-                    Debug.LogError("GameObject '" + gameObject.name + "' does not have a component that implements ISubmitHandler");
                 }
             }
         }
@@ -57,7 +53,14 @@ namespace Jotunn.GUI
         {
             if (InteractionTarget != null)
             {
-                interactionTargetSubmitHandler.OnSubmit(eventData);
+                if (interactionTargetSubmitHandler == null)
+                {
+                    InteractionTarget.GetComponent<Selectable>()?.Select();
+                }
+                else
+                {
+                    interactionTargetSubmitHandler.OnSubmit(eventData);
+                }
             }
         }
 


### PR DESCRIPTION
Makes individual settings in Mod Settings navigable with a controller. Mostly addresses concerns I brought up in Issue Valheim-Modding/ModSettings#1 

Interacts with some settings better than others:

- Toggles work great.
- Inputs with sliders work reasonably well (depending on range, steps may be excessively large)
- Pure text inputs are intentionally skipped (avoids getting user trapped in text input)
- Color settings bring up the pop up, but can't be changed.
- Keybinds are a mixed result, slight changes were made to keep the keybind dialog from taking the button press that activates it as the keybind, but inputs are still passed to the settings (so confirm button is set as keybind, and immediately brings up a new keybind dialog, cancel button backs out of settings). Other buttons work fine.
- Gamepad button settings bring up the dropdown but the drop down's can't be navigated.

Also binds the navigation from Ok button and back Button to each other. I attempted to get navigation from them back to the settings, but failed.

While this is far from perfect, it addresses the primary goal of making the mod settings navigable by controller, is overall an improvement , and further improvement is beyond my current familiarity with the code base.
