### PR TITLE
Allow mock resolution to continue when exception thrown

### DIFF
--- a/JotunnLib/Managers/MockSystem/FieldMember.cs
+++ b/JotunnLib/Managers/MockSystem/FieldMember.cs
@@ -21,7 +21,14 @@ namespace Jotunn {
 
         public override object GetValue(object obj)
         {
-            return fieldInfo.GetValue(obj);
+            try
+            {
+                return fieldInfo.GetValue(obj);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public override void SetValue(object obj, object value)

--- a/JotunnLib/Managers/MockSystem/PropertyMember.cs
+++ b/JotunnLib/Managers/MockSystem/PropertyMember.cs
@@ -27,7 +27,7 @@ namespace Jotunn {
             }
             catch
             {
-                return null; 
+                return null;
             }
         }
 

--- a/JotunnLib/Managers/MockSystem/PropertyMember.cs
+++ b/JotunnLib/Managers/MockSystem/PropertyMember.cs
@@ -21,7 +21,14 @@ namespace Jotunn {
 
         public override object GetValue(object obj)
         {
-            return propertyInfo.GetValue(obj);
+            try
+            {
+                return propertyInfo.GetValue(obj);
+            }
+            catch
+            {
+                return null; 
+            }
         }
 
         public override void SetValue(object obj, object value)


### PR DESCRIPTION
Adding try-catch block to GetValue to prevent exception from failing entire mock resolution chain. Null checking already implemented in codebase for usage of this getter.