### PR TITLE
RenderManager copy components instead of destroying spawned components

### DIFF
--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Reflection;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace Jotunn
@@ -24,7 +25,7 @@ namespace Jotunn
         /// <typeparam name="T">Any type that inherits MonoBehaviour</typeparam>
         /// <param name="this">this</param>
         /// <returns>Returns null when MonoBehaviours.op_equality returns false.</returns>
-        public static T OrNull<T>(this T @this) where T : UnityEngine.Object
+        public static T OrNull<T>(this T @this) where T : Object
         {
             return (T)(@this ? @this : null);
         }
@@ -39,6 +40,34 @@ namespace Jotunn
         public static T GetOrAddComponent<T>(this GameObject gameObject) where T : Component
         {
             return gameObject.GetComponent<T>() ?? gameObject.AddComponent<T>();
+        }
+
+        /// <summary>
+        ///     Adds a new copy of the provided component to a gameObject
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="duplicate"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Component AddComponentCopy<T>(this GameObject gameObject, T duplicate) where T : Component
+        {
+            Component target = gameObject.AddComponent(duplicate.GetType());
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+            foreach (PropertyInfo propertyInfo in duplicate.GetType().GetProperties(flags))
+            {
+                if (propertyInfo.CanWrite)
+                {
+                    propertyInfo.SetValue(target, propertyInfo.GetValue(duplicate, null), null);
+                }
+            }
+
+            foreach (FieldInfo fieldInfo in duplicate.GetType().GetFields(flags))
+            {
+                fieldInfo.SetValue(target, fieldInfo.GetValue(duplicate));
+            }
+
+            return target;
         }
     }
 

--- a/JotunnLib/Managers/RenderManager.cs
+++ b/JotunnLib/Managers/RenderManager.cs
@@ -123,7 +123,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Create a <see cref="Sprite"/> of the <paramref name="target"/>
         /// </summary>
-        /// <param name="target"></param>
+        /// <param name="target">Can be a prefab or any existing GameObject in the world</param>
         /// <returns>If this is called on a headless server or when there is no active visual Mesh attached to the target, this method returns null.</returns>
         public Sprite Render(GameObject target)
         {
@@ -131,7 +131,18 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
-        ///     Render the provided <see cref="RenderRequest"/>
+        ///     Create a <see cref="Sprite"/> of the <paramref name="target"/>
+        /// </summary>
+        /// <param name="target">Can be a prefab or any existing GameObject in the world</param>
+        /// <param name="rotation">Rotation while rendering of the GameObject. See <code>RenderManager.IsometricRotation</code> for example/></param>
+        /// <returns>If this is called on a headless server or when there is no active visual Mesh attached to the target, this method returns null.</returns>
+        public Sprite Render(GameObject target, Quaternion rotation)
+        {
+            return Render(new RenderRequest(target) { Rotation = rotation });
+        }
+
+        /// <summary>
+        ///     Create a <see cref="Sprite"/> of the <paramref name="target"/>
         /// </summary>
         /// <param name="renderRequest"></param>
         /// <returns>If this is called on a headless server or when there is no active visual Mesh attached to the target, this method returns null.</returns>


### PR DESCRIPTION
The previous solution was to spawn the whole prefab and then remove not needed components. Because components can depend on one another, this has lead to conflicts with RRR for example. Now the Prefab is recursively traversed and only Transform and visuals are copied to the spawned prefab.

~Because `SkinnedMeshRenderer` don't work well as they are copied (they depend on bone references and animators) they are faked with a `MeshRender`. This works most the time well, but can be off when the original mesh was rotated somehow unexpected. Though I only noticed this on Bonemass, so this might be fine?~