### PR TITLE
feat: hide IManager.Init() methods by prodviding explicit implementations

### DIFF
--- a/JotunnLib/Managers/CommandManager.cs
+++ b/JotunnLib/Managers/CommandManager.cs
@@ -40,7 +40,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize console commands that come with Jotunn.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             AddConsoleCommand(new ClearCommand());
 

--- a/JotunnLib/Managers/CreatureManager.cs
+++ b/JotunnLib/Managers/CreatureManager.cs
@@ -62,7 +62,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Creates the spawner container and registers all hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             SpawnListContainer = new GameObject("Creatures");
             SpawnListContainer.transform.parent = Main.RootObject.transform;

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -292,7 +292,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize the manager
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             // Cache headless state
             Headless = SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -211,7 +211,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize the manager
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             // Dont init on a dedicated server
             if (!GUIManager.IsHeadless())

--- a/JotunnLib/Managers/ItemManager.cs
+++ b/JotunnLib/Managers/ItemManager.cs
@@ -66,7 +66,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Registers all hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             Main.Harmony.PatchAll(typeof(Patches));
         }

--- a/JotunnLib/Managers/KeyHintManager.cs
+++ b/JotunnLib/Managers/KeyHintManager.cs
@@ -61,7 +61,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize the manager
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             // Dont init on a headless server
             if (!GUIManager.IsHeadless())

--- a/JotunnLib/Managers/KitbashManager.cs
+++ b/JotunnLib/Managers/KitbashManager.cs
@@ -32,7 +32,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Registers all hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             ItemManager.OnKitbashItemsAvailable += ApplyKitbashes;
         }

--- a/JotunnLib/Managers/LocalizationManager.cs
+++ b/JotunnLib/Managers/LocalizationManager.cs
@@ -84,7 +84,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize localization manager.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             Main.Harmony.PatchAll(typeof(Patches));
 

--- a/JotunnLib/Managers/MinimapManager.cs
+++ b/JotunnLib/Managers/MinimapManager.cs
@@ -96,7 +96,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Creates the Overlays and registers hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             // Dont init on a headless server
             if (GUIManager.IsHeadless())

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -50,7 +50,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Creates the container and registers all hooks
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             MockPrefabContainer = new GameObject("MockPrefabs");
             MockPrefabContainer.transform.parent = Main.RootObject.transform;

--- a/JotunnLib/Managers/NetworkManager.cs
+++ b/JotunnLib/Managers/NetworkManager.cs
@@ -43,7 +43,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Manager's main init
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             Main.Harmony.PatchAll(typeof(Patches));
         }

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -80,7 +80,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Creates the piece table container and registers all hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             Main.Harmony.PatchAll(typeof(Patches));
         }

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -54,7 +54,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Creates the prefab container and registers all hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             PrefabContainer = new GameObject("Prefabs");
             PrefabContainer.transform.parent = Main.RootObject.transform;

--- a/JotunnLib/Managers/RenderManager.cs
+++ b/JotunnLib/Managers/RenderManager.cs
@@ -45,7 +45,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize the manager
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             if (GUIManager.IsHeadless())
             {

--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -29,7 +29,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize the manager
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             Main.Harmony.PatchAll(typeof(Patches));
         }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -60,7 +60,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Manager's main init
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             // Register RPCs and the admin watchdog
             ConfigRPC = NetworkManager.Instance.AddRPC(

--- a/JotunnLib/Managers/UndoManager.cs
+++ b/JotunnLib/Managers/UndoManager.cs
@@ -65,7 +65,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Registers all hooks.
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             Main.Harmony.PatchAll(typeof(Patches));
         }

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -56,7 +56,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Initialize the manager
         /// </summary>
-        public void Init()
+        void IManager.Init()
         {
             LocationContainer = new GameObject("Locations");
             LocationContainer.transform.parent = Main.RootObject.transform;


### PR DESCRIPTION
This keeps the `IManager` intact but makes all `Init()` method not callable for other mods.

No mod should call this method anyway and it can cause unexpected behaviour if they do so. Thus introducing a breaking change in a minor update should be justified.