### PR TITLE
feat: only init managers when they are first accessed

### DIFF
--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -38,59 +38,20 @@ namespace Jotunn
         internal static Harmony Harmony;
         internal static GameObject RootObject;
 
-        private List<IManager> Managers;
-
         private void Awake()
         {
-            // Set instance
             Instance = this;
-
-            // Harmony patches
             Harmony = new Harmony(ModGuid);
-            Harmony.PatchAll(typeof(ModCompatibility));
-
-            // Initialize Logger
-            Jotunn.Logger.Init();
 
             // Root Container for GameObjects in the DontDestroyOnLoad scene
             RootObject = new GameObject("_JotunnRoot");
             DontDestroyOnLoad(RootObject);
 
-            // Create and initialize all managers
-            Managers = new List<IManager>
-            {
-                LocalizationManager.Instance,
-                CommandManager.Instance,
-                InputManager.Instance,
-                SkillManager.Instance,
-                PrefabManager.Instance,
-                ItemManager.Instance,
-                PieceManager.Instance,
-                CreatureManager.Instance,
-                ZoneManager.Instance,
-                MockManager.Instance,
-                KitbashManager.Instance,
-                GUIManager.Instance,
-                KeyHintManager.Instance,
-                NetworkManager.Instance,
-                SynchronizationManager.Instance,
-                RenderManager.Instance,
-                MinimapManager.Instance,
-                UndoManager.Instance
-            };
-            foreach (IManager manager in Managers)
-            {
-                Logger.LogInfo("Initializing " + manager.GetType().Name);
-                manager.Init();
-            }
-
-            ModQuery.Init();
+            Jotunn.Logger.Init();
             ModCompatibility.Init();
 
             // Flip the "modded" switch of Valheim
             Game.isModded = true;
-
-            Logger.LogInfo("Jötunn v" + Version + " loaded successfully");
         }
 
         private void Start()

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -68,7 +68,7 @@ namespace Jotunn
             InitializePatches();
 #pragma warning restore CS0612 // Method is obsolete
 
-            LocalizationManager.Instance.LoadingAutomaticLocalizations();
+            AutomaticLocalizationsLoading.Init();
         }
 
         private void OnApplicationQuit()

--- a/JotunnLib/Managers/CommandManager.cs
+++ b/JotunnLib/Managers/CommandManager.cs
@@ -22,7 +22,12 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private CommandManager() {}
+        private CommandManager() { }
+
+        static CommandManager()
+        {
+            ((IManager)Instance).Init();
+        }
 
         /// <summary>
         ///     Internal Action delegate to add custom entities into vanilla command's option list
@@ -42,6 +47,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing CommandManager");
             AddConsoleCommand(new ClearCommand());
 
             Main.Harmony.PatchAll(typeof(Patches));

--- a/JotunnLib/Managers/CreatureManager.cs
+++ b/JotunnLib/Managers/CreatureManager.cs
@@ -25,6 +25,11 @@ namespace Jotunn.Managers
         /// </summary>
         private CreatureManager() { }
 
+        static CreatureManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Unity "character" layer ID. 
         /// </summary>
@@ -64,6 +69,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing CreatureManager");
+
             SpawnListContainer = new GameObject("Creatures");
             SpawnListContainer.transform.parent = Main.RootObject.transform;
             SpawnListContainer.SetActive(false);

--- a/JotunnLib/Managers/GUIManager.cs
+++ b/JotunnLib/Managers/GUIManager.cs
@@ -36,6 +36,11 @@ namespace Jotunn.Managers
         /// </summary>
         private GUIManager() { }
 
+        static GUIManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Event that gets fired every time the Unity scene changed and a new PixelFix
         ///     object was created. Subscribe to this event to create your custom GUI objects
@@ -286,6 +291,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing GUIManager");
+
             // Cache headless state
             Headless = SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
 

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -206,13 +206,20 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private InputManager() {}
+        private InputManager() { }
+
+        static InputManager()
+        {
+            ((IManager)Instance).Init();
+        }
 
         /// <summary>
         ///     Initialize the manager
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing InputManager");
+
             // Dont init on a dedicated server
             if (!GUIManager.IsHeadless())
             {

--- a/JotunnLib/Managers/ItemManager.cs
+++ b/JotunnLib/Managers/ItemManager.cs
@@ -29,6 +29,11 @@ namespace Jotunn.Managers
         /// </summary>
         private ItemManager() { }
 
+        static ItemManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Event that gets fired after the vanilla items are in memory and available for cloning.
         ///     Your code will execute every time a new ObjectDB is copied (on every menu start).
@@ -68,6 +73,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing ItemManager");
             Main.Harmony.PatchAll(typeof(Patches));
         }
 

--- a/JotunnLib/Managers/KeyHintManager.cs
+++ b/JotunnLib/Managers/KeyHintManager.cs
@@ -25,6 +25,11 @@ namespace Jotunn.Managers
         /// </summary>
         private KeyHintManager() { }
 
+        static KeyHintManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Internal Dictionary holding the references to the custom key hints added to the manager
         /// </summary>
@@ -63,6 +68,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing KeyHintManager");
+
             // Dont init on a headless server
             if (!GUIManager.IsHeadless())
             {

--- a/JotunnLib/Managers/KitbashManager.cs
+++ b/JotunnLib/Managers/KitbashManager.cs
@@ -22,7 +22,12 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private KitbashManager() {}
+        private KitbashManager() { }
+
+        static KitbashManager()
+        {
+            ((IManager)Instance).Init();
+        }
 
         /// <summary>
         ///     Internal list of objects to which Kitbashing should be applied.
@@ -34,6 +39,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing KitbashManager");
             ItemManager.OnKitbashItemsAvailable += ApplyKitbashes;
         }
 

--- a/JotunnLib/Managers/LocalizationManager.cs
+++ b/JotunnLib/Managers/LocalizationManager.cs
@@ -35,12 +35,12 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Name of the folder that will hold the custom .json translations files.
         /// </summary>
-        public const string TranslationsFolderName = "Translations";
+        public const string TranslationsFolderName = AutomaticLocalizationsLoading.TranslationsFolderName;
 
         /// <summary>
         ///     Name of the community translation files that will be the first custom languages files loaded before any others.
         /// </summary>
-        public const string CommunityTranslationFileName = "community_translation.json";
+        public const string CommunityTranslationFileName = AutomaticLocalizationsLoading.CommunityTranslationFileName;
 
         /// <summary>
         ///     String of chars not allowed in a token string.
@@ -174,71 +174,6 @@ namespace Jotunn.Managers
         internal static string GetPlayerLanguage()
         {
             return PlayerPrefs.GetString("language", DefaultLanguage);
-        }
-
-        private IEnumerable<FileInfo> GetTranslationFiles(string path, string searchPattern)
-        {
-            return GetTranslationFiles(new DirectoryInfo(path), searchPattern);
-        }
-
-        private IEnumerable<FileInfo> GetTranslationFiles(DirectoryInfo pathDirectoryInfo, string searchPattern)
-        {
-            if (!pathDirectoryInfo.Exists) yield break;
-
-            foreach (var path in Directory
-                .GetFiles(pathDirectoryInfo.FullName, searchPattern, SearchOption.AllDirectories).Where(path =>
-                    new DirectoryInfo(path).Parent?.Parent?.Name == TranslationsFolderName))
-            {
-                yield return new FileInfo(path);
-            }
-        }
-
-        internal void LoadingAutomaticLocalizations()
-        {
-            var jsonFormat = new HashSet<FileInfo>();
-            var unityFormat = new HashSet<FileInfo>();
-
-            // Json format community files
-            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, CommunityTranslationFileName))
-            {
-                jsonFormat.Add(fileInfo);
-            }
-
-            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.json"))
-            {
-                jsonFormat.Add(fileInfo);
-            }
-
-            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.language"))
-            {
-                unityFormat.Add(fileInfo);
-            }
-
-            foreach (var fileInfo in jsonFormat)
-            {
-                try
-                {
-                    var mod = BepInExUtils.GetPluginInfoFromPath(fileInfo)?.Metadata;
-                    GetLocalization(mod ?? Main.Instance.Info.Metadata).AddFileByPath(fileInfo.FullName, true);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogWarning($"Exception caught while loading localization file {fileInfo}: {ex}");
-                }
-            }
-
-            foreach (var fileInfo in unityFormat)
-            {
-                try
-                {
-                    var mod = BepInExUtils.GetPluginInfoFromPath(fileInfo)?.Metadata;
-                    GetLocalization(mod ?? Main.Instance.Info.Metadata).AddFileByPath(fileInfo.FullName);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogWarning($"Exception caught while loading localization file {fileInfo}: {ex}");
-                }
-            }
         }
 
         /// <summary>

--- a/JotunnLib/Managers/LocalizationManager.cs
+++ b/JotunnLib/Managers/LocalizationManager.cs
@@ -61,7 +61,12 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private LocalizationManager() {}
+        private LocalizationManager() { }
+
+        static LocalizationManager()
+        {
+            ((IManager)Instance).Init();
+        }
 
         /// <summary>
         ///     Localizations for internal use.
@@ -86,6 +91,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing LocalizationManager");
+
             Main.Harmony.PatchAll(typeof(Patches));
 
             DoQuoteLineSplit = (Func<StringReader, List<List<string>>>)

--- a/JotunnLib/Managers/MinimapManager.cs
+++ b/JotunnLib/Managers/MinimapManager.cs
@@ -29,6 +29,11 @@ namespace Jotunn.Managers
         /// </summary>
         private MinimapManager() { }
 
+        static MinimapManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Event that gets fired once the Map for a World has started and Mods can begin to draw.
         /// </summary>
@@ -98,6 +103,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing MinimapManager");
+
             // Dont init on a headless server
             if (GUIManager.IsHeadless())
             {

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -24,7 +24,10 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private MockManager() {}
+        private MockManager()
+        {
+            ((IManager)this).Init();
+        }
 
         /// <summary>
         ///     Legacy ValheimLib prefix used by the Mock System to recognize Mock gameObject that must be replaced at some point.
@@ -52,6 +55,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing MockManager");
+
             MockPrefabContainer = new GameObject("MockPrefabs");
             MockPrefabContainer.transform.parent = Main.RootObject.transform;
             MockPrefabContainer.SetActive(false);

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using HarmonyLib;
 using Jotunn.Managers.MockSystem;
 using Jotunn.Utils;
 using UnityEngine;
@@ -61,8 +62,14 @@ namespace Jotunn.Managers
             MockPrefabContainer.transform.parent = Main.RootObject.transform;
             MockPrefabContainer.SetActive(false);
 
+            Main.Harmony.PatchAll(typeof(Patches));
+        }
+
+        private static class Patches
+        {
             // use a later event to fix materials as more textures have loaded by then
-            ZoneManager.OnVanillaLocationsAvailable += FixQueuedMaterials;
+            [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.Start)), HarmonyPostfix]
+            private static void ZoneSystem_Start(ZoneSystem __instance) => FixQueuedMaterials();
         }
 
         /// <summary>

--- a/JotunnLib/Managers/NetworkManager.cs
+++ b/JotunnLib/Managers/NetworkManager.cs
@@ -24,7 +24,12 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private NetworkManager() {}
+        private NetworkManager() { }
+
+        static NetworkManager()
+        {
+            ((IManager)Instance).Init();
+        }
 
         /// <summary>
         ///     Delegate for receiving <see cref="ZPackage">ZPackages</see>.
@@ -45,6 +50,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing NetworkManager");
             Main.Harmony.PatchAll(typeof(Patches));
         }
 

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -32,6 +32,11 @@ namespace Jotunn.Managers
         /// </summary>
         private PieceManager() { }
 
+        static PieceManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Event that gets fired after all pieces were added to their respective PieceTables.
         ///     Your code will execute every time a new ObjectDB is created (on every game start).
@@ -86,6 +91,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing PieceManager");
             Main.Harmony.PatchAll(typeof(Patches));
         }
 

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -27,6 +27,11 @@ namespace Jotunn.Managers
         /// </summary>
         private PrefabManager() { }
 
+        static PrefabManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Event that gets fired after the vanilla prefabs are in memory and available for cloning.
         ///     Your code will execute every time before a new <see cref="ObjectDB"/> is copied (on every menu start).
@@ -56,6 +61,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing PrefabManager");
+
             PrefabContainer = new GameObject("Prefabs");
             PrefabContainer.transform.parent = Main.RootObject.transform;
             PrefabContainer.SetActive(false);

--- a/JotunnLib/Managers/RenderManager.cs
+++ b/JotunnLib/Managers/RenderManager.cs
@@ -31,7 +31,12 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Hide .ctor
         /// </summary>
-        private RenderManager() {}
+        private RenderManager() { }
+
+        static RenderManager()
+        {
+            ((IManager)Instance).Init();
+        }
 
         /// <summary>
         ///     Unused Layer in Unity
@@ -47,6 +52,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing RenderManager");
+
             if (GUIManager.IsHeadless())
             {
                 return;

--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -24,6 +24,11 @@ namespace Jotunn.Managers
         /// </summary>
         private SkillManager() { }
 
+        static SkillManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         private bool addedSkillsToTerminal = false;
 
         /// <summary>
@@ -31,6 +36,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing SkillManager");
             Main.Harmony.PatchAll(typeof(Patches));
         }
 

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -51,6 +51,11 @@ namespace Jotunn.Managers
         /// </summary>
         private SynchronizationManager() { }
 
+        static SynchronizationManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Clientside indicator if the current player has admin status on 
         ///     the current world, always true on local games
@@ -62,6 +67,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing SynchronizationManager");
+
             // Register RPCs and the admin watchdog
             ConfigRPC = NetworkManager.Instance.AddRPC(
                 Main.Instance.Info.Metadata, "ConfigSync", ConfigRPC_OnServerReceive, ConfigRPC_OnClientReceive);

--- a/JotunnLib/Managers/UndoManager.cs
+++ b/JotunnLib/Managers/UndoManager.cs
@@ -57,6 +57,11 @@ namespace Jotunn.Managers
         /// </summary>
         private UndoManager() { }
 
+        static UndoManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Container to hold all Queues.
         /// </summary>
@@ -67,6 +72,7 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing UndoManager");
             Main.Harmony.PatchAll(typeof(Patches));
         }
 

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -30,6 +30,11 @@ namespace Jotunn.Managers
         /// </summary>
         private ZoneManager() { }
 
+        static ZoneManager()
+        {
+            ((IManager)Instance).Init();
+        }
+
         /// <summary>
         ///     Event that gets fired after the vanilla locations are in memory and available for cloning or editing.
         ///     Your code will execute every time before a new <see cref="ObjectDB"/> is copied (on every menu start).
@@ -58,6 +63,8 @@ namespace Jotunn.Managers
         /// </summary>
         void IManager.Init()
         {
+            Logger.LogInfo("Initializing ZoneManager");
+
             LocationContainer = new GameObject("Locations");
             LocationContainer.transform.parent = Main.RootObject.transform;
             LocationContainer.SetActive(false);

--- a/JotunnLib/Utils/AutomaticLocalizationsLoading.cs
+++ b/JotunnLib/Utils/AutomaticLocalizationsLoading.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Jotunn.Managers;
+
+namespace Jotunn.Utils
+{
+    internal static class AutomaticLocalizationsLoading
+    {
+        public const string TranslationsFolderName = "Translations";
+        public const string CommunityTranslationFileName = "community_translation.json";
+
+        public static void Init()
+        {
+            var jsonFormat = new HashSet<FileInfo>();
+            var unityFormat = new HashSet<FileInfo>();
+
+            // Json format community files
+            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, CommunityTranslationFileName))
+            {
+                jsonFormat.Add(fileInfo);
+            }
+
+            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.json"))
+            {
+                jsonFormat.Add(fileInfo);
+            }
+
+            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.language"))
+            {
+                unityFormat.Add(fileInfo);
+            }
+
+            foreach (var fileInfo in jsonFormat)
+            {
+                try
+                {
+                    var mod = BepInExUtils.GetPluginInfoFromPath(fileInfo)?.Metadata;
+                    LocalizationManager.Instance.GetLocalization(mod ?? Main.Instance.Info.Metadata).AddFileByPath(fileInfo.FullName, true);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning($"Exception caught while loading localization file {fileInfo}: {ex}");
+                }
+            }
+
+            foreach (var fileInfo in unityFormat)
+            {
+                try
+                {
+                    var mod = BepInExUtils.GetPluginInfoFromPath(fileInfo)?.Metadata;
+                    LocalizationManager.Instance.GetLocalization(mod ?? Main.Instance.Info.Metadata).AddFileByPath(fileInfo.FullName);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning($"Exception caught while loading localization file {fileInfo}: {ex}");
+                }
+            }
+        }
+
+        private static IEnumerable<FileInfo> GetTranslationFiles(string path, string searchPattern)
+        {
+            return GetTranslationFiles(new DirectoryInfo(path), searchPattern);
+        }
+
+        private static IEnumerable<FileInfo> GetTranslationFiles(DirectoryInfo pathDirectoryInfo, string searchPattern)
+        {
+            if (!pathDirectoryInfo.Exists)
+            {
+                yield break;
+            }
+
+            var files = Directory.GetFiles(pathDirectoryInfo.FullName, searchPattern, SearchOption.AllDirectories);
+
+            foreach (var path in files.Where(path => new DirectoryInfo(path).Parent?.Parent?.Name == TranslationsFolderName))
+            {
+                yield return new FileInfo(path);
+            }
+        }
+    }
+}

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -26,9 +26,13 @@ namespace Jotunn.Utils
 
         internal static void Init()
         {
+            Logger.LogInfo("Initializing ModCompatibility");
+
             var localization = LocalizationManager.Instance.JotunnLocalization;
             localization.AddJsonFile("English", AssetUtils.LoadTextFromResources("English.json", typeof(Main).Assembly));
             localization.AddJsonFile("German", AssetUtils.LoadTextFromResources("German.json", typeof(Main).Assembly));
+
+            Main.Harmony.PatchAll(typeof(ModCompatibility));
         }
 
         [HarmonyPatch(typeof(ZNet), nameof(ZNet.OnNewConnection)), HarmonyPrefix, HarmonyPriority(Priority.First)]

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -27,11 +27,6 @@ namespace Jotunn.Utils
         internal static void Init()
         {
             Logger.LogInfo("Initializing ModCompatibility");
-
-            var localization = LocalizationManager.Instance.JotunnLocalization;
-            localization.AddJsonFile("English", AssetUtils.LoadTextFromResources("English.json", typeof(Main).Assembly));
-            localization.AddJsonFile("German", AssetUtils.LoadTextFromResources("German.json", typeof(Main).Assembly));
-
             Main.Harmony.PatchAll(typeof(ModCompatibility));
         }
 
@@ -199,6 +194,10 @@ namespace Jotunn.Utils
 
         private static CompatibilityWindow LoadCompatWindow()
         {
+            var localization = LocalizationManager.Instance.JotunnLocalization;
+            localization.AddJsonFile("English", AssetUtils.LoadTextFromResources("English.json", typeof(Main).Assembly));
+            localization.AddJsonFile("German", AssetUtils.LoadTextFromResources("German.json", typeof(Main).Assembly));
+
             AssetBundle bundle = AssetUtils.LoadAssetBundleFromResources("modcompat", typeof(Main).Assembly);
             var compatWindowGameObject = Object.Instantiate(bundle.LoadAsset<GameObject>("CompatibilityWindow"), GUIManager.CustomGUIFront.transform);
             bundle.Unload(false);

--- a/JotunnLib/Utils/ModQuery.cs
+++ b/JotunnLib/Utils/ModQuery.cs
@@ -27,6 +27,7 @@ namespace Jotunn.Utils
 
         internal static void Init()
         {
+            Logger.LogInfo("Initializing ModQuery");
             Main.Harmony.PatchAll(typeof(ModQuery));
         }
 
@@ -49,6 +50,11 @@ namespace Jotunn.Utils
         /// </summary>
         public static void Enable()
         {
+            if (!enabled)
+            {
+                Init();
+            }
+
             enabled = true;
         }
 
@@ -119,11 +125,6 @@ namespace Jotunn.Utils
         [HarmonyPatch(typeof(FejdStartup), nameof(FejdStartup.Awake)), HarmonyPostfix]
         private static void FejdStartup_Awake_Postfix()
         {
-            if (!enabled)
-            {
-                return;
-            }
-
             FindAndPatchPatches(AccessTools.Method(typeof(ZNetScene), nameof(ZNetScene.Awake)));
             FindAndPatchPatches(AccessTools.Method(typeof(ObjectDB), nameof(ObjectDB.Awake)));
             FindAndPatchPatches(AccessTools.Method(typeof(ObjectDB), nameof(ObjectDB.CopyOtherDB)));
@@ -133,11 +134,6 @@ namespace Jotunn.Utils
         [HarmonyPatch(typeof(ObjectDB), nameof(ObjectDB.Awake)), HarmonyPrefix, HarmonyPriority(1000)]
         private static void ObjectDBAwake(ObjectDB __instance)
         {
-            if (!enabled)
-            {
-                return;
-            }
-
             // make sure vanilla prefabs are already added to not assign them to the first mod that call this function in a prefix
             __instance.UpdateItemHashes();
         }


### PR DESCRIPTION
This initalizes managers in a static constructor instead of initialising all of them at the start. The first time a manager is accessed via a member like events or a singelton access from a mod, it will be initalized.

The advantage is that Jotunn will load much faster with a small mod count, as only the necessary managers are loaded and initalized. Also, if some part breaks after a Valheim update, only called managers are effected.
For a large modpack, there's practically no difference as most managers are used anyway. The startup time without additional mods drops from about 800ms to about 150ms, which finally makes Jotunn lighweight.

The only possible problem is that a manager might be initalized too late and certain patches won't apply. Although this is rather unlikely, as most is happening in the Awake or Start methods of mods anyway. After testing a small number of mods, no issues were found. Nevertheless, extended testing is needed.