### PR TITLE
Fixed disconnecting on first connection attempt with QuickConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ﻿# Changelog
+## Version 2.6.3
+* Fixed connection error on first connection attempt with QuickConnect
 
 ## Version 2.6.2
 * Fixed custom category display using Auga (and probably other UI mods)

--- a/JotunnLib/Utils/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility.cs
@@ -30,14 +30,14 @@ namespace Jotunn.Utils
         }
 
         // Send client module list to server
-        [HarmonyPatch(typeof(ZNet), nameof(ZNet.RPC_ClientHandshake)), HarmonyPrefix, HarmonyPriority(Priority.Last)]
+        [HarmonyPatch(typeof(ZNet), nameof(ZNet.RPC_ClientHandshake)), HarmonyPrefix, HarmonyPriority(Priority.First)]
         private static void ZNet_RPC_ClientHandshake(ZNet __instance, ZRpc rpc)
         {
             rpc.Invoke(nameof(RPC_Jotunn_ReceiveVersionData), new ModuleVersionData(GetEnforcableMods().ToList()).ToZPackage());
         }
 
         // Send server module list to client
-        [HarmonyPatch(typeof(ZNet), nameof(ZNet.RPC_ServerHandshake)), HarmonyPrefix, HarmonyPriority(Priority.Last)]
+        [HarmonyPatch(typeof(ZNet), nameof(ZNet.RPC_ServerHandshake)), HarmonyPrefix, HarmonyPriority(Priority.First)]
         private static void ZNet_RPC_ServerHandshake(ZNet __instance, ZRpc rpc)
         {
             rpc.Invoke(nameof(RPC_Jotunn_ReceiveVersionData), new ModuleVersionData(GetEnforcableMods().ToList()).ToZPackage());


### PR DESCRIPTION
The sending of client mods was too late, as QuickConnect already has called SendPeerInfo. This caused the server to assume that a vanilla client has connected.
The fix is to always send the mod list early, that seems like the best behaviour anyway.

The only bug left is that the compatibility window currently needs a server with password to become visible. Without a password just the vanilla "incompatible version" is shown. This also causes to not show the compatibility window when connecting via QuickConnect. But that should be handled in a separate PR.