### PR TITLE
chore: cleaner localization adding

### DIFF
--- a/JotunnLib/Entities/CustomLocalization.cs
+++ b/JotunnLib/Entities/CustomLocalization.cs
@@ -28,8 +28,10 @@ namespace Jotunn.Entities
         /// <summary> Retrieve translations for given language. </summary>
         /// <param name="language"> Language of the translation you want to retrieve. </param>
         public IReadOnlyDictionary<string, string> GetTranslations(in string language)
-            => Map.TryGetValue(language, out var x) ? x : null;
-        
+        {
+            return Map.TryGetValue(language, out var languageMap) ? languageMap : new Dictionary<string, string>();
+        }
+
         /// <summary>
         ///     Retrieve a translation from this custom localization or <see cref="Localization.Translate"/>.
         ///     Searches with the user language with a fallback to English.
@@ -49,7 +51,7 @@ namespace Jotunn.Entities
             }
 
             var cleanedWord = word.TrimStart(LocalizationManager.TokenFirstChar);
-            var playerLang = PlayerPrefs.GetString("language", LocalizationManager.DefaultLanguage);
+            var playerLang = LocalizationManager.GetPlayerLanguage();
 
             if (Map.TryGetValue(playerLang, out var playerDictionary) && 
                 playerDictionary.TryGetValue(cleanedWord, out var playerTranslation))


### PR DESCRIPTION
This cleans up the localization injection code and makes it act more passive and straight forward. #193/#196 are still respected with the SetupGui patch but will not fix other mods like it did before.

In addition, the changes make the system compatible with the beta vanilla language change at runtime. Although it only works for vanilla languages, since the reload doesn't load English like it does on game start. Maybe this can be fixed in a follow up PR together with Skill localizations.

Some more details:
- Vanilla LoadLanguages/SetupLanguage are not called by Jotunn again as SetupLanguage is a heavy method. Instead those are always hooked and modded words/languages are appended
- All modded English translations are added as a fallback before any non-English translations are added. This was already implicitly the case but is now guaranteed and easier to see
- AutomaticLocalizationLoading() now happens at LocalizationManager.Init()
- Removed debug logs, those are not really needed and would be printed way to often now. Especially since some other mods are calling SetupLanguage themselves