### PR TITLE
fix: override piece requirements only when needed

### DIFF
--- a/JotunnLib/Configs/PieceConfig.cs
+++ b/JotunnLib/Configs/PieceConfig.cs
@@ -105,9 +105,6 @@ namespace Jotunn.Configs
             var requirements = GetRequirements();
             if (requirements.Length > 0)
             {
-                if (piece.m_resources.Length > 0)
-                    Logger.LogWarning($"Piece {piece.name} requirements ({piece.m_resources.Length} items) were overriden by PieceConfig ({requirements.Length} items)");
-
                 piece.m_resources = requirements;
             }
 

--- a/JotunnLib/Configs/PieceConfig.cs
+++ b/JotunnLib/Configs/PieceConfig.cs
@@ -102,7 +102,14 @@ namespace Jotunn.Configs
             }
 
             // Assign all needed resources for this piece
-            piece.m_resources = GetRequirements();
+            var requirements = GetRequirements();
+            if (requirements.Length > 0)
+            {
+                if (piece.m_resources.Length > 0)
+                    Logger.LogWarning($"Piece {piece.name} requirements ({piece.m_resources.Length} items) were overriden by PieceConfig ({requirements.Length} items)");
+
+                piece.m_resources = requirements;
+            }
 
             // Assign the CraftingStation for this piece
             if (!string.IsNullOrEmpty(CraftingStation))


### PR DESCRIPTION
`PieceConfig` adds several different possibilities and not only setting requirements, like setting custom `Category` or `PieceTable`. But using it forces you to define piece requirements in code, even if they're already defined in your Prefab (e.g. in Unity Editor).

So it seems intuitive that, you won't redefine existing requirements unless they're explicitly added to `PieceConfig`.

Rare case of redefining of such requirements with empty Array is still achievable by one line:
```C#
piece.m_resources = [];
```
Which shouldn't cause any problems. We might even mention it in docs. I can add separate PR for that if needed.