### PR TITLE
Add some fonts and colours

### DIFF
--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -78,9 +78,19 @@ namespace Jotunn.Managers
         public const int UILayer = 5;
 
         /// <summary>
+        ///     The default Valheim beige color.
+        /// </summary>
+        public Color ValheimBeige = new Color(0.8529f, 0.725f, 0.5331f, 1f);
+
+        /// <summary>
         ///     The default Valheim orange color.
         /// </summary>
         public Color ValheimOrange = new Color(1f, 0.631f, 0.235f, 1f);
+
+        /// <summary>
+        ///     The default Valheim yellow color.
+        /// </summary>
+        public Color ValheimYellow = new Color(1f, 0.889f, 0f, 1f);
 
         /// <summary>
         ///     Scrollbar handle color block in default Valheim orange.
@@ -125,14 +135,25 @@ namespace Jotunn.Managers
         };
 
         /// <summary>
-        ///     Valheim standard font normal faced.
+        ///     Valheim's standard font, normal faced.
         /// </summary>
         public Font AveriaSerif { get; private set; }
 
         /// <summary>
-        ///     Valheims standard font bold faced.
+        ///     Valheim's standard font, bold faced.
         /// </summary>
         public Font AveriaSerifBold { get; private set; }
+
+
+        /// <summary>
+        ///     Valheim's rune-like font, normal faced.
+        /// </summary>
+        public Font Norse { get; private set; }
+
+        /// <summary>
+        ///     Valheim's rune-like font, bold faced.
+        /// </summary>
+        public Font NorseBold { get; private set; }
 
         /// <summary>
         ///     <see cref="DefaultControls.Resources"/> with default Valheim assets.
@@ -341,6 +362,8 @@ namespace Jotunn.Managers
                     {
                         throw new Exception("Fonts not found");
                     }
+                    Norse = fonts.FirstOrDefault(x => x.name == "Norse");
+                    NorseBold = fonts.FirstOrDefault(x => x.name == "Norsebold");
 
                     // DefaultControls.Resources pack
                     AssetBundle jotunnBundle = AssetUtils.LoadAssetBundleFromResources("jotunn", typeof(Main).Assembly);

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -358,12 +358,12 @@ namespace Jotunn.Managers
                     Font[] fonts = Resources.FindObjectsOfTypeAll<Font>();
                     AveriaSerif = fonts.FirstOrDefault(x => x.name == "AveriaSerifLibre-Regular");
                     AveriaSerifBold = fonts.FirstOrDefault(x => x.name == "AveriaSerifLibre-Bold");
-                    if (AveriaSerifBold == null || AveriaSerif == null)
+                    Norse = fonts.FirstOrDefault(x => x.name == "Norse");
+                    NorseBold = fonts.FirstOrDefault(x => x.name == "Norsebold");
+                    if (AveriaSerifBold == null || AveriaSerif == null || Norse == null || NorseBold == null)
                     {
                         throw new Exception("Fonts not found");
                     }
-                    Norse = fonts.FirstOrDefault(x => x.name == "Norse");
-                    NorseBold = fonts.FirstOrDefault(x => x.name == "Norsebold");
 
                     // DefaultControls.Resources pack
                     AssetBundle jotunnBundle = AssetUtils.LoadAssetBundleFromResources("jotunn", typeof(Main).Assembly);


### PR DESCRIPTION
I wasn't sure how you'd like the font check to work going forward. Currently it checks for all existing (two) fonts: 

    if (AveriaSerifBold == null || AveriaSerif == null)
    {

It seems to me that this is enough to determine whether or not font loading has worked, and since it throws an exception I don't think it's necessary to add checks for other fonts. 

Hence I have loaded "my" fonts after the exception - at this point the first two fonts loaded fine, so we should be in the clear (right?)

        throw new Exception("Fonts not found");
    }    
    Norse = fonts.FirstOrDefault(x => x.name == "Norse");

I could move them up to before the check, so it's all in one place, but there's not really a point in loading them all and then afterwards giving up because the first two have failed. Nitpicking at this point :)

As for the colours I added, the yellow is used in various menus and headings, and the beige is found on the start screen on for example the Select World window: 

![image](https://user-images.githubusercontent.com/123466188/224359588-f2eb7e2a-c2fb-4a95-b4ca-d03fa1bbe6c7.png)
