### PR TITLE
Added render cache

### DIFF
--- a/JotunnLib/Utils/Paths.cs
+++ b/JotunnLib/Utils/Paths.cs
@@ -28,5 +28,10 @@ namespace Jotunn.Utils
         ///     Path to the global translation folder
         /// </summary>
         public static string LanguageTranslationsFolder => BepInEx.Paths.PluginPath;
+
+        /// <summary>
+        ///     Path to cached icons. See <see cref="Managers.RenderManager"/>
+        /// </summary>
+        public static string IconCachePath => Path.Combine(JotunnFolder, "CachedIcons");
     }
 }


### PR DESCRIPTION
A render can take 1-100ms (worst case), normally ~5-20ms if it is no complex one. This PR adds an optional `UseCache` and `TargetPlugin` option for the renderer, where sprites are written as .png to `%AppData%/LocalLow/IronGate/Valheim/Jotunn/CachedIcons`. The loading time with a cache used is 0-2ms.
The sprites are named `<prefabname>-<gameversion>.png` so they will re-render when the game version changes. When a `TargetPlugin` is set, the name is `<prefabname>-<modname>-<modversion>.png`