### PR TITLE
Synchronization Events Pre-Sync and on Dedicated Server

### DIFF
--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -704,6 +704,8 @@ namespace Jotunn.Managers
                     // Send values to server if it is a client instance
                     if (ZNet.instance.IsClientInstance())
                     {
+                        // Fire event that admin config will be changed locally, since the RPC does not come back to the sender
+                        InvokeOnApplyingConfiguration();
                         ConfigRPC.SendPackage(ZRoutedRpc.instance.GetServerPeerID(), package);
 
                         // Get IDs of plugins that received data
@@ -711,8 +713,7 @@ namespace Jotunn.Managers
                         pluginIDs.ForEach(x => GetPluginIdentifier(x));
 
                         // Also fire event that admin config was changed locally, since the RPC does not come back to the sender
-                        var pluginIDs = new HashSet<string>(valuesToSend.Select(x => x.Item1));
-                        InvokeOnConfigurationSynchronized(false, pluginIDs);
+                        InvokeOnConfigurationSynchronized(false, new HashSet<string>(pluginIDs));
                     }
                     // Send changed values to all connected clients
                     else

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -808,7 +808,7 @@ namespace Jotunn.Managers
 
         private IEnumerator ConfigRPC_OnClientReceive(long sender, ZPackage package)
         {
-            InvokeOnApplyingConfiguration(); // new line
+            InvokeOnApplyingConfiguration();
 
             byte packageFlags = package.ReadByte();
 
@@ -829,11 +829,11 @@ namespace Jotunn.Managers
             if (ZNet.instance.IsAdmin(sender))
             {
                 Logger.LogInfo($"Received configuration data from client {sender}");
-                InvokeOnApplyingConfiguration(); // new line
+                InvokeOnApplyingConfiguration();
 
                 // Apply config locally
                 ApplyConfigZPackage(package, out bool initial, out HashSet<string> pluginIDs);
-                InvokeOnConfigurationSynchronized(initial, pluginIDs); // new line
+                InvokeOnConfigurationSynchronized(initial, pluginIDs);
 
                 // Send to all other clients
                 ConfigRPC.SendPackage(ZNet.instance.m_peers.Where(x => x.m_uid != sender).ToList(), package);

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -716,7 +716,7 @@ namespace Jotunn.Managers
                     if (ZNet.instance.IsClientInstance())
                     {
                         // Fire event that admin config will be changed locally, since the RPC does not come back to the sender
-                        InvokeOnApplyingConfiguration();
+                        InvokeOnSyncingConfiguration();
                         ConfigRPC.SendPackage(ZRoutedRpc.instance.GetServerPeerID(), package);
 
                         // Get IDs of plugins that received data
@@ -826,7 +826,7 @@ namespace Jotunn.Managers
 
         private IEnumerator ConfigRPC_OnClientReceive(long sender, ZPackage package)
         {
-            InvokeOnApplyingConfiguration();
+            InvokeOnSyncingConfiguration();
 
             byte packageFlags = package.ReadByte();
 
@@ -847,7 +847,7 @@ namespace Jotunn.Managers
             if (ZNet.instance.IsAdmin(sender))
             {
                 Logger.LogInfo($"Received configuration data from client {sender}");
-                InvokeOnApplyingConfiguration();
+                InvokeOnSyncingConfiguration();
 
                 // Apply config locally
                 ApplyConfigZPackage(package, out bool initial, out HashSet<string> pluginGUIDs);
@@ -877,7 +877,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Safely invoke the <see cref="OnConfigurationSynchronized"/> event
         /// </summary>
-        private void InvokeOnApplyingConfiguration()
+        private void InvokeOnSyncingConfiguration()
         {
             OnSyncingConfiguration?.SafeInvoke(this, new SyncingConfigurationEventArgs());
         }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -898,7 +898,6 @@ namespace Jotunn.Managers
 
                 if (config != null)
                 {
-                    pluginIDs.Add(configIdentifier);
                     if (config.Keys.Contains(new ConfigDefinition(section, key)))
                     {
                         var entry = config[section, key];

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -31,7 +31,7 @@ namespace Jotunn.Managers
         private bool ConfigurationManagerWindowShown;
 
         /// <summary>
-        ///     Event triggered after server configuration is applied to client
+        ///     Event triggered after configuration has been synced on either the server or client
         /// </summary>
         public static event EventHandler<ConfigurationSynchronizationEventArgs> OnConfigurationSynchronized;
 
@@ -810,6 +810,7 @@ namespace Jotunn.Managers
 
                 // Apply config locally
                 ApplyConfigZPackage(package, out bool initial);
+                InvokeOnConfigurationSynchronized(initial); // new line
 
                 // Send to all other clients
                 ConfigRPC.SendPackage(ZNet.instance.m_peers.Where(x => x.m_uid != sender).ToList(), package);

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -39,7 +39,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Event triggered before syncing configuration on either the server or client
         /// </summary>
-        public static event EventHandler<ConfigurationSynchronizationEventArgs> OnApplyingConfiguration;
+        public static event EventHandler<SyncingConfigurationEventArgs> OnSyncingConfiguration;
 
         /// <summary>
         ///     Event triggered after a clients admin status changed on the server
@@ -879,7 +879,7 @@ namespace Jotunn.Managers
         /// </summary>
         private void InvokeOnApplyingConfiguration()
         {
-            OnApplyingConfiguration?.SafeInvoke(this, new ConfigurationSynchronizationEventArgs());
+            OnSyncingConfiguration?.SafeInvoke(this, new SyncingConfigurationEventArgs());
         }
 
         /// <summary>

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -27,6 +27,7 @@ namespace Jotunn.Managers
         private readonly Dictionary<string, bool> CachedAdminStates = new Dictionary<string, bool>();
         private readonly Dictionary<string, ConfigFile> CustomConfigs = new Dictionary<string, ConfigFile>();
         private List<Tuple<string, string, string, string>> CachedConfigValues = new List<Tuple<string, string, string, string>>();
+        private readonly Dictionary<string, string> CachedCustomConfigGUIDs = new Dictionary<string, string>();
         private BaseUnityPlugin ConfigurationManager;
         private bool ConfigurationManagerWindowShown;
 
@@ -145,6 +146,10 @@ namespace Jotunn.Managers
 
             Logger.LogDebug($"Registering custom config file {identifier}");
             CustomConfigs.Add(identifier, customFile);
+
+            // Add to cached pluginGUIDs to get source mod for custom config files
+            var plugin = BepInExUtils.GetSourceModMetadata();
+            CachedCustomConfigGUIDs.Add(identifier, plugin.GUID);
         }
 
         /// <summary>

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -461,6 +461,15 @@ namespace Jotunn.Managers
             return config.ConfigFilePath.Replace(BepInEx.Paths.ConfigPath, "").Replace("\\", "/").Trim('/');
         }
 
+        private static string GetPluginIdentifier(string configFileIdentifier)
+        {
+            if (configFileIdentifier.EndsWith(".cfg"))
+            {
+                configFileIdentifier = configFileIdentifier.Substring(0, configFileIdentifier.Length - 4);
+            }
+            return configFileIdentifier;
+        }
+
         private ConfigFile GetConfigFile(string identifier)
         {
             if (CustomConfigs.TryGetValue(identifier, out var config))
@@ -697,6 +706,10 @@ namespace Jotunn.Managers
                     {
                         ConfigRPC.SendPackage(ZRoutedRpc.instance.GetServerPeerID(), package);
 
+                        // Get IDs of plugins that received data
+                        var pluginIDs = valuesToSend.Select(x => x.Item1).ToList();
+                        pluginIDs.ForEach(x => GetPluginIdentifier(x));
+
                         // Also fire event that admin config was changed locally, since the RPC does not come back to the sender
                         var pluginIDs = new HashSet<string>(valuesToSend.Select(x => x.Item1));
                         InvokeOnConfigurationSynchronized(false, pluginIDs);
@@ -876,6 +889,7 @@ namespace Jotunn.Managers
                 var section = configPkg.ReadString();
                 var key = configPkg.ReadString();
                 var serializedValue = configPkg.ReadString();
+                pluginIDs.Add(GetPluginIdentifier(configIdentifier));
 
                 Logger.LogDebug($"Received {configIdentifier} {section} {key} {serializedValue}");
 

--- a/JotunnLib/Utils/ConfigurationSynchronizationEventArgs.cs
+++ b/JotunnLib/Utils/ConfigurationSynchronizationEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 
 namespace Jotunn.Utils
 {
@@ -11,5 +12,10 @@ namespace Jotunn.Utils
         ///     Is this the initial synchronization?
         /// </summary>
         public bool InitialSynchronization { get; set; }
+
+        /// <summary>
+        ///     GUID for each Plugin that received configuration data.
+        /// </summary>
+        public HashSet<string> UpdatedPluginIDs { get; set; }
     }
 }

--- a/JotunnLib/Utils/ConfigurationSynchronizationEventArgs.cs
+++ b/JotunnLib/Utils/ConfigurationSynchronizationEventArgs.cs
@@ -16,6 +16,6 @@ namespace Jotunn.Utils
         /// <summary>
         ///     GUID for each Plugin that received configuration data.
         /// </summary>
-        public HashSet<string> UpdatedPluginIDs { get; set; }
+        public HashSet<string> UpdatedPluginGUIDs { get; set; }
     }
 }

--- a/JotunnLib/Utils/SyncingConfigurationEventArgs.cs
+++ b/JotunnLib/Utils/SyncingConfigurationEventArgs.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Jotunn.Utils
 {

--- a/JotunnLib/Utils/SyncingConfigurationEventArgs.cs
+++ b/JotunnLib/Utils/SyncingConfigurationEventArgs.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jotunn.Utils
+{
+    /// <summary>
+    ///     Event args class for syncing configuration event
+    /// </summary>
+    public class SyncingConfigurationEventArgs : EventArgs
+    {
+        // currently empty but thought that keeping
+        // symmetry with ConfigurationSynchronizationEventArgs was
+        // a better design and that other devs might have
+        // ideas of what should go here so doing it this way
+        // was more future-proof.
+    }
+}


### PR DESCRIPTION
### New Synchronization Event
This pull request adds a new event, `OnSyncingConfiguration`, that triggers just before applying the synchronized values (on both client and server). This event has it's own class for event args which is currently empty but I thought it was best to keep the same design pattern as the `OnConfigurationSynchronized` event and prevent changes in API if other devs want to add argument to the event. 

### Modified `OnConfigurationSynchronized` to Fire on Server
The event `OnConfigurationSynchronized` has been altered to fire on both the client and the dedicated server after the configuration has been synchronized. I testing the effects of doing this using a mod list that had two different mods that used Jotunn to sync configurations and one that used Blaxxun's ServerSync. 

I set up the two Jotunn dependant mods to save their configuration files whenever the `OnConfigurationSynchronized` event fired and set up the file-watcher in each mod to reload the configuration file when it was saved so the mod could be updated. when Both of the Jotunn dependent mods used a file-watcher that would reload the configuration file when it was changed and an in-game configuration manager watcher that would save the configuration file when the in-game manager was closed. 

I tested changing the configuration via the in-game manager, by editing the server configuration file, and editing the local client configuration file. For all test cases the behaviour on the client-side was identical to when `OnConfigurationSynchronized` only fired on the client. For the server, configuration changes were saved just like they were on client whenever "OnConfigurationSynchronized" fired on the server.  As far as I can tell from those tests firing the "OnConfigurationSynchronized" even on the server does not result in any sort of infinite synchronization loop or duplicate synchronizations for existing mods.

### Added Synced PluginGUIDs argument to `OnConfigurationSynchronized` Event
The `OnConfigurationSynchronized` has a new argument that is a HashSet containing the PluginGUID for each plugin that received configuration data from the SynchronizationManager. This is so that plugins can check if they actually had their configuration updated by checking if the HashSet contains their plugin's GUID. This also required caching the PluginGUID for each custom configuration file that is registered so that changes to custom configuration files are tracked appropriately.