### PR TITLE
feat: prefab name helpers

### DIFF
--- a/JotunnLib/Configs/CookingConversionConfig.cs
+++ b/JotunnLib/Configs/CookingConversionConfig.cs
@@ -9,14 +9,20 @@ namespace Jotunn.Configs
     public class CookingConversionConfig : ConversionConfig
     {
         /// <summary>
-        ///     The name of the station prefab this conversion is added to. Defaults to "piece_cookingstation".
+        ///     The name of the station prefab this conversion is added to. Defaults to <see cref="CookingStations.CookingStation"/>.
         /// </summary>
-        public override string Station { get; set; } = "piece_cookingstation";
+        public override string Station
+        {
+            get => station;
+            set => station = CookingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     Amount of time it takes to perform the conversion. Defaults to 10f.
         /// </summary>
         public float CookTime { get; set; } = 10f;
+
+        private string station = CookingStations.CookingStation;
 
         /// <summary>
         ///     Turns the CookingConversionConfig into a Valheim CookingStation.ItemConversion item.

--- a/JotunnLib/Configs/CookingStations.cs
+++ b/JotunnLib/Configs/CookingStations.cs
@@ -1,0 +1,23 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///     Helper to get existing cooking station names
+    /// </summary>
+    public static class CookingStations
+    {
+        /// <summary>
+        ///     Cooking station
+        /// </summary>
+        public static string CookingStation => "piece_cookingstation";
+
+        /// <summary>
+        ///     Iron cooking station
+        /// </summary>
+        public static string IronCookingStation => "piece_cookingstation_iron";
+
+        /// <summary>
+        ///     Stone oven cooking station
+        /// </summary>
+        public static string StoneOven => "piece_oven";
+    }
+}

--- a/JotunnLib/Configs/CookingStations.cs
+++ b/JotunnLib/Configs/CookingStations.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -19,5 +23,54 @@ namespace Jotunn.Configs
         ///     Stone oven cooking station
         /// </summary>
         public static string StoneOven => "piece_oven";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all cooking station names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid cooking stations can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var stationConfig = Config.Bind("Section", "Key", nameof(CookingStations.CookingStation), new ConfigDescription("Description", CookingStations.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a cooking station from its human readable name.
+        ///     If the given name is not a known cooking station, the value is returned unchanged.
+        /// </summary>
+        /// <param name="cookingStation"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string cookingStation)
+        {
+            if (NamesMap.TryGetValue(cookingStation, out string internalName))
+            {
+                return internalName;
+            }
+
+            return cookingStation;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(CookingStation), CookingStation },
+            { nameof(IronCookingStation), IronCookingStation },
+            { nameof(StoneOven), StoneOven },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/CookingStations.cs
+++ b/JotunnLib/Configs/CookingStations.cs
@@ -35,12 +35,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all cooking station names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid cooking stations can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var stationConfig = Config.Bind("Section", "Key", nameof(CookingStations.CookingStation), new ConfigDescription("Description", CookingStations.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid cooking stations can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///         var stationConfig = Config.Bind("Section", "Key", nameof(CookingStations.CookingStation), new ConfigDescription("Description", CookingStations.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()

--- a/JotunnLib/Configs/CookingStations.cs
+++ b/JotunnLib/Configs/CookingStations.cs
@@ -70,6 +70,6 @@ namespace Jotunn.Configs
             { nameof(StoneOven), StoneOven },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/CraftingStations.cs
+++ b/JotunnLib/Configs/CraftingStations.cs
@@ -60,12 +60,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all crafting station names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid crafting stations can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var stationConfig = Config.Bind("Section", "Key", nameof(CraftingStations.Workbench), new ConfigDescription("Description", CraftingStations.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid crafting stations can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///         var stationConfig = Config.Bind("Section", "Key", nameof(CraftingStations.Workbench), new ConfigDescription("Description", CraftingStations.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()

--- a/JotunnLib/Configs/CraftingStations.cs
+++ b/JotunnLib/Configs/CraftingStations.cs
@@ -100,6 +100,6 @@ namespace Jotunn.Configs
             { nameof(GaldrTable), GaldrTable },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/CraftingStations.cs
+++ b/JotunnLib/Configs/CraftingStations.cs
@@ -1,0 +1,48 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///     Helper to get existing crafting station names
+    /// </summary>
+    public static class CraftingStations
+    {
+        /// <summary>
+        ///     No crafting station
+        /// </summary>
+        public static string None => string.Empty;
+
+        /// <summary>
+        ///    Workbench crafting station
+        /// </summary>
+        public static string Workbench => "piece_workbench";
+
+        /// <summary>
+        ///    Forge crafting station
+        /// </summary>
+        public static string Forge => "forge";
+
+        /// <summary>
+        ///     Stonecutter crafting station
+        /// </summary>
+        public static string Stonecutter => "piece_stonecutter";
+
+        /// <summary>
+        ///     Cauldron crafting station
+        /// </summary>
+        public static string Cauldron => "piece_cauldron";
+
+        /// <summary>
+        ///     Artisan table crafting station
+        /// </summary>
+        public static string ArtisanTable => "piece_artisanstation";
+
+        /// <summary>
+        ///     Black forge crafting station
+        /// </summary>
+        public static string BlackForge => "blackforge";
+
+        /// <summary>
+        ///     Galdr table crafting station
+        /// </summary>
+        public static string GaldrTable => "piece_magetable";
+    }
+}

--- a/JotunnLib/Configs/CraftingStations.cs
+++ b/JotunnLib/Configs/CraftingStations.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -44,5 +48,59 @@ namespace Jotunn.Configs
         ///     Galdr table crafting station
         /// </summary>
         public static string GaldrTable => "piece_magetable";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all crafting station names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid crafting stations can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var stationConfig = Config.Bind("Section", "Key", nameof(CraftingStations.Workbench), new ConfigDescription("Description", CraftingStations.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a crafting station from its human readable name.
+        ///     If the given name is not a known crafting station, the value is returned unchanged.
+        /// </summary>
+        /// <param name="craftingStation"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string craftingStation)
+        {
+            if (NamesMap.TryGetValue(craftingStation, out string internalName))
+            {
+                return internalName;
+            }
+
+            return craftingStation;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(None), None },
+            { nameof(Workbench), Workbench },
+            { nameof(Forge), Forge },
+            { nameof(Stonecutter), Stonecutter },
+            { nameof(Cauldron), Cauldron },
+            { nameof(ArtisanTable), ArtisanTable },
+            { nameof(BlackForge), BlackForge },
+            { nameof(GaldrTable), GaldrTable },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/FermenterConversionConfig.cs
+++ b/JotunnLib/Configs/FermenterConversionConfig.cs
@@ -9,14 +9,20 @@ namespace Jotunn.Configs
     public class FermenterConversionConfig : ConversionConfig
     {
         /// <summary>
-        ///     The name of the station prefab this conversion is added to. Defaults to "fermenter".
+        ///     The name of the station prefab this conversion is added to. Defaults to <see cref="Fermenters.Fermenter"/>.
         /// </summary>
-        public override string Station { get; set; } = "fermenter";
+        public override string Station
+        {
+            get => station;
+            set => station = Fermenters.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The amount of items one conversion yields. Defaults to 4.
         /// </summary>
         public int ProducedItems { get; set; } = 4;
+
+        private string station = Fermenters.Fermenter;
 
         /// <summary>
         ///     Turns the FermenterConversionConfig into a Valheim Fermenter.ItemConversion item.

--- a/JotunnLib/Configs/Fermenters.cs
+++ b/JotunnLib/Configs/Fermenters.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -9,5 +13,52 @@ namespace Jotunn.Configs
         ///     Fermenter
         /// </summary>
         public static string Fermenter => "fermenter";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all fermenter names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid fermenter can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var fermenterConfig = Config.Bind("Section", "Key", nameof(Fermenters.Fermenter), new ConfigDescription("Description", Fermenters.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a fermenter from its human readable name.
+        ///     If the given name is not a known fermenter, the value is returned unchanged.
+        /// </summary>
+        /// <param name="fermenter"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string fermenter)
+        {
+            if (NamesMap.TryGetValue(fermenter, out string internalName))
+            {
+                return internalName;
+            }
+
+            return fermenter;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(Fermenter), Fermenter },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/Fermenters.cs
+++ b/JotunnLib/Configs/Fermenters.cs
@@ -58,6 +58,6 @@ namespace Jotunn.Configs
             { nameof(Fermenter), Fermenter },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/Fermenters.cs
+++ b/JotunnLib/Configs/Fermenters.cs
@@ -1,0 +1,13 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///     Helper to get existing fermenter names
+    /// </summary>
+    public class Fermenters
+    {
+        /// <summary>
+        ///     Fermenter
+        /// </summary>
+        public static string Fermenter => "fermenter";
+    }
+}

--- a/JotunnLib/Configs/Fermenters.cs
+++ b/JotunnLib/Configs/Fermenters.cs
@@ -25,12 +25,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all fermenter names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid fermenter can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var fermenterConfig = Config.Bind("Section", "Key", nameof(Fermenters.Fermenter), new ConfigDescription("Description", Fermenters.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid fermenter can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///         var fermenterConfig = Config.Bind("Section", "Key", nameof(Fermenters.Fermenter), new ConfigDescription("Description", Fermenters.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()

--- a/JotunnLib/Configs/IncineratorConversionConfig.cs
+++ b/JotunnLib/Configs/IncineratorConversionConfig.cs
@@ -10,9 +10,13 @@ namespace Jotunn.Configs
     public class IncineratorConversionConfig : ConversionConfig
     {
         /// <summary>
-        ///     The name of the station prefab this conversion is added to. Defaults to "incinerator".
+        ///     The name of the station prefab this conversion is added to. Defaults to <see cref="Incinerators.Incinerator"/>.
         /// </summary>
-        public override string Station { get; set; } = "incinerator";
+        public override string Station
+        {
+            get => station;
+            set => station = Incinerators.GetInternalName(value);
+        }
 
         /// <summary>
         ///     List of requirements for this conversion.
@@ -36,6 +40,8 @@ namespace Jotunn.Configs
         ///     Defaults to false.
         /// </summary>
         public bool RequireOnlyOneIngredient { get; set; }
+
+        private string station = Incinerators.Incinerator;
 
         /// <summary>
         ///     Turns the IncineratorConversionConfig into a Valheim Incinerator.IncineratorConversion item.

--- a/JotunnLib/Configs/Incinerators.cs
+++ b/JotunnLib/Configs/Incinerators.cs
@@ -58,6 +58,6 @@ namespace Jotunn.Configs
             { nameof(Incinerator), Incinerator },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/Incinerators.cs
+++ b/JotunnLib/Configs/Incinerators.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -9,5 +13,52 @@ namespace Jotunn.Configs
         ///     Incinerator
         /// </summary>
         public static string Incinerator => "incinerator";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all incinerator names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid incinerator can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var incineratorConfig = Config.Bind("Section", "Key", nameof(Incinerators.Incinerator), new ConfigDescription("Description", Incinerators.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a incinerator from its human readable name.
+        ///     If the given name is not a known incinerator, the value is returned unchanged.
+        /// </summary>
+        /// <param name="incinerator"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string incinerator)
+        {
+            if (NamesMap.TryGetValue(incinerator, out string internalName))
+            {
+                return internalName;
+            }
+
+            return incinerator;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(Incinerator), Incinerator },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/Incinerators.cs
+++ b/JotunnLib/Configs/Incinerators.cs
@@ -1,0 +1,13 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///     Helper to get existing incinerator names
+    /// </summary>
+    public class Incinerators
+    {
+        /// <summary>
+        ///     Incinerator
+        /// </summary>
+        public static string Incinerator => "incinerator";
+    }
+}

--- a/JotunnLib/Configs/Incinerators.cs
+++ b/JotunnLib/Configs/Incinerators.cs
@@ -25,12 +25,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all incinerator names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid incinerator can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var incineratorConfig = Config.Bind("Section", "Key", nameof(Incinerators.Incinerator), new ConfigDescription("Description", Incinerators.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid incinerator can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///         var incineratorConfig = Config.Bind("Section", "Key", nameof(Incinerators.Incinerator), new ConfigDescription("Description", Incinerators.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()

--- a/JotunnLib/Configs/ItemConfig.cs
+++ b/JotunnLib/Configs/ItemConfig.cs
@@ -48,13 +48,21 @@ namespace Jotunn.Configs
         ///     The name of the crafting station prefab where this recipe can be crafted.<br/>
         ///     Can be set to <c>null</c> to have the recipe be craftable without a crafting station.
         /// </summary>
-        public string CraftingStation { get; set; } = string.Empty;
+        public string CraftingStation
+        {
+            get => craftingStation;
+            set => craftingStation = CraftingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The name of the crafting station prefab where this item can be repaired.<br/>
         ///     Can be set to <c>null</c> to have the item be repairable without a crafting station.
         /// </summary>
-        public string RepairStation { get; set; } = string.Empty;
+        public string RepairStation
+        {
+            get => repairStation;
+            set => repairStation = CraftingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The minimum required level for the crafting station. Defaults to <c>1</c>.
@@ -75,6 +83,9 @@ namespace Jotunn.Configs
         ///     Array of <see cref="RequirementConfig"/>s for all crafting materials it takes to craft the recipe.
         /// </summary>
         public RequirementConfig[] Requirements { get; set; } = Array.Empty<RequirementConfig>();
+
+        private string craftingStation = string.Empty;
+        private string repairStation = string.Empty;
 
         /// <summary>
         ///     Apply this config's values to a GameObject's ItemDrop.

--- a/JotunnLib/Configs/PieceCategories.cs
+++ b/JotunnLib/Configs/PieceCategories.cs
@@ -45,12 +45,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all piece category names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid piece category can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var pieceCategoryConfig = Config.Bind("Section", "Key", nameof(PieceCategories.Building), new ConfigDescription("Description", PieceCategories.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid piece category can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///         var pieceCategoryConfig = Config.Bind("Section", "Key", nameof(PieceCategories.Building), new ConfigDescription("Description", PieceCategories.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()

--- a/JotunnLib/Configs/PieceCategories.cs
+++ b/JotunnLib/Configs/PieceCategories.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -29,5 +33,56 @@ namespace Jotunn.Configs
         ///     All piece categories
         /// </summary>
         public static string All => "All";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all piece category names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid piece category can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var pieceCategoryConfig = Config.Bind("Section", "Key", nameof(PieceCategories.Building), new ConfigDescription("Description", PieceCategories.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a piece category from its human readable name.
+        ///     If the given name is not a known piece category, the value is returned unchanged.
+        /// </summary>
+        /// <param name="pieceCategory"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string pieceCategory)
+        {
+            if (NamesMap.TryGetValue(pieceCategory, out string internalName))
+            {
+                return internalName;
+            }
+
+            return pieceCategory;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(Misc), Misc },
+            { nameof(Crafting), Crafting },
+            { nameof(Building), Building },
+            { nameof(Furniture), Furniture },
+            { nameof(All), All },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/PieceCategories.cs
+++ b/JotunnLib/Configs/PieceCategories.cs
@@ -1,0 +1,33 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///     Helper to get existing piece category names
+    /// </summary>
+    public static class PieceCategories
+    {
+        /// <summary>
+        ///     Piece 'Misc' category
+        /// </summary>
+        public static string Misc => "Misc";
+
+        /// <summary>
+        ///     Piece 'Crafting' category
+        /// </summary>
+        public static string Crafting => "Crafting";
+
+        /// <summary>
+        ///     Piece 'Building' category
+        /// </summary>
+        public static string Building => "Building";
+
+        /// <summary>
+        ///     Piece 'Furniture' category
+        /// </summary>
+        public static string Furniture => "Furniture";
+
+        /// <summary>
+        ///     All piece categories
+        /// </summary>
+        public static string All => "All";
+    }
+}

--- a/JotunnLib/Configs/PieceCategories.cs
+++ b/JotunnLib/Configs/PieceCategories.cs
@@ -82,6 +82,6 @@ namespace Jotunn.Configs
             { nameof(All), All },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/PieceConfig.cs
+++ b/JotunnLib/Configs/PieceConfig.cs
@@ -37,7 +37,11 @@ namespace Jotunn.Configs
         /// <summary>
         ///     The name of the piece table where this piece will be added.
         /// </summary>
-        public string PieceTable { get; set; } = string.Empty;
+        public string PieceTable
+        {
+            get => pieceTable;
+            set => pieceTable = PieceTables.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The name of the category this piece will appear on. If categories are disabled on the 
@@ -45,17 +49,29 @@ namespace Jotunn.Configs
         ///     If categories are enabled but the given category can't be found, a new 
         ///     <see cref="Piece.PieceCategory"/> will be added to the table.
         /// </summary>
-        public string Category { get; set; } = string.Empty;
+        public string Category
+        {
+            get => category;
+            set => category = PieceCategories.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The name of the crafting station prefab which needs to be in close proximity to build this piece.
         /// </summary>
-        public string CraftingStation { get; set; } = string.Empty;
+        public string CraftingStation
+        {
+            get => craftingStation;
+            set => craftingStation = CraftingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The name of the crafting station prefab to which this piece will be an upgrade to.
         /// </summary>
-        public string ExtendStation { get; set; } = string.Empty;
+        public string ExtendStation
+        {
+            get => extendStation;
+            set => extendStation = CraftingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     Icon which is displayed in the crafting GUI.
@@ -66,6 +82,11 @@ namespace Jotunn.Configs
         ///     Array of <see cref="RequirementConfig"/>s for all crafting materials it takes to craft the recipe.
         /// </summary>
         public RequirementConfig[] Requirements { get; set; } = Array.Empty<RequirementConfig>();
+
+        private string pieceTable = string.Empty;
+        private string category = string.Empty;
+        private string craftingStation = string.Empty;
+        private string extendStation = string.Empty;
 
         /// <summary>
         ///     Apply this configs values to a piece GameObject.

--- a/JotunnLib/Configs/PieceTables.cs
+++ b/JotunnLib/Configs/PieceTables.cs
@@ -70,6 +70,6 @@ namespace Jotunn.Configs
             { nameof(Hoe), Hoe },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/PieceTables.cs
+++ b/JotunnLib/Configs/PieceTables.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -19,5 +23,54 @@ namespace Jotunn.Configs
         ///     Hoe piece table
         /// </summary>
         public static string Hoe => "_HoePieceTable";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all piece table names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid piece table can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var pieceTableConfig = Config.Bind("Section", "Key", nameof(PieceTables.Hammer), new ConfigDescription("Description", PieceTables.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a piece table from its human readable name.
+        ///     If the given name is not a known piece table, the value is returned unchanged.
+        /// </summary>
+        /// <param name="pieceTable"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string pieceTable)
+        {
+            if (NamesMap.TryGetValue(pieceTable, out string internalName))
+            {
+                return internalName;
+            }
+
+            return pieceTable;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(Hammer), Hammer },
+            { nameof(Cultivator), Cultivator },
+            { nameof(Hoe), Hoe },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/PieceTables.cs
+++ b/JotunnLib/Configs/PieceTables.cs
@@ -1,0 +1,23 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///    Helper to get existing piece table names
+    /// </summary>
+    public static class PieceTables
+    {
+        /// <summary>
+        ///     Hammer piece table
+        /// </summary>
+        public static string Hammer => "_HammerPieceTable";
+
+        /// <summary>
+        ///     Cultivator piece table
+        /// </summary>
+        public static string Cultivator => "_CultivatorPieceTable";
+
+        /// <summary>
+        ///     Hoe piece table
+        /// </summary>
+        public static string Hoe => "_HoePieceTable";
+    }
+}

--- a/JotunnLib/Configs/PieceTables.cs
+++ b/JotunnLib/Configs/PieceTables.cs
@@ -35,12 +35,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all piece table names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid piece table can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var pieceTableConfig = Config.Bind("Section", "Key", nameof(PieceTables.Hammer), new ConfigDescription("Description", PieceTables.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid piece table can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///          var pieceTableConfig = Config.Bind("Section", "Key", nameof(PieceTables.Hammer), new ConfigDescription("Description", PieceTables.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()

--- a/JotunnLib/Configs/RecipeConfig.cs
+++ b/JotunnLib/Configs/RecipeConfig.cs
@@ -36,14 +36,22 @@ namespace Jotunn.Configs
         ///     <br/>
         ///     Can be set to <c>null</c> to have the recipe be craftable without a crafting station.
         /// </summary>
-        public string CraftingStation { get; set; } = string.Empty;
+        public string CraftingStation
+        {
+            get => craftingStation;
+            set => craftingStation = CraftingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The name of the crafting station prefab where this item can be repaired.
         ///     <br/>
         ///     Can be set to <c>null</c> to have the recipe be repairable without a crafting station.
         /// </summary>
-        public string RepairStation { get; set; } = string.Empty;
+        public string RepairStation
+        {
+            get => repairStation;
+            set => repairStation = CraftingStations.GetInternalName(value);
+        }
 
         /// <summary>
         ///     The minimum required level for the crafting station. Defaults to <c>1</c>.
@@ -54,6 +62,9 @@ namespace Jotunn.Configs
         ///     Array of <see cref="RequirementConfig"/>s for all crafting materials it takes to craft the recipe.
         /// </summary>
         public RequirementConfig[] Requirements { get; set; } = Array.Empty<RequirementConfig>();
+
+        private string craftingStation = string.Empty;
+        private string repairStation = string.Empty;
 
         /// <summary>
         ///     Converts the RequirementConfigs to Valheim style Piece.Requirements

--- a/JotunnLib/Configs/SmelterConversionConfig.cs
+++ b/JotunnLib/Configs/SmelterConversionConfig.cs
@@ -9,9 +9,15 @@ namespace Jotunn.Configs
     public class SmelterConversionConfig : ConversionConfig
     {
         /// <summary>
-        ///     The name of the station prefab this conversion is added to. Defaults to "smelter".
+        ///     The name of the station prefab this conversion is added to. Defaults to <see cref="Smelters.Smelter"/>.
         /// </summary>
-        public override string Station { get; set; } = "smelter";
+        public override string Station
+        {
+            get => station;
+            set => station = Smelters.GetInternalName(value);
+        }
+
+        private string station = Smelters.Smelter;
 
         /// <summary>
         ///     Turns the SmelterConversionConfig into a Valheim Smelter.ItemConversion item.

--- a/JotunnLib/Configs/Smelters.cs
+++ b/JotunnLib/Configs/Smelters.cs
@@ -94,6 +94,6 @@ namespace Jotunn.Configs
             { nameof(Windmill), Windmill },
         };
 
-        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());
     }
 }

--- a/JotunnLib/Configs/Smelters.cs
+++ b/JotunnLib/Configs/Smelters.cs
@@ -1,0 +1,43 @@
+namespace Jotunn.Configs
+{
+    /// <summary>
+    ///     Helper to get existing smelter names
+    /// </summary>
+    public static class Smelters
+    {
+        /// <summary>
+        ///     Smelter
+        /// </summary>
+        public static string Smelter => "smelter";
+
+        /// <summary>
+        ///     Blast furnace
+        /// </summary>
+        public static string BlastFurnace => "blastfurnace";
+
+        /// <summary>
+        ///     Charcoal kiln
+        /// </summary>
+        public static string CharcoalKiln => "charcoal_kiln";
+
+        /// <summary>
+        ///     Eitr refinery
+        /// </summary>
+        public static string EitrRefinery => "eitrrefinery";
+
+        /// <summary>
+        ///     Bathtub
+        /// </summary>
+        public static string Bathtub => "piece_bathtub";
+
+        /// <summary>
+        ///     Spinning wheel
+        /// </summary>
+        public static string SpinningWheel => "piece_spinningwheel";
+
+        /// <summary>
+        ///     Windmill
+        /// </summary>
+        public static string Windmill => "windmill";
+    }
+}

--- a/JotunnLib/Configs/Smelters.cs
+++ b/JotunnLib/Configs/Smelters.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Configuration;
+
 namespace Jotunn.Configs
 {
     /// <summary>
@@ -39,5 +43,58 @@ namespace Jotunn.Configs
         ///     Windmill
         /// </summary>
         public static string Windmill => "windmill";
+
+        /// <summary>
+        ///     Gets the human readable name to internal names map
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetNames()
+        {
+            return NamesMap;
+        }
+
+        /// <summary>
+        ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all smelter names.
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid smelter can be selected.
+        ///     <example>
+        ///         <code>
+        ///             var smelterConfig = Config.Bind("Section", "Key", nameof(Smelters.Smelter), new ConfigDescription("Description", Smelters.GetAcceptableValueList()));
+        ///         </code>
+        ///     </example>
+        /// </summary>
+        /// <returns></returns>
+        public static AcceptableValueList<string> GetAcceptableValueList()
+        {
+            return AcceptableValues;
+        }
+
+        /// <summary>
+        ///     Get the internal name for a smelter from its human readable name.
+        ///     If the given name is not a known smelter, the value is returned unchanged.
+        /// </summary>
+        /// <param name="smelter"></param>
+        /// <returns></returns>
+        public static string GetInternalName(string smelter)
+        {
+            if (NamesMap.TryGetValue(smelter, out string internalName))
+            {
+                return internalName;
+            }
+
+            return smelter;
+        }
+
+        private static readonly Dictionary<string, string> NamesMap = new Dictionary<string, string>
+        {
+            { nameof(Smelter), Smelter },
+            { nameof(BlastFurnace), BlastFurnace },
+            { nameof(CharcoalKiln), CharcoalKiln },
+            { nameof(EitrRefinery), EitrRefinery },
+            { nameof(Bathtub), Bathtub },
+            { nameof(SpinningWheel), SpinningWheel },
+            { nameof(Windmill), Windmill },
+        };
+
+        private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Values.ToArray());
     }
 }

--- a/JotunnLib/Configs/Smelters.cs
+++ b/JotunnLib/Configs/Smelters.cs
@@ -55,12 +55,11 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Get a <see cref="BepInEx.Configuration.AcceptableValueList{T}"/> of all smelter names.
-        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid smelter can be selected.
-        ///     <example>
-        ///         <code>
-        ///             var smelterConfig = Config.Bind("Section", "Key", nameof(Smelters.Smelter), new ConfigDescription("Description", Smelters.GetAcceptableValueList()));
-        ///         </code>
-        ///     </example>
+        ///     This can be used to create a <see cref="BepInEx.Configuration.ConfigEntry{T}"/> where only valid smelter can be selected.<br/><br/>
+        ///     Example:
+        ///     <code>
+        ///         var smelterConfig = Config.Bind("Section", "Key", nameof(Smelters.Smelter), new ConfigDescription("Description", Smelters.GetAcceptableValueList()));
+        ///     </code>
         /// </summary>
         /// <returns></returns>
         public static AcceptableValueList<string> GetAcceptableValueList()


### PR DESCRIPTION
Adds name shortcuts from human-readable names to internal ids.

## Helper Classes
- CookingStations: 
- CraftingStations
- Fermenters
- Incinerators
- PieceCategories
- PieceTables
- Smelters

## Jotunn Config Changes
For example:
```cs
PieceConfig piece = new PieceConfig();
piece.Name = "$display_name";
piece.PieceTable = "Hammer";
piece.Category = "Misc";
piece.CraftingStation = "piece_workbench";
```

can also be written as:
```cs
PieceConfig piece = new PieceConfig();
piece.Name = "$display_name";
piece.PieceTable = PieceTables.Hammer;
piece.Category = PieceCategories.Misc;
piece.CraftingStation = CraftingStations.Workbench;
```

The names on Configs are resolved on set, thus:
```cs
piece.CraftingStation = CraftingStations.Workbench;
piece.CraftingStation = nameof(CraftingStations.Workbench);
piece.CraftingStation = "Workbench";
piece.CraftingStation = "piece_workbench";
```
all set piece.CraftingStation to "piece_workbench" internally.
If a custom name is used, it will still be set and not changed.

## BepInEx Config
Additionally, the helper provide `GetAcceptableValueList()` to create configs that are validated by existing names. This will create a human readable list of `None, Workbench, Forge, Stonecutter, Cauldron, ArtisanTable, BlackForge, GaldrTable`.
```cs
var stationConfig = Config.Bind("Section", "Key", nameof(CraftingStations.Workbench), new ConfigDescription("Description", CraftingStations.GetAcceptableValueList()));
```

## Documentation
The documentation is not yet adapted, this will happen in a later PR.