### PR TITLE
fix: Fix custom items without recipes

### DIFF
--- a/JotunnLib/Configs/ItemConfig.cs
+++ b/JotunnLib/Configs/ItemConfig.cs
@@ -180,6 +180,12 @@ namespace Jotunn.Configs
                 return null;
             }
 
+            // If there are no requirements, don't create a recipe.
+            if (Requirements.Length == 0)
+            {
+                return null;
+            }
+
             var recipe = ScriptableObject.CreateInstance<Recipe>();
 
             recipe.name = "Recipe_" + Item;

--- a/JotunnLib/Entities/CustomItem.cs
+++ b/JotunnLib/Entities/CustomItem.cs
@@ -63,7 +63,11 @@ namespace Jotunn.Entities
             FixReference = fixReference;
             itemConfig.Apply(ItemPrefab);
             FixConfig = true;
-            Recipe = new CustomRecipe(itemConfig.GetRecipe(), true, true);
+            var recipe = itemConfig.GetRecipe();
+            if (recipe != null)
+            {
+                Recipe = new CustomRecipe(recipe, true, true);
+            }
         }
 
         /// <summary>
@@ -93,7 +97,11 @@ namespace Jotunn.Entities
             ItemDrop.m_itemData.m_shared = new ItemDrop.ItemData.SharedData();
             itemConfig.Apply(ItemPrefab);
             FixConfig = true;
-            Recipe = new CustomRecipe(itemConfig.GetRecipe(), true, true);
+            var recipe = itemConfig.GetRecipe();
+            if (recipe != null)
+            {
+                Recipe = new CustomRecipe(recipe, true, true);
+            }
         }
 
         /// <summary>
@@ -126,7 +134,11 @@ namespace Jotunn.Entities
                 ItemDrop = itemPrefab.GetComponent<ItemDrop>();
                 itemConfig.Apply(itemPrefab);
                 FixConfig = true;
-                Recipe = new CustomRecipe(itemConfig.GetRecipe(), true, true);
+                var recipe = itemConfig.GetRecipe();
+                if (recipe != null)
+                {
+                    Recipe = new CustomRecipe(recipe, true, true);
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ These people have been integral to pushing JVL out of the door, and without them
 *Tekla#1012*: [github](https://github.com/T3kla/ValMods/wiki)
 
 *Margmas#9562*: [github](https://github.com/MSchmoecker), [thunderstore](https://valheim.thunderstore.io/package/MSchmoecker/), [nexus](https://www.nexusmods.com/users/111418768)
+
+*JoeyParrish#8644*: [github](https://github.com/joeyparrish), [thunderstore](https://valheim.thunderstore.io/package/joeyparrish/), [nexus](https://www.nexusmods.com/users/128211453)


### PR DESCRIPTION
Having no requirements should imply no recipe, rather than a recipe
with no ingredients that you can make infinitely and for free.