### PR TITLE
fix: patch DocFX JavaScript when building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,17 @@ jobs:
         with:
           args: JotunnLib/docfx.json
 
+      # Fix permissions on DocFX output (should not be owned by root!)
+      # See https://github.com/nikeee/docfx-action/issues/13
+      - name: Fix DocFX output permissions
+        run: |
+          sudo chown -R "$UID" JotunnLib/_site
+
+      # Patch broken docfx JavaScript that fails to parse query params for tabs
+      - name: Patch DocFX JavaScript bugs
+        run: |
+          sed -e "s/queryString = ''/queryString = location.search/" -i.orig JotunnLib/_site/styles/docfx.js
+
       # Publish generated site using GitHub Pages
       - uses: maxheld83/ghpages@master
         name: Publish documentation to GitHub Pages


### PR DESCRIPTION
Opening a doc link to a specific tab, such as [1], was not working.
This makes it difficult to link to from the docs of a mod using
Jotunn.

It turns out that DocFX's JavaScript was failing to parse query
parameters entirely.  The function parseQueryString() takes a query
string parameter, but no caller ever passes one.  The function then
defaults the parameter to the empty string, rather than the browser's
current query string.

This patches the JavaScript during the GitHub Actions workflow for
docs so that the query string parameter is read from the browser's
location bar, thereby fixing the DocFX bug.

It is possible that this has already been solved upstream in DocFX,
but I have not verified that.  We are using the action from
nikeee/docfx-action, which does not have a newer tag than what we are
using currently.

[1]: https://valheim-modding.github.io/Jotunn/guides/guide.html?tabs=tabid-3