### PR TITLE
fix: piece categories were hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ﻿# Changelog
 ## Version 2.6.4
 * Fixed a CustomLocation was not prepared correctly if a deactivated prefab was passed, causing it to spawn inside itself when proximity loaded again
+* Fixed vanilla piece categories could be hidden when a mod used the long piece table name
 
 ## Version 2.6.3
 * Fixed connection error on first connection attempt with QuickConnect

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -536,6 +536,12 @@ namespace Jotunn.Managers
         /// </summary>
         private void TogglePieceCategories()
         {
+            // Only touch categories when new ones were added
+            if (!PieceCategories.Any())
+            {
+                return;
+            }
+
             // Get currently selected tool and toggle PieceTableCategories
             try
             {


### PR DESCRIPTION
Fixes that a CustomPiece with `PieceTable = "_HammerPieceTable"` caused to hide all other vanilla categories.

The reason it worked with 2.6.0 was because the hook for `TogglePieceCategories()` was already behind an `if (!PieceCategories.Any()) return` check, so it hasn't executed when no new category was added. The hook was inside the `CreatePieceTableCategories()` function. 
Another alternitive would be to remove the check altogether with `CreatePieceTableCategories()` but I think it's better to not always to touch the categories.