### PR TITLE
Fixed password field was required for Compatibility Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ﻿# Changelog
 ## Version 2.6.3
 * Fixed connection error on first connection attempt with QuickConnect
+* Fixed the compatibility window was not showing up, if the server has no password
+* Fixed a client could sometimes connect to a server, even if mods are incompatible
 
 ## Version 2.6.2
 * Fixed custom category display using Auga (and probably other UI mods)

--- a/JotunnLib/Utils/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility.cs
@@ -97,6 +97,18 @@ namespace Jotunn.Utils
                         return false;
                     }
                 }
+                else
+                {
+                    var serverData = new ModuleVersionData(GetEnforcableMods().ToList());
+                    var clientData = new ModuleVersionData(ClientVersions[rpc.m_socket.GetEndPointString()]);
+
+                    if (!CompareVersionData(serverData, clientData))
+                    {
+                        // Disconnect if mods are not network compatible
+                        rpc.Invoke("Error", (int)ZNet.ConnectionStatus.ErrorVersion);
+                        return false;
+                    }
+                }
             }
 
             return true;


### PR DESCRIPTION
LastServerVersion was cleared too early because with no password field `SendPeerInfo` is called immediately. 

Also fixed that a client could sometimes connect to a server without password, even if some mods are required. 