### PR TITLE
fix: modify GetOrAddComponent to use TryGetComponent.

### DIFF
--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+﻿﻿using System.Reflection;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -39,7 +39,7 @@ namespace Jotunn
         /// <returns>Component</returns>
         public static T GetOrAddComponent<T>(this GameObject gameObject) where T : Component
         {
-            return gameObject.GetComponent<T>() ?? gameObject.AddComponent<T>();
+            return gameObject.TryGetComponent(out T component) ? component : gameObject.AddComponent<T>();
         }
 
         /// <summary>


### PR DESCRIPTION
Null-coalescing operators do not work properly on Unity objects.

See: https://stackoverflow.com/q/76294124

Also it removed the BOM for some reason.