### PR TITLE
fix: don't error when saving unset keyboard shortcut

### DIFF
--- a/JotunnLib/GUI/InGameConfig.cs
+++ b/JotunnLib/GUI/InGameConfig.cs
@@ -1030,6 +1030,10 @@ namespace Jotunn.GUI
 
             public override KeyboardShortcut GetValue()
             {
+                if (Text.text == KeyboardShortcut.Empty.ToString())
+                {
+                    return KeyboardShortcut.Empty;
+                }
                 return KeyboardShortcut.Deserialize(Text.text);
             }
 


### PR DESCRIPTION
Prevents the following error message from appearing when a `KeyboardShortcut` is `KeyboardShortcut.empty` (unset) and OK is pressed:

> [Error  :   BepInEx] Failed to read keybind from settings: Requested value 'Not' was not found.
