### PR TITLE
Added  pre-defined BeInExPath to be considered in JotunnLibRefsCorlib…

### DIFF
--- a/JotunnLib/BuildProps/JotunnLibRefsCorlib.props
+++ b/JotunnLib/BuildProps/JotunnLibRefsCorlib.props
@@ -1,4 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="$(BepInExPath)=='' AND $(VALHEIM_INSTALL) != ''">
+    <BepInExPath>$(VALHEIM_INSTALL)\BepInEx</BepInExPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="assembly_googleanalytics_publicized">
       <HintPath>$(VALHEIM_INSTALL)\valheim_Data\Managed\publicized_assemblies\assembly_googleanalytics_publicized.dll</HintPath>
@@ -37,19 +40,19 @@
       <Private>false</Private>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>$(BepInExPath)\core\BepInEx.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>$(BepInExPath)\core\0Harmony.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="BepInEx.Preloader">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.Preloader.dll</HintPath>
+      <HintPath>$(BepInExPath)\core\BepInEx.Preloader.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="HarmonyXInterop">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\HarmonyXInterop.dll</HintPath>
+      <HintPath>$(BepInExPath)\core\HarmonyXInterop.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Mono.Security">

--- a/JotunnLib/BuildProps/JotunnLibRefsCorlib.props
+++ b/JotunnLib/BuildProps/JotunnLibRefsCorlib.props
@@ -1,7 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="$(BepInExPath)=='' AND $(VALHEIM_INSTALL) != ''">
-    <BepInExPath>$(VALHEIM_INSTALL)\BepInEx</BepInExPath>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="assembly_googleanalytics_publicized">
       <HintPath>$(VALHEIM_INSTALL)\valheim_Data\Managed\publicized_assemblies\assembly_googleanalytics_publicized.dll</HintPath>
@@ -40,19 +37,19 @@
       <Private>false</Private>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>$(BepInExPath)\core\BepInEx.dll</HintPath>
+      <HintPath>$(BEPINEX_PATH)\core\BepInEx.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>$(BepInExPath)\core\0Harmony.dll</HintPath>
+      <HintPath>$(BEPINEX_PATH)\core\0Harmony.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="BepInEx.Preloader">
-      <HintPath>$(BepInExPath)\core\BepInEx.Preloader.dll</HintPath>
+      <HintPath>$(BEPINEX_PATH)\core\BepInEx.Preloader.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="HarmonyXInterop">
-      <HintPath>$(BepInExPath)\core\HarmonyXInterop.dll</HintPath>
+      <HintPath>$(BEPINEX_PATH)\core\HarmonyXInterop.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Mono.Security">

--- a/JotunnLib/BuildProps/Paths.props
+++ b/JotunnLib/BuildProps/Paths.props
@@ -19,4 +19,7 @@
       </PropertyGroup>
     </When>
   </Choose>
+  <PropertyGroup Condition="$(BEPINEX_PATH)=='' AND $(VALHEIM_INSTALL) != ''">
+    <BEPINEX_PATH>$(VALHEIM_INSTALL)\BepInEx</BEPINEX_PATH>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi the reason for this is to improve the flexibility when building with the Environment.props or via setting up different place where BepInEx resides. It gives a bit more flexibility to the developer and allows to use mode managers like Vortex, Thunderstore as bepinex base when building.