### PR TITLE
RenderManager render Sprite immediately

### DIFF
--- a/JotunnLib/Documentation/tutorials/renderqueue.md
+++ b/JotunnLib/Documentation/tutorials/renderqueue.md
@@ -18,8 +18,7 @@ private void Awake()
 }
 ```
 
-In our method we enqueue the Beech1 prefab for rendering into the RenderManager.
-[RenderManager.EnqueueRender](xref:Jotunn.Managers.RenderManager.EnqueueRender(UnityEngine.GameObject,System.Action{UnityEngine.Sprite},System.Int32,System.Int32)) provides a delegate for notification after the render process completes.
+In our method we render an icon of the Beech1 with [RenderManager.Render](xref:Jotunn.Managers.RenderManager.Render(Jotunn.Managers.RenderManager.RenderRequest)).
 Here we clone the vanilla BeechSeeds to a new [CustomItem](xref:Jotunn.Entities.CustomItem) (see our [tutorial on items](items.md) for more information about cloning vanilla prefabs).
 
 ```cs
@@ -28,26 +27,24 @@ private void AddItemsWithRenderedIcons()
 {
     try
     {
-        // local function that will get called when the rendering is done
-        void CreateTreeItem(Sprite sprite)
-        {
-            CustomItem treeItem = new CustomItem("item_MyTree", "BeechSeeds",
-                new ItemConfig
-                {
-                    Name = "$rendered_tree",
-                    Description = "$rendered_tree_desc",
-                    Icons = new[] { sprite },
-                    Requirements = new[]
-                    {
-                        new RequirementConfig { Item = "Wood", Amount = 1, Recover = true }
-                    }
-                });
-            ItemManager.Instance.AddItem(treeItem);
-        }
-
         // use the vanilla beech tree prefab to render our icon from
         GameObject beech = PrefabManager.Instance.GetPrefab("Beech1");
-        RenderManager.Instance.EnqueueRender(beech, CreateTreeItem);
+
+        // create the custom item with the rendered icon
+        CustomItem treeItem = new CustomItem("item_MyTree", "BeechSeeds", new ItemConfig
+        {
+            Name = "$rendered_tree",
+            Description = "$rendered_tree_desc",
+            Icons = new[]
+            {
+                RenderManager.Instance.Render(beech)
+            },
+            Requirements = new[]
+            {
+                new RequirementConfig { Item = "Wood", Amount = 1, Recover = true }
+            }
+        });
+        ItemManager.Instance.AddItem(treeItem);
     }
     catch (Exception ex)
     {
@@ -66,6 +63,3 @@ Note that all texts are tokenized and translated ingame. The translations are al
 The resulting item with the rendered icon in game:
 
 ![item with rendered icon](../images/data/renderedIcon.png)
-
-> [!NOTE]
->Because a copy of the prefab has to be spawned for rendering and the prefab needs one frame to destroy all components that are not Renderer or MeshFilter, this is done in a coroutine. While spawning the copy, no Awake methods from scripts are called.

--- a/JotunnLib/Managers/RenderManager.cs
+++ b/JotunnLib/Managers/RenderManager.cs
@@ -40,8 +40,6 @@ namespace Jotunn.Managers
         /// </summary>
         private const int Layer = 3;
 
-        private readonly Queue<RenderRequest> RenderRequestQueue = new Queue<RenderRequest>();
-
         private static readonly Vector3 SpawnPoint = new Vector3(10000f, 10000f, 10000f);
         private Camera Renderer;
         private Light Light;
@@ -56,7 +54,7 @@ namespace Jotunn.Managers
                 return;
             }
 
-            Main.Instance.StartCoroutine(RenderQueue());
+            Main.Instance.StartCoroutine(ClearRenderRoutine());
         }
 
         /// <summary>
@@ -65,6 +63,7 @@ namespace Jotunn.Managers
         /// <param name="target">GameObject to render</param>
         /// <param name="callback">Callback for the generated <see cref="Sprite"/></param>
         /// <returns>If there is no active visual Mesh attached to the target, this method invokes the callback with null immediately and returns false.</returns>
+        [Obsolete("Use Render instead")]
         public bool EnqueueRender(GameObject target, Action<Sprite> callback)
         {
             return EnqueueRender(new RenderRequest(target), callback);
@@ -76,24 +75,64 @@ namespace Jotunn.Managers
         /// <param name="renderRequest"></param>
         /// <param name="callback">Callback for the generated <see cref="Sprite"/></param>
         /// <returns>If there is no active visual Mesh attached to the target, this method invokes the callback with null immediately and returns false.</returns>
+        [Obsolete("Use Render instead")]
         public bool EnqueueRender(RenderRequest renderRequest, Action<Sprite> callback)
         {
             if(!renderRequest.Target)
             {
                 throw new ArgumentException("Target is required");
             }
+
             if(callback == null)
             {
                 throw new ArgumentException("Callback is required");
             }
+
             if (!renderRequest.Target.GetComponentsInChildren<Component>(false).Any(IsVisualComponent))
             {
                 callback.Invoke(null);
                 return false;
             }
+
             renderRequest.Callback = callback;
-            RenderRequestQueue.Enqueue(renderRequest);
+            callback?.Invoke(Render(renderRequest));
             return true;
+        }
+
+        /// <summary>
+        ///     Create a <see cref="Sprite"/> of the <paramref name="target"/>
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns>If there is no active visual Mesh attached to the target, this method returns null.</returns>
+        public Sprite Render(GameObject target)
+        {
+            return Render(new RenderRequest(target));
+        }
+
+        /// <summary>
+        ///     Render the provided <see cref="RenderRequest"/>
+        /// </summary>
+        /// <param name="renderRequest"></param>
+        /// <returns>If there is no active visual Mesh attached to the target, this method returns null.</returns>
+        public Sprite Render(RenderRequest renderRequest)
+        {
+            if(!renderRequest.Target)
+            {
+                throw new ArgumentException("Target is required");
+            }
+
+            if (!renderRequest.Target.GetComponentsInChildren<Component>(false).Any(IsVisualComponent))
+            {
+                return null;
+            }
+
+            if (!Renderer)
+            {
+                SetupRendering();
+            }
+
+            RenderObject spawned = SpawnSafe(renderRequest);
+            return RenderSprite(spawned);
         }
 
         /// <summary>
@@ -105,7 +144,7 @@ namespace Jotunn.Managers
         /// <param name="width">Width of the resulting <see cref="Sprite"/></param>
         /// <param name="height">Height of the resulting <see cref="Sprite"/></param>
         /// <returns>Only true if the target was queued for rendering</returns>
-        [Obsolete("Use RenderRequest instead")]
+        [Obsolete("Use Render instead")]
 #pragma warning disable S3427 // Method overloads with default parameter values should not overlap 
         public bool EnqueueRender(GameObject target, Action<Sprite> callback, int width = 128, int height = 128)
 #pragma warning restore S3427 // Method overloads with default parameter values should not overlap 
@@ -117,7 +156,7 @@ namespace Jotunn.Managers
             }, callback);
         }
 
-        private void Render(RenderObject renderObject)
+        private Sprite RenderSprite(RenderObject renderObject)
         {
             int width = renderObject.Request.Width;
             int height = renderObject.Request.Height;
@@ -147,36 +186,19 @@ namespace Jotunn.Managers
             RenderTexture.ReleaseTemporary(Renderer.targetTexture);
             RenderTexture.active = oldRenderTexture;
 
-            Sprite sprite = Sprite.Create(previewImage, new Rect(0, 0, width, height), Vector2.one / 2f);
-            renderObject.Request.Callback?.Invoke(sprite);
+            return Sprite.Create(previewImage, new Rect(0, 0, width, height), Vector2.one / 2f);
         }
 
-        private IEnumerator RenderQueue()
+        private IEnumerator ClearRenderRoutine()
         {
             while (true)
             {
-                Queue<RenderObject> spawnQueue = new Queue<RenderObject>();
-
-                while (RenderRequestQueue.Count > 0)
+                if (Renderer)
                 {
-                    RenderRequest request = RenderRequestQueue.Dequeue();  
-                    spawnQueue.Enqueue(SpawnSafe(request));
-                }
-
-                // wait one frame to allow Unity destroy components properly
-                yield return null;
-
-                if (spawnQueue.Count > 0)
-                {
-                    SetupRendering();
-
-                    while (spawnQueue.Count > 0)
-                    {
-                        Render(spawnQueue.Dequeue());
-                    }
-
                     ClearRendering();
                 }
+
+                yield return null;
             }
         }
 
@@ -249,13 +271,13 @@ namespace Jotunn.Managers
             // needs to be destroyed first as Character depend on it
             foreach (CharacterDrop characterDrop in spawn.GetComponentsInChildren<CharacterDrop>())
             {
-                Object.Destroy(characterDrop);
+                Object.DestroyImmediate(characterDrop);
             }
 
             // needs to be destroyed first as Rigidbody depend on it
             foreach (Joint joint in spawn.GetComponentsInChildren<Joint>())
             {
-                Object.Destroy(joint);
+                Object.DestroyImmediate(joint);
             }
 
             // destroy all other components except visuals
@@ -266,7 +288,7 @@ namespace Jotunn.Managers
                     continue;
                 }
 
-                Object.Destroy(component);
+                Object.DestroyImmediate(component);
             }
 
             // just in case it doesn't gets deleted properly later
@@ -315,11 +337,11 @@ namespace Jotunn.Managers
             public readonly GameObject Target;
 
             /// <summary>
-            ///     Width of the generated <see cref="Sprite"/>
+            ///     Pixel width of the generated <see cref="Sprite"/>
             /// </summary>
             public int Width { get; set; } = 128;
             /// <summary>
-            ///     Height of the generated <see cref="Sprite"/>
+            ///     Pixel height of the generated <see cref="Sprite"/>
             /// </summary>
             public int Height { get; set; } = 128;
             /// <summary>
@@ -338,6 +360,7 @@ namespace Jotunn.Managers
             /// <summary>
             ///     Callback for the generated <see cref="Sprite"/>
             /// </summary>
+            [Obsolete]
             public Action<Sprite> Callback { get; internal set; }
 
             /// <summary>

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -1286,26 +1286,24 @@ namespace TestMod
         {
             try
             {
-                // local function that will get called when the rendering is done
-                void CreateTreeItem(Sprite sprite)
-                {
-                    CustomItem treeItem = new CustomItem("item_MyTree", "BeechSeeds",
-                        new ItemConfig
-                        {
-                            Name = "$rendered_tree",
-                            Description = "$rendered_tree_desc",
-                            Icons = new[] { sprite },
-                            Requirements = new[]
-                            {
-                                new RequirementConfig { Item = "Wood", Amount = 1, Recover = true }
-                            }
-                        });
-                    ItemManager.Instance.AddItem(treeItem);
-                }
-
                 // use the vanilla beech tree prefab to render our icon from
                 GameObject beech = PrefabManager.Instance.GetPrefab("Beech1");
-                RenderManager.Instance.EnqueueRender(beech, CreateTreeItem);
+
+                // create the custom item with the rendered icon
+                CustomItem treeItem = new CustomItem("item_MyTree", "BeechSeeds", new ItemConfig
+                {
+                    Name = "$rendered_tree",
+                    Description = "$rendered_tree_desc",
+                    Icons = new[]
+                    {
+                        RenderManager.Instance.Render(beech)
+                    },
+                    Requirements = new[]
+                    {
+                        new RequirementConfig { Item = "Wood", Amount = 1, Recover = true }
+                    }
+                });
+                ItemManager.Instance.AddItem(treeItem);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
RenderManager now is using `Object.DestroyImmediate` instead of `Object.Destroy` which is executed directly instead of taking one frame. This completely makes the callback irrelevant and the sprite can be used directly. Therefore the usage is a lot simpler as it can be seen in the TestMod.

For compatibility the new method is named `Render` and the old ones are marked as obsolete. The coroutine is still used to clear the renderer when not needed. As before, the same rendering Camera and Light is used when executing multiple renders in one frame