### PR TITLE
OnConfigurationWindowClosed Event

### DIFF
--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -875,7 +875,7 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
-        ///     Safely invoke the <see cref="OnConfigurationSynchronized"/> event
+        ///     Safely invoke the <see cref="OnSyncingConfiguration"/> event
         /// </summary>
         private void InvokeOnSyncingConfiguration()
         {

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -46,6 +46,11 @@ namespace Jotunn.Managers
         /// </summary>
         public static event Action OnAdminStatusChanged;
 
+        /// <summary>
+        ///     Event triggered after the in-game configuration manager window is closed
+        /// </summary>
+        public static event Action OnConfigurationWindowClosed;
+
         private static SynchronizationManager _instance;
 
         /// <summary>
@@ -574,9 +579,19 @@ namespace Jotunn.Managers
 
             if (!ConfigurationManagerWindowShown)
             {
+                InvokeOnConfigurationWindowClosed();
+
                 // After closing the window check for changed configs
                 SynchronizeChangedConfig();
             }
+        }
+
+        /// <summary>
+        ///     Safely invoke the <see cref="OnConfigurationWindowClosed"/> event
+        /// </summary>
+        private void InvokeOnConfigurationWindowClosed()
+        {
+            OnConfigurationWindowClosed?.SafeInvoke();
         }
 
         /// <summary>


### PR DESCRIPTION
I wanted to add an event that triggers when the in-game configuration manager window is closed because I realized that probablykory and I likely aren't the only ones who use the window closing as a way to trigger updating mods after configuration settings have been changed. Plus having an event for it in Jotunn would be quite convenient and reduce the amount of boilerplate code needed to set up the event in each mod I make.

Since this would be a feature that is mostly used for local management of configuration files I don't know if adding the event to the SynchronizationManager class is the most appropriate place for it or not? This was the easiest place to add the event though as the code in it already checks for the configuration manager window closing.