### PR TITLE
feat: dynamic category tab width

### DIFF
--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -45,7 +45,7 @@ namespace Jotunn.Managers
         private Piece.PieceCategory PieceCategoryMax = Piece.PieceCategory.Max;
 
         private const float PieceCategorySize = 700f;
-        private const float PieceCategoryTabSize = 150f;
+        private const float PieceCategoryTabSize = 140f;
         private const float PieceCategoryTabOffset = 50f;
 
         /// <summary>
@@ -780,12 +780,13 @@ namespace Jotunn.Managers
                 float offset = 0f;
                 foreach (GameObject go in Hud.instance.m_pieceCategoryTabs.Where(x => x.activeSelf))
                 {
+                    float width = CalculateTabWidth(go);
                     go.SetMiddleLeft();
                     go.SetHeight(30f);
-                    go.SetWidth(PieceCategoryTabSize);
+                    go.SetWidth(width);
                     RectTransform tf = (go.transform as RectTransform);
                     tf.anchoredPosition = new Vector2(offset, 0f);
-                    offset += PieceCategoryTabSize;
+                    offset += width;
                 }
             }
 
@@ -865,7 +866,7 @@ namespace Jotunn.Managers
                         go.GetComponent<RectTransform>().anchoredPosition += new Vector2(offsetX, 0);
                     }
                 }
-                float maxX = tab.GetComponent<RectTransform>().anchoredPosition.x + PieceCategoryTabSize + PieceCategoryTabOffset;
+                float maxX = tab.GetComponent<RectTransform>().anchoredPosition.x + CalculateTabWidth(tab) + PieceCategoryTabOffset;
                 if (maxX > PieceCategorySize)
                 {
                     float offsetX = selectedCategory == Values.Max() ? maxX - PieceCategorySize - PieceCategoryTabOffset: maxX - PieceCategorySize;
@@ -874,6 +875,11 @@ namespace Jotunn.Managers
                         go.GetComponent<RectTransform>().anchoredPosition -= new Vector2(offsetX, 0);
                     }
                 }
+            }
+
+            private static float CalculateTabWidth(GameObject tab)
+            {
+                return Mathf.Max(PieceCategoryTabSize, 11f * (tab.name.Length + 6f));
             }
         }
     }


### PR DESCRIPTION
Changed category tab width is depending on the name. As the font is not monospace it is only an approximation but it works well for small and large strings.


<details>
  <summary>A few example images</summary>

  ![grafik](https://user-images.githubusercontent.com/39767545/166134640-2e0967ca-8d28-4a39-9c3f-20350226588e.png)
  ![grafik](https://user-images.githubusercontent.com/39767545/166134652-3ba65773-361e-4a6e-8149-b340d2937f9a.png)
  ![grafik](https://user-images.githubusercontent.com/39767545/166134657-c6e9dae6-f47a-4797-af11-d6f11bb1ae5e.png)

</details>