### PR TITLE
Added feature to help resolve mocks based off same type search.

### DIFF
--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -229,7 +229,7 @@ namespace Jotunn
         /// <param name="searchType">Whether to preform a breadth first or depth first search. Default is breadth first.</param>
         public static Transform FindDeepChild(
             this GameObject gameObject,
-            List<string> childNames,
+            IEnumerable<string> childNames,
             global::Utils.IterativeSearchType searchType = global::Utils.IterativeSearchType.BreadthFirst
         )
         {

--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -4,6 +4,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using Jotunn.Extensions;
+using System.Collections.Generic;
 
 namespace Jotunn
 {
@@ -217,6 +218,28 @@ namespace Jotunn
         )
         {
             return gameObject.transform.FindDeepChild(childName, searchType);
+        }
+
+        /// <summary>
+        ///     Extension method to find nested children by an ordered list of names using either
+        ///     a breadth-first or depth-first search. Default is breadth-first.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="childNames">Names in order of the child object to search for.</param>
+        /// <param name="searchType">Whether to preform a breadth first or depth first search. Default is breadth first.</param>
+        public static Transform FindDeepChild(
+            this GameObject gameObject,
+            List<string> childNames,
+            global::Utils.IterativeSearchType searchType = global::Utils.IterativeSearchType.BreadthFirst
+        )
+        {
+            var child = gameObject.transform.FindDeepChild(childNames[0], searchType);
+            for (int i = 1; i < childNames.Count; i++)
+            {
+                child = child.FindDeepChild(childNames[i], searchType);
+            }
+
+            return child;
         }
     }
 

--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -243,6 +243,11 @@ namespace Jotunn
             foreach (string childName in childNames)
             {
                 child = child.FindDeepChild(childName, searchType);
+
+                if (!child)
+                {
+                    return null;
+                }
             }
 
             return child;

--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -233,10 +233,10 @@ namespace Jotunn
             global::Utils.IterativeSearchType searchType = global::Utils.IterativeSearchType.BreadthFirst
         )
         {
-            var child = gameObject.transform.FindDeepChild(childNames[0], searchType);
-            for (int i = 1; i < childNames.Count; i++)
-            {
-                child = child.FindDeepChild(childNames[i], searchType);
+            var child = gameObject.transform;
+
+            foreach (string childName in childNames) {
+                child = child.FindDeepChild(childName, searchType);
             }
 
             return child;

--- a/JotunnLib/Extensions/GameObjectExtension.cs
+++ b/JotunnLib/Extensions/GameObjectExtension.cs
@@ -123,6 +123,7 @@ namespace Jotunn
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -141,6 +142,7 @@ namespace Jotunn
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -159,6 +161,7 @@ namespace Jotunn
                     return false;
                 }
             }
+
             return true;
         }
 
@@ -177,6 +180,7 @@ namespace Jotunn
                     return false;
                 }
             }
+
             return true;
         }
 
@@ -201,6 +205,7 @@ namespace Jotunn
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -235,7 +240,8 @@ namespace Jotunn
         {
             var child = gameObject.transform;
 
-            foreach (string childName in childNames) {
+            foreach (string childName in childNames)
+            {
                 child = child.FindDeepChild(childName, searchType);
             }
 

--- a/JotunnLib/Managers/CreatureManager.cs
+++ b/JotunnLib/Managers/CreatureManager.cs
@@ -244,7 +244,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customCreature?.SourceMod, $"Skipping creature {customCreature}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customCreature?.SourceMod, $"Skipping creature {customCreature}: {ex.Message}");
                         toDelete.Add(customCreature);
                     }
                     catch (Exception ex)

--- a/JotunnLib/Managers/ItemManager.cs
+++ b/JotunnLib/Managers/ItemManager.cs
@@ -402,7 +402,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customItem?.SourceMod, $"Skipping item {customItem}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customItem?.SourceMod, $"Skipping item {customItem}: {ex.Message}");
                         toDelete.Add(customItem);
                     }
                     catch (Exception ex)
@@ -509,7 +509,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customRecipe?.SourceMod, $"Skipping recipe {customRecipe}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customRecipe?.SourceMod, $"Skipping recipe {customRecipe}: {ex.Message}");
                         toDelete.Add(customRecipe);
                     }
                     catch (Exception ex)
@@ -556,7 +556,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customStatusEffect?.SourceMod, $"Skipping status effect {customStatusEffect}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customStatusEffect?.SourceMod, $"Skipping status effect {customStatusEffect}: {ex.Message}");
                         toDelete.Add(customStatusEffect);
                     }
                     catch (Exception ex)
@@ -666,7 +666,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(conversion?.SourceMod, $"Skipping item conversion {conversion}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(conversion?.SourceMod, $"Skipping item conversion {conversion}: {ex.Message}");
                         toDelete.Add(conversion);
                     }
                     catch (Exception ex)

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -216,7 +216,7 @@ namespace Jotunn.Managers
 
             if (name.StartsWith(JVLMockPrefix, StringComparison.Ordinal))
             {
-                var splitNames = name.Split(new[] { "__" }, StringSplitOptions.RemoveEmptyEntries);
+                var splitNames = name.Split(new[] { JVLMockSeparator }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (splitNames.Length > 1)
                 {

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -151,16 +151,16 @@ namespace Jotunn.Managers
             {
                 unityObjectName = GetCleanedName(unityObject.GetType(), unityObjectName);
 
-                if (pathName != null)
+                if (!string.IsNullOrEmpty(pathName))
                 {
                     // Handle mocks that require path of existing prefab to find/replace
                     // These are represented by JVLMock_PrefabName__ChildName
                     pathName = GetCleanedName(mockObjectType, pathName);
 
-                    GameObject parent = PrefabManager.Cache.GetPrefab(typeof(GameObject), unityObjectName) as GameObject;
-                    var childTransform = parent?.FindDeepChild(pathName);
+                    GameObject parent = PrefabManager.Cache.GetPrefab<GameObject>(unityObjectName);
+                    var childTransform = parent.FindDeepChild(pathName);
 
-                    var obj = FindObjectInChildren(childTransform?.gameObject, mockObjectType);
+                    var obj = FindObjectInChildren(childTransform.gameObject, mockObjectType);
 
                     if (obj == null)
                     {
@@ -215,7 +215,7 @@ namespace Jotunn.Managers
 
             if (name.StartsWith(JVLMockPrefix, StringComparison.Ordinal))
             {
-                int separator = name.IndexOf(JVLMockSeparator);
+                int separator = name.IndexOf(JVLMockSeparator, StringComparison.Ordinal);
 
                 if (separator > 0)
                 {

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using HarmonyLib;
 using Jotunn.Extensions;
@@ -217,22 +218,8 @@ namespace Jotunn.Managers
             if (name.StartsWith(JVLMockPrefix, StringComparison.Ordinal))
             {
                 var splitNames = name.Split(new[] { JVLMockSeparator }, StringSplitOptions.RemoveEmptyEntries);
-
-                if (splitNames.Length > 1)
-                {
-                    childNames = new List<string>();
-                    cleanedName = splitNames[0].Substring(JVLMockPrefix.Length);
-
-                    for (int i = 1; i < splitNames.Length; i++)
-                    {
-                        childNames.Add(splitNames[i]);
-                    }
-                }
-                else
-                {
-                    cleanedName = name.Substring(JVLMockPrefix.Length);
-                }
-
+                cleanedName = splitNames[0].Substring(JVLMockPrefix.Length);
+                childNames = splitNames.Skip(1).ToList();
                 return true;
             }
 

--- a/JotunnLib/Managers/MockSystem/MockResolveException.cs
+++ b/JotunnLib/Managers/MockSystem/MockResolveException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Jotunn.Managers.MockSystem
 {
@@ -39,7 +40,7 @@ namespace Jotunn.Managers.MockSystem
         /// <param name="message"></param>
         /// <param name="failedMockName"></param>
         /// <param name="mockType"></param>
-        public MockResolveException(string message, string failedMockName, Type mockType) : base(message)
+        public MockResolveException(string message, string failedMockName, Type mockType) : base(ConstructMessage(message, failedMockName, string.Empty, mockType))
         {
             FailedMockName = failedMockName;
             MockType = mockType;
@@ -52,11 +53,21 @@ namespace Jotunn.Managers.MockSystem
         /// <param name="failedMockName"></param>
         /// <param name="failedMockPath"></param>
         /// <param name="mockType"></param>
-        public MockResolveException(string message, string failedMockName, string failedMockPath, Type mockType) : base(message)
+        public MockResolveException(string message, string failedMockName, IEnumerable<string> failedMockPath, Type mockType) : base(ConstructMessage(message, failedMockName, string.Join<string>("->", failedMockPath), mockType))
         {
             FailedMockName = failedMockName;
-            FailedMockPath = failedMockPath;
+            FailedMockPath = string.Join<string>("->", failedMockPath);
             MockType = mockType;
+        }
+
+        private static string ConstructMessage(string message, string failedMockName, string failedMockPath, Type mockType)
+        {
+            if (string.IsNullOrEmpty(failedMockPath))
+            {
+                return $"Mock {mockType.Name} '{failedMockName}' could not be resolved. {message}";
+            }
+
+            return $"Mock {mockType.Name} at '{failedMockName}' with child path '{failedMockPath}' could not be resolved. {message}";
         }
     }
 }

--- a/JotunnLib/Managers/MockSystem/MockResolveException.cs
+++ b/JotunnLib/Managers/MockSystem/MockResolveException.cs
@@ -15,7 +15,7 @@ namespace Jotunn.Managers.MockSystem
         /// <summary>
         ///     Path within the prefab that could not be resolved.
         /// </summary>
-        public string FailedMockPathName { get; private set; }
+        public string FailedMockPath { get; private set; }
 
         /// <summary>
         ///     Type of the prefab that could not be resolved.
@@ -50,12 +50,12 @@ namespace Jotunn.Managers.MockSystem
         /// </summary>
         /// <param name="message"></param>
         /// <param name="failedMockName"></param>
-        /// <param name="failedMockPathName"></param>
+        /// <param name="failedMockPath"></param>
         /// <param name="mockType"></param>
-        public MockResolveException(string message, string failedMockName, string failedMockPathName, Type mockType) : base(message)
+        public MockResolveException(string message, string failedMockName, string failedMockPath, Type mockType) : base(message)
         {
             FailedMockName = failedMockName;
-            FailedMockPathName = failedMockPathName;
+            FailedMockPath = failedMockPath;
             MockType = mockType;
         }
     }

--- a/JotunnLib/Managers/MockSystem/MockResolveException.cs
+++ b/JotunnLib/Managers/MockSystem/MockResolveException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Jotunn.Managers.MockSystem
 {
@@ -11,6 +11,11 @@ namespace Jotunn.Managers.MockSystem
         ///     Name of the prefab that could not be resolved. Mock prefix is already removed.
         /// </summary>
         public string FailedMockName { get; private set; }
+
+        /// <summary>
+        ///     Path within the prefab that could not be resolved.
+        /// </summary>
+        public string FailedMockPathName { get; private set; }
 
         /// <summary>
         ///     Type of the prefab that could not be resolved.
@@ -37,6 +42,20 @@ namespace Jotunn.Managers.MockSystem
         public MockResolveException(string message, string failedMockName, Type mockType) : base(message)
         {
             FailedMockName = failedMockName;
+            MockType = mockType;
+        }
+
+        /// <summary>
+        ///     Creates a new instance of the <see cref="MockResolveException" /> class.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="failedMockName"></param>
+        /// <param name="failedMockPathName"></param>
+        /// <param name="mockType"></param>
+        public MockResolveException(string message, string failedMockName, string failedMockPathName, Type mockType) : base(message)
+        {
+            FailedMockName = failedMockName;
+            FailedMockPathName = failedMockPathName;
             MockType = mockType;
         }
     }

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -484,7 +484,7 @@ namespace Jotunn.Managers
                 }
                 catch (MockResolveException ex)
                 {
-                    Logger.LogWarning(customPiece?.SourceMod, $"Skipping piece {customPiece}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                    Logger.LogWarning(customPiece?.SourceMod, $"Skipping piece {customPiece}: {ex.Message}");
                     toDelete.Add(customPiece);
                 }
                 catch (Exception ex)

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx;
@@ -41,7 +41,7 @@ namespace Jotunn.Managers
 
         /// <summary>
         ///     Event that gets fired after registering all custom prefabs to <see cref="ZNetScene"/>.
-        ///     Your code will execute every time a new ZNetScene is created (on every game start). 
+        ///     Your code will execute every time a new ZNetScene is created (on every game start).
         ///     If you want to execute just once you will need to unregister from the event after execution.
         /// </summary>
         public static event Action OnPrefabsRegistered;
@@ -401,7 +401,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Safely invoke the <see cref="OnVanillaPrefabsAvailable"/> event
         /// </summary>
-        /// 
+        ///
         private void InvokeOnVanillaObjectsAvailable()
         {
             OnVanillaPrefabsAvailable?.SafeInvoke();

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -343,7 +343,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customPrefab?.SourceMod, $"Skipping prefab {customPrefab}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customPrefab?.SourceMod, $"Skipping prefab {customPrefab}: {ex.Message}");
                         toDelete.Add(customPrefab);
                     }
                     catch (Exception ex)

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -442,7 +442,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customClutter?.SourceMod, $"Skipping clutter {customClutter}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customClutter?.SourceMod, $"Skipping clutter {customClutter}: {ex.Message}");
                         toDelete.Add(customClutter.Name);
                     }
                     catch (Exception ex)
@@ -500,7 +500,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customLocation?.SourceMod, $"Skipping location {customLocation}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customLocation?.SourceMod, $"Skipping location {customLocation}: {ex.Message}");
                         toDelete.Add(customLocation.Name);
                     }
                     catch (Exception ex)
@@ -539,7 +539,7 @@ namespace Jotunn.Managers
                     }
                     catch (MockResolveException ex)
                     {
-                        Logger.LogWarning(customVegetation?.SourceMod, $"Skipping vegetation {customVegetation}: could not resolve mock {ex.MockType.Name} {ex.FailedMockName}");
+                        Logger.LogWarning(customVegetation?.SourceMod, $"Skipping vegetation {customVegetation}: {ex.Message}");
                         toDelete.Add(customVegetation.Name);
                     }
                     catch (Exception ex)


### PR DESCRIPTION
* Accepts new mock format JVLmock_PrefabName__ChildName.
* Finds an object that matches the type of the mock from the specified child of the prefab in the new format.
* Cleans name of any object Mesh with " Instance" on the end of the name for finding mock replacement.

Since there are many unnamed Mesh objects used the current mocking system can not replace them. This is the required changes to get a functioning mesh mocking system, but should work for other types too.

Examples of usage:
1. Create a mocked mesh called JVLmock_Pickable_Thistle__default, this will find the first Mesh on the Pickable_Thistle prefab under the child "default" for a replacement.
2. Create a mocked mesh named JVLmock_TrollCave02__dirtfloor (11), this will find the first Mesh on the TrollCave02 prefab under the child "dirtfloor (11)" for a replacement.