### PR TITLE
Bog Witch Beta Fixes (0.219.10+)

### DIFF
--- a/JotunnDoc/Docs/InputDoc.cs
+++ b/JotunnDoc/Docs/InputDoc.cs
@@ -40,7 +40,7 @@ namespace JotunnDoc.Docs
             foreach (var pair in buttons.Where(x => !jotunnButtons.ContainsKey(x.Key)))
             {
                 ZInput.ButtonDef button = pair.Value;
-                AddTableRow(pair.Key, button.m_mouseButton.ToString(), button.m_key.ToString(), button.m_gamepadInput.ToString());
+                // AddTableRow(pair.Key, button.m_mouseButton.ToString(), button.m_key.ToString(), button.m_gamepadInput.ToString());
             }
 
             Save();

--- a/JotunnLib/Configs/ButtonConfig.cs
+++ b/JotunnLib/Configs/ButtonConfig.cs
@@ -206,14 +206,9 @@ namespace Jotunn.Configs
 
         internal bool IsSameButton(ZInput.ButtonDef buttonDef)
         {
-            if (InputUtils.TryKeyCodeToMouseButton(Key, out UnityEngine.InputSystem.LowLevel.MouseButton mouseButton))
-            {
-                return buttonDef.m_mouseButton == mouseButton;
-            }
-
-            return buttonDef.m_key == InputUtils.KeyCodeToKey(Key) ||
-                   buttonDef.m_key == InputUtils.KeyCodeToKey(GetGamepadKeyCode(GamepadButton)) ||
-                   buttonDef.m_gamepadInput == GetGamepadInput(GamepadButton);
+            // Input TODO
+            // return buttonDef.ButtonAction
+            return false;
         }
     }
 }

--- a/JotunnLib/Configs/ButtonConfig.cs
+++ b/JotunnLib/Configs/ButtonConfig.cs
@@ -203,12 +203,5 @@ namespace Jotunn.Configs
         ///     Internal flag if this button config is backed by any BepInEx ConfigEntry
         /// </summary>
         internal bool IsConfigBacked => Config != null || ShortcutConfig != null || GamepadConfig != null;
-
-        internal bool IsSameButton(ZInput.ButtonDef buttonDef)
-        {
-            // Input TODO
-            // return buttonDef.ButtonAction
-            return false;
-        }
     }
 }

--- a/JotunnLib/Configs/CraftingStations.cs
+++ b/JotunnLib/Configs/CraftingStations.cs
@@ -50,6 +50,16 @@ namespace Jotunn.Configs
         public static string GaldrTable => "piece_magetable";
 
         /// <summary>
+        ///     Mead Ketill crafting station
+        /// </summary>
+        public static string MeadKetill => "piece_MeadCauldron";
+
+        /// <summary>
+        ///     Food Preparation Table crafting station
+        /// </summary>
+        public static string FoodPreparationTable => "piece_preptable";
+
+        /// <summary>
         ///     Gets the human readable name to internal names map
         /// </summary>
         /// <returns></returns>
@@ -106,6 +116,8 @@ namespace Jotunn.Configs
             { nameof(ArtisanTable), ArtisanTable },
             { nameof(BlackForge), BlackForge },
             { nameof(GaldrTable), GaldrTable },
+            { nameof(MeadKetill), MeadKetill },
+            { nameof(FoodPreparationTable), FoodPreparationTable },
         };
 
         private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());

--- a/JotunnLib/Configs/PieceCategories.cs
+++ b/JotunnLib/Configs/PieceCategories.cs
@@ -12,32 +12,47 @@ namespace Jotunn.Configs
         /// <summary>
         ///     Piece 'Misc' category
         /// </summary>
-        public static string Misc => "Misc";
+        public static string Misc => nameof(Piece.PieceCategory.Misc);
 
         /// <summary>
         ///     Piece 'Crafting' category
         /// </summary>
-        public static string Crafting => "Crafting";
+        public static string Crafting => nameof(Piece.PieceCategory.Crafting);
 
         /// <summary>
         ///     Piece 'Building' category
         /// </summary>
-        public static string Building => "BuildingWorkbench";
+        public static string Building => nameof(Piece.PieceCategory.BuildingWorkbench);
 
         /// <summary>
         ///     Piece 'HeavyBuild' category
         /// </summary>
-        public static string HeavyBuild => "BuildingStonecutter";
+        public static string HeavyBuild => nameof(Piece.PieceCategory.BuildingStonecutter);
 
         /// <summary>
         ///     Piece 'Furniture' category
         /// </summary>
-        public static string Furniture => "Furniture";
+        public static string Furniture => nameof(Piece.PieceCategory.Furniture);
+
+        /// <summary>
+        ///     Piece 'Food' category
+        /// </summary>
+        public static string Food => nameof(Piece.PieceCategory.Food);
+
+        /// <summary>
+        ///     Piece 'Mead' category
+        /// </summary>
+        public static string Mead => nameof(Piece.PieceCategory.Meads);
+
+        /// <summary>
+        ///     Piece 'Feasts' category
+        /// </summary>
+        public static string Feasts => nameof(Piece.PieceCategory.Feasts);
 
         /// <summary>
         ///     All piece categories
         /// </summary>
-        public static string All => "All";
+        public static string All => nameof(Piece.PieceCategory.All);
 
         /// <summary>
         ///     Gets the human readable name to internal names map
@@ -93,6 +108,9 @@ namespace Jotunn.Configs
             { nameof(Building), Building },
             { nameof(HeavyBuild), HeavyBuild },
             { nameof(Furniture), Furniture },
+            { nameof(Feasts), Feasts },
+            { nameof(Food), Food },
+            { nameof(Mead), Mead },
             { nameof(All), All },
         };
 

--- a/JotunnLib/Configs/PieceTableConfig.cs
+++ b/JotunnLib/Configs/PieceTableConfig.cs
@@ -73,9 +73,6 @@ namespace Jotunn.Configs
                 return;
             }
 
-            // Use categories at all?
-            table.m_useCategories = UseCategories || UseCustomCategories;
-
             // Can remove pieces?
             table.m_canRemovePieces = CanRemovePieces;
         }

--- a/JotunnLib/Configs/PieceTables.cs
+++ b/JotunnLib/Configs/PieceTables.cs
@@ -25,6 +25,11 @@ namespace Jotunn.Configs
         public static string Hoe => "_HoePieceTable";
 
         /// <summary>
+        ///     Serving Tray piece table
+        /// </summary>
+        public static string ServingTray => "_FeasterPieceTable";
+
+        /// <summary>
         ///     Gets the human readable name to internal names map
         /// </summary>
         /// <returns></returns>
@@ -76,6 +81,7 @@ namespace Jotunn.Configs
             { nameof(Hammer), Hammer },
             { nameof(Cultivator), Cultivator },
             { nameof(Hoe), Hoe },
+            { nameof(ServingTray), ServingTray },
         };
 
         private static readonly AcceptableValueList<string> AcceptableValues = new AcceptableValueList<string>(NamesMap.Keys.ToArray());

--- a/JotunnLib/DebugUtils/DebugInfo.cs
+++ b/JotunnLib/DebugUtils/DebugInfo.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using BepInEx.Configuration;
 using HarmonyLib;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 namespace Jotunn.DebugUtils
@@ -186,8 +187,20 @@ namespace Jotunn.DebugUtils
 
         private void UpdateKeys()
         {
-            var key = ZInput.instance.GetPressedKey(); 
-            _keyValue.text = Enum.GetName(typeof(KeyCode), key);
+            _keyValue.text = GetPressedKey();
+        }
+
+        private string GetPressedKey()
+        {
+            foreach (var button in ZInput.instance.m_buttons)
+            {
+                if (ZInput.GetButton(button.Key))
+                {
+                    return button.Value.ButtonAction.GetBindingDisplayString() + " | " + button.Value.Name;
+                }
+            }
+
+            return string.Empty;
         }
 
         private void UpdateZones()

--- a/JotunnLib/DebugUtils/DebugInfo.cs
+++ b/JotunnLib/DebugUtils/DebugInfo.cs
@@ -201,7 +201,7 @@ namespace Jotunn.DebugUtils
 
             _zoneAltitudeValue.text = $"<color=#ffe082>{altitude:0}</color>";
 
-            Vector2i sector = ZoneSystem.instance.GetZone(position);
+            Vector2i sector = ZoneSystem.GetZone(position);
 
             _zoneSectorValue.text = $"<color=#ffe082>{sector.x}</color>, <color=#a5d6a7>{sector.y}</color>";
 

--- a/JotunnLib/Entities/CustomPieceTable.cs
+++ b/JotunnLib/Entities/CustomPieceTable.cs
@@ -49,7 +49,7 @@ namespace Jotunn.Entities
         {
             PieceTablePrefab = pieceTablePrefab;
             PieceTable = pieceTablePrefab.GetComponent<PieceTable>();
-            if (PieceTable != null && PieceTable.m_useCategories)
+            if (PieceTable != null)
             {
                 List<string> categories = new List<string>();
                 for (int i = 0; i < PieceUtils.VanillaMaxPieceCategory; i++)

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -270,7 +270,8 @@ namespace Jotunn.Managers
                 string extenstion = key.Split('.').Last();
                 string asset = key.RemoveSuffix($".{extenstion}");
 
-                if (pair.Key == "Assets/UI/prefabs/radials/elements/Hammer.prefab")
+                if (pair.Key == "Assets/UI/prefabs/radials/elements/Hammer.prefab" ||
+                    pair.Key == "Assets/UI/prefabs/Radial/elements/Hammer.prefab")
                 {
                     // skip UI element in favour of Assets/GameElements/Items/tools/Hammer.prefab
                     continue;

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -107,13 +107,25 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
-        ///     Translate an axis string to its <see cref="UnityEngine.InputSystem.InputBinding.path">UnityEngine.InputSystem.InputBinding.path</see> value
+        ///     Translate an axis string to its
+        ///     <see cref="UnityEngine.InputSystem.InputBinding.path">UnityEngine.InputSystem.InputBinding.path</see> value
         /// </summary>
         /// <param name="axis"></param>
         /// <returns></returns>
         public static string GetAxisPath(string axis)
         {
             return InputUtils.GetAxisPath(axis);
+        }
+
+        /// <summary>
+        ///     Translate a <see cref="GamepadInput"/> to its
+        ///     <see cref="UnityEngine.InputSystem.InputBinding.path">UnityEngine.InputSystem.InputBinding.path</see> value
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string GetGamepadInputPath(GamepadInput input)
+        {
+            return InputUtils.GetGamepadInputPath(input);
         }
 
         /// <summary>
@@ -294,13 +306,12 @@ namespace Jotunn.Managers
 
                     if (btn.GamepadButton != GamepadButton.None)
                     {
-                        var joyBtnName = $"Joy!{btn.Name}";
                         GamepadInput input = GetGamepadInput(btn.GamepadButton);
 
                         if (input != GamepadInput.None)
                         {
-                            // Input TODO
-                            //self.AddButton(joyBtnName, input, btn.RepeatDelay, btn.RepeatInterval);
+                            var joyBtnName = $"Joy!{btn.Name}";
+                            self.AddButton(joyBtnName, GetGamepadInputPath(input), false, true, true, btn.RepeatDelay, btn.RepeatInterval);
                         }
                     }
 

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -6,7 +6,7 @@ using HarmonyLib;
 using Jotunn.Configs;
 using Jotunn.Utils;
 using UnityEngine;
-using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem;
 
 namespace Jotunn.Managers
 {
@@ -387,9 +387,9 @@ namespace Jotunn.Managers
                 return true;
             }
 
-            if (button.BlockOtherInputs)
+            if (button.BlockOtherInputs && ZInput.instance.m_buttons.TryGetValue(button.Name, out var def))
             {
-                foreach (var btn in ZInput.instance.m_buttons.Where(pair => button.IsSameButton(pair.Value)))
+                foreach (var btn in ZInput.instance.m_buttons.Where(pair => IsSameButton(def, pair.Value)))
                 {
                     ZInput.ResetButtonStatus(btn.Key);
                     btn.Value.m_pressedDynamic = false;
@@ -408,6 +408,13 @@ namespace Jotunn.Managers
             }
 
             return Player.m_localPlayer.TakeInput();
+        }
+
+        private static bool IsSameButton(ZInput.ButtonDef buttonA, ZInput.ButtonDef buttonB)
+        {
+            var pathsA = buttonA.ButtonAction.bindings.Select(binding => binding.path);
+            var pathsB = buttonB.ButtonAction.bindings.Select(binding => binding.path);
+            return pathsA.Intersect(pathsB).Any();
         }
     }
 }

--- a/JotunnLib/Managers/InputManager.cs
+++ b/JotunnLib/Managers/InputManager.cs
@@ -107,6 +107,16 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
+        ///     Translate an axis string to its <see cref="UnityEngine.InputSystem.InputBinding.path">UnityEngine.InputSystem.InputBinding.path</see> value
+        /// </summary>
+        /// <param name="axis"></param>
+        /// <returns></returns>
+        public static string GetAxisPath(string axis)
+        {
+            return InputUtils.GetAxisPath(axis);
+        }
+
+        /// <summary>
         ///     Translates a <see cref="GamepadButton"/> to its printable string value
         /// </summary>
         public static string GetGamepadString(GamepadButton @enum)
@@ -271,29 +281,15 @@ namespace Jotunn.Managers
 
                     if (!string.IsNullOrEmpty(btn.Axis))
                     {
-                        self.AddButton(btn.Name, GetGamepadInput(GetGamepadButton(btn.Axis)), btn.RepeatDelay, btn.RepeatInterval);
+                        self.AddButton(btn.Name, GetAxisPath(btn.Axis), false, true, true, btn.RepeatDelay, btn.RepeatInterval);
                     }
                     else if (btn.Key != KeyCode.None)
                     {
-                        if (InputUtils.TryKeyCodeToMouseButton(btn.Key, out MouseButton mouseButton))
-                        {
-                            self.AddButton(btn.Name, mouseButton, btn.RepeatDelay, btn.RepeatInterval);
-                        }
-                        else
-                        {
-                            self.AddButton(btn.Name, InputUtils.KeyCodeToKey(btn.Key), btn.RepeatDelay, btn.RepeatInterval);
-                        }
+                        self.AddButton(btn.Name, ZInput.KeyCodeToPath(btn.Key), false, true, true, btn.RepeatDelay, btn.RepeatInterval);
                     }
                     else if (btn.Shortcut.MainKey != KeyCode.None)
                     {
-                        if (InputUtils.TryKeyCodeToMouseButton(btn.Shortcut.MainKey, out MouseButton mouseButton))
-                        {
-                            self.AddButton(btn.Name, mouseButton, btn.RepeatDelay, btn.RepeatInterval);
-                        }
-                        else
-                        {
-                            self.AddButton(btn.Name, InputUtils.KeyCodeToKey(btn.Shortcut.MainKey), btn.RepeatDelay, btn.RepeatInterval);
-                        }
+                        self.AddButton(btn.Name, ZInput.KeyCodeToPath(btn.Shortcut.MainKey), false, true, true, btn.RepeatDelay, btn.RepeatInterval);
                     }
 
                     if (btn.GamepadButton != GamepadButton.None)
@@ -303,7 +299,8 @@ namespace Jotunn.Managers
 
                         if (input != GamepadInput.None)
                         {
-                            self.AddButton(joyBtnName, input, btn.RepeatDelay, btn.RepeatInterval);
+                            // Input TODO
+                            //self.AddButton(joyBtnName, input, btn.RepeatDelay, btn.RepeatInterval);
                         }
                     }
 
@@ -384,7 +381,7 @@ namespace Jotunn.Managers
                 foreach (var btn in ZInput.instance.m_buttons.Where(pair => button.IsSameButton(pair.Value)))
                 {
                     ZInput.ResetButtonStatus(btn.Key);
-                    btn.Value.m_pressed = false;
+                    btn.Value.m_pressedDynamic = false;
                     btn.Value.m_pressedFixed = false;
                 }
             }

--- a/JotunnLib/Managers/ItemManager.cs
+++ b/JotunnLib/Managers/ItemManager.cs
@@ -700,7 +700,7 @@ namespace Jotunn.Managers
 #pragma warning restore 612
             InvokeOnKitbashItemsAvailable();
 
-            UpdateItemHashesSafe(other);
+            UpdateRegistersSafe(other);
             RegisterCustomItems(other);
         }
 
@@ -737,7 +737,7 @@ namespace Jotunn.Managers
         {
             if (SceneManager.GetActiveScene().name == "main")
             {
-                UpdateItemHashesSafe(self);
+                UpdateRegistersSafe(self);
                 RegisterCustomItems(self);
                 RegisterCustomRecipes(self);
                 RegisterCustomStatusEffects(self);
@@ -775,9 +775,10 @@ namespace Jotunn.Managers
             }
         }
 
-        private static void UpdateItemHashesSafe(ObjectDB objectDB)
+        private static void UpdateRegistersSafe(ObjectDB objectDB)
         {
             objectDB.m_itemByHash.Clear();
+            objectDB.m_itemByData.Clear();
 
             foreach (GameObject item in objectDB.m_items)
             {
@@ -798,6 +799,13 @@ namespace Jotunn.Managers
                 }
 
                 objectDB.m_itemByHash.Add(hash, item);
+
+                ItemDrop component = item.GetComponent<ItemDrop>();
+
+                if (component != null)
+                {
+                    objectDB.m_itemByData[component.m_itemData.m_shared] = item;
+                }
             }
         }
     }

--- a/JotunnLib/Managers/KeyHintManager.cs
+++ b/JotunnLib/Managers/KeyHintManager.cs
@@ -315,14 +315,15 @@ namespace Jotunn.Managers
                 var gamepadButton = buttonConfig.GamepadButton;
                 if (gamepadButton == GamepadButton.None && ZInput.instance.m_buttons.TryGetValue($"Joy{buttonConfig.Name}", out var buttonDef))
                 {
-                    // Input TODO
-                    //gamepadButton = GetGamepadButton(buttonDef.m_gamepadInput);
+                    // TODO extract GamepadButton from buttonDef path
+                    gamepadButton = GamepadButton.None;
                 }
 
                 if (gamepadButton != GamepadButton.None)
                 {
                     string buttonString = GetGamepadString(gamepadButton);
 
+                    // TODO fix GamepadButton keyhints
                     switch (gamepadButton)
                     {
                         case GamepadButton.DPadLeft:

--- a/JotunnLib/Managers/KeyHintManager.cs
+++ b/JotunnLib/Managers/KeyHintManager.cs
@@ -315,7 +315,8 @@ namespace Jotunn.Managers
                 var gamepadButton = buttonConfig.GamepadButton;
                 if (gamepadButton == GamepadButton.None && ZInput.instance.m_buttons.TryGetValue($"Joy{buttonConfig.Name}", out var buttonDef))
                 {
-                    gamepadButton = GetGamepadButton(buttonDef.m_gamepadInput);
+                    // Input TODO
+                    //gamepadButton = GetGamepadButton(buttonDef.m_gamepadInput);
                 }
 
                 if (gamepadButton != GamepadButton.None)

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -11,6 +11,7 @@ using Jotunn.Utils;
 using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace Jotunn.Managers
@@ -103,17 +104,14 @@ namespace Jotunn.Managers
 
         private static class Patches
         {
-            [HarmonyPatch(typeof(PieceTable), nameof(PieceTable.NextCategory)), HarmonyPostfix]
-            public static void PieceTable_NextCategory_Postfix(PieceTable __instance) => Instance.PieceTable_NextCategory(__instance);
-
-            [HarmonyPatch(typeof(PieceTable), nameof(PieceTable.PrevCategory)), HarmonyPostfix]
-            public static void PieceTable_PrevCategory_Postfix(PieceTable __instance) => Instance.PieceTable_PrevCategory(__instance);
-
             [HarmonyPatch(typeof(Player), nameof(Player.SetPlaceMode)), HarmonyPostfix]
             public static void Player_SetPlaceMode() => Instance.RefreshCategories();
 
             [HarmonyPatch(typeof(Hud), nameof(Hud.Awake)), HarmonyPostfix, HarmonyPriority(Priority.Low)]
             private static void Hud_Awake() => Instance.RefreshCategories();
+
+            [HarmonyPatch(typeof(Hud), nameof(Hud.UpdateBuild)), HarmonyPrefix]
+            private static void Hud_UpdateBuild() => Instance.RefreshCategories();
 
             [HarmonyPatch(typeof(Hud), nameof(Hud.LateUpdate)), HarmonyPostfix]
             private static void Hud_LateUpdate()
@@ -146,15 +144,6 @@ namespace Jotunn.Managers
 
             [HarmonyPatch(typeof(PieceTable), nameof(PieceTable.UpdateAvailable)), HarmonyTranspiler]
             private static IEnumerable<CodeInstruction> UpdateAvailable_Transpiler(IEnumerable<CodeInstruction> instructions) => TranspileMaxCategory(instructions, 0);
-
-            [HarmonyPatch(typeof(PieceTable), nameof(PieceTable.NextCategory)), HarmonyTranspiler]
-            private static IEnumerable<CodeInstruction> NextCategory_Transpiler(IEnumerable<CodeInstruction> instructions) => TranspileMaxCategory(instructions, 0);
-
-            [HarmonyPatch(typeof(PieceTable), nameof(PieceTable.PrevCategory)), HarmonyTranspiler]
-            private static IEnumerable<CodeInstruction> PrevCategory_Transpiler(IEnumerable<CodeInstruction> instructions) => TranspileMaxCategory(instructions, -1);
-
-            [HarmonyPatch(typeof(PieceTable), nameof(PieceTable.SetCategory)), HarmonyTranspiler]
-            private static IEnumerable<CodeInstruction> SetCategory_Transpiler(IEnumerable<CodeInstruction> instructions) => TranspileMaxCategory(instructions, -1);
 
             [HarmonyPatch(typeof(Enum), nameof(Enum.GetValues)), HarmonyPostfix]
             private static void EnumGetValuesPatch(Type enumType, ref Array __result) => Instance.EnumGetValuesPatch(enumType, ref __result);
@@ -777,12 +766,6 @@ namespace Jotunn.Managers
 
             int maxCategory = MaxCategory();
 
-            // Fill empty category names to prevent index issues, the correct names are set by the respective mods later
-            for (int i = Hud.instance.m_buildCategoryNames.Count; i < maxCategory; ++i)
-            {
-                Hud.instance.m_buildCategoryNames.Add("");
-            }
-
             // Append tabs and their names to the GUI for every custom category not already added
             for (int i = Hud.instance.m_pieceCategoryTabs.Length; i < maxCategory; i++)
             {
@@ -840,9 +823,8 @@ namespace Jotunn.Managers
 
         private GameObject CreateCategoryTab()
         {
-            Transform categoryRoot = Hud.instance.m_pieceCategoryRoot.transform;
-
-            GameObject newTab = Object.Instantiate(Hud.instance.m_pieceCategoryTabs[0], categoryRoot);
+            GameObject firstTab = Hud.instance.m_pieceCategoryTabs[0];
+            GameObject newTab = Object.Instantiate(firstTab, firstTab.transform.parent);
             newTab.SetActive(false);
 
             UIInputHandler handler = newTab.GetOrAddComponent<UIInputHandler>();
@@ -887,17 +869,16 @@ namespace Jotunn.Managers
             RectTransform categoryRoot = (RectTransform)Hud.instance.m_pieceCategoryRoot.transform;
             RectTransform selectionWindow = (RectTransform)Hud.instance.m_pieceSelectionWindow.transform;
 
+            firstTab.parent.GetComponent<HorizontalLayoutGroup>().enabled = false;
+
             const int verticalSpacing = 1;
             Vector2 tabSize = firstTab.rect.size;
 
             var visibleCategories = CategoriesInPieceTable(pieceTable);
-            var categories = GetPieceCategoriesMap();
-
-            bool onlyMiscActive = visibleCategories.Count == 1 && visibleCategories.First() == Piece.PieceCategory.Misc;
-            pieceTable.m_useCategories = !onlyMiscActive;
+            UpdatePieceTableCategories(pieceTable, visibleCategories);
 
             int maxHorizontalTabs = Mathf.Max((int)(categoryRoot.rect.width / tabSize.x), 1);
-            int visibleTabs = VisibleTabCount(visibleCategories);
+            int visibleTabs = pieceTable.m_categories.Count;
 
             float tabAnchorX = (-tabSize.x * maxHorizontalTabs) / 2f + tabSize.x / 2f;
             float tabAnchorY = (tabSize.y + verticalSpacing) * Mathf.Floor((float)(visibleTabs - 1) / maxHorizontalTabs) + 5f;
@@ -905,28 +886,16 @@ namespace Jotunn.Managers
 
             int tabIndex = 0;
 
-            for (int i = 0; i < Hud.instance.m_pieceCategoryTabs.Length; ++i)
+            for (int i = 0; i < pieceTable.m_categories.Count; ++i)
             {
                 GameObject tab = Hud.instance.m_pieceCategoryTabs[i];
-                string categoryName = categories[(Piece.PieceCategory)i];
-                bool active = visibleCategories.Contains((Piece.PieceCategory)i);
-
-                SetTabActive(tab, categoryName, active);
-
-                if (active)
-                {
-                    RectTransform rect = tab.GetComponent<RectTransform>();
-                    float x = tabSize.x * (tabIndex % maxHorizontalTabs);
-                    float y = -(tabSize.y + verticalSpacing) * (Mathf.Floor((float)tabIndex / maxHorizontalTabs) + 0.5f);
-                    rect.anchoredPosition = tabAnchor + new Vector2(x, y);
-                    tabIndex++;
-                }
-
-                // only update names of own tabs, as translation tokens may be different between mods
-                if (PieceCategories.ContainsKey(categoryName))
-                {
-                    Hud.instance.m_buildCategoryNames[i] = $"${GetCategoryToken(categoryName)}";
-                }
+                RectTransform rect = tab.GetComponent<RectTransform>();
+                float x = tabSize.x * (tabIndex % maxHorizontalTabs);
+                float y = -(tabSize.y + verticalSpacing) * (Mathf.Floor((float)tabIndex / maxHorizontalTabs) + 0.5f);
+                rect.anchoredPosition = tabAnchor + new Vector2(x, y);
+                rect.anchorMin = new Vector2(0.5f, 1);
+                rect.anchorMax = new Vector2(0.5f, 1);
+                tabIndex++;
             }
 
             RectTransform background = (RectTransform)selectionWindow.Find("Bkg2")?.transform;
@@ -941,55 +910,28 @@ namespace Jotunn.Managers
                 Logger.LogWarning("Category Refresh: Could not find background image, skipping resize");
             }
 
-            if ((int)Player.m_localPlayer.m_buildPieces.m_selectedCategory >= Hud.instance.m_buildCategoryNames.Count)
-            {
-                Player.m_localPlayer.m_buildPieces.SetCategory((int)visibleCategories.First());
-            }
-
             Hud.instance.GetComponentInParent<Localize>().RefreshLocalization();
         }
 
-        private static int VisibleTabCount(HashSet<Piece.PieceCategory> visibleCategories) {
-            int visibleTabs = 0;
+        private void UpdatePieceTableCategories(PieceTable pieceTable, HashSet<Piece.PieceCategory> visibleCategories)
+        {
+            foreach (var entry in PieceCategories)
+            {
+                string name = entry.Key;
+                Piece.PieceCategory category = entry.Value;
 
-            for (int i = 0; i < Hud.instance.m_pieceCategoryTabs.Length; ++i) {
-                bool active = visibleCategories.Contains((Piece.PieceCategory)i);
-
-                if (active) {
-                    visibleTabs++;
+                if (visibleCategories.Contains(category) && !pieceTable.m_categories.Contains(category))
+                {
+                    pieceTable.m_categories.Add(category);
+                    pieceTable.m_categoryLabels.Add($"${GetCategoryToken(name)}");
                 }
-            }
 
-            return visibleTabs;
-        }
-
-        private void PieceTable_NextCategory(PieceTable self)
-        {
-            if (self.m_pieces.Count == 0 || !self.m_useCategories)
-            {
-                return;
-            }
-
-            var selectedTab = Hud.instance.m_pieceCategoryTabs[(int)self.m_selectedCategory];
-
-            if (selectedTab.name.Contains(hiddenCategoryMagic))
-            {
-                self.NextCategory();
-            }
-        }
-
-        private void PieceTable_PrevCategory(PieceTable self)
-        {
-            if (self.m_pieces.Count == 0 || !self.m_useCategories)
-            {
-                return;
-            }
-
-            var selectedTab = Hud.instance.m_pieceCategoryTabs[(int)self.m_selectedCategory];
-
-            if (selectedTab.name.Contains(hiddenCategoryMagic))
-            {
-                self.PrevCategory();
+                if (!visibleCategories.Contains(category) && pieceTable.m_categories.Contains(category))
+                {
+                    int index = pieceTable.m_categories.IndexOf(category);
+                    pieceTable.m_categories.RemoveAt(index);
+                    pieceTable.m_categoryLabels.RemoveAt(index);
+                }
             }
         }
 

--- a/JotunnLib/Utils/InputUtils.cs
+++ b/JotunnLib/Utils/InputUtils.cs
@@ -254,6 +254,26 @@ namespace Jotunn.Utils
         }
 
         /// <summary>
+        ///     Translate an axis string to its <see cref="UnityEngine.InputSystem.InputBinding.path">UnityEngine.InputSystem.InputBinding.path</see> value
+        /// </summary>
+        /// <param name="axis"></param>
+        /// <returns></returns>
+        public static string GetAxisPath(string axis)
+        {
+            return axis switch
+            {
+                "Mouse ScrollWheel" => "<Mouse>/scroll",
+                "JoyAxis 7" => "<Gamepad>/dpad/up",
+                "-JoyAxis 7" => "<Gamepad>/dpad/down",
+                "-JoyAxis 6" => "<Gamepad>/dpad/left",
+                "JoyAxis 6" => "<Gamepad>/dpad/right",
+                "-JoyAxis 3" => "<Gamepad>/leftTrigger",
+                "JoyAxis 3" => "<Gamepad>/rightTrigger",
+                _ => string.Empty
+            };
+        }
+
+        /// <summary>
         ///     Translates a <see cref="KeyCode"/> to its <see cref="GamepadButton"/> value
         /// </summary>
         public static GamepadButton GetGamepadButton(KeyCode key)
@@ -292,22 +312,12 @@ namespace Jotunn.Utils
 
             if (entry.SettingType == typeof(KeyCode) && ZInput.instance.m_buttons.TryGetValue(buttonName, out def))
             {
-                if (TryKeyCodeToMouseButton((KeyCode)entry.BoxedValue, out var mouseButton))
-                {
-                    def.m_bMouseButtonSet = true;
-                    def.m_mouseButton = mouseButton;
-                    def.m_key = Key.None;
-                }
-                else
-                {
-                    def.m_bMouseButtonSet = false;
-                    def.m_key = KeyCodeToKey((KeyCode)entry.BoxedValue);
-                }
+                def.Rebind(ZInput.KeyCodeToPath((KeyCode)entry.BoxedValue));
             }
 
             if (entry.SettingType == typeof(KeyboardShortcut) && ZInput.instance.m_buttons.TryGetValue(buttonName, out def))
             {
-                def.m_key = KeyCodeToKey(((KeyboardShortcut)entry.BoxedValue).MainKey);
+                def.Rebind(ZInput.KeyCodeToPath(((KeyboardShortcut)entry.BoxedValue).MainKey));
             }
 
             if (entry.SettingType == typeof(GamepadButton) && ZInput.instance.m_buttons.TryGetValue($"Joy!{buttonName}", out def))
@@ -315,13 +325,15 @@ namespace Jotunn.Utils
                 var keyCode = GetGamepadKeyCode((GamepadButton)entry.BoxedValue);
                 var input = GetGamepadInput((GamepadButton)entry.BoxedValue);
 
+                // Input TODO
                 if (input != GamepadInput.None)
                 {
-                    def.m_gamepadInput = input;
+                    // buttonActionBackingField.SetValue(def,
+                    // def.m_gamepadInput = input;
                 }
                 else
                 {
-                    def.m_key = KeyCodeToKey(keyCode);
+                    // def.m_key = KeyCodeToKey(ZInput.KeyCodeToPath(keyCode));
                 }
             }
         }

--- a/JotunnLib/Utils/InputUtils.cs
+++ b/JotunnLib/Utils/InputUtils.cs
@@ -185,8 +185,18 @@ namespace Jotunn.Utils
                 GamepadButton.DPadDown => GamepadInput.DPadDown,
                 GamepadButton.DPadLeft => GamepadInput.DPadLeft,
                 GamepadButton.DPadRight => GamepadInput.DPadRight,
+                GamepadButton.ButtonSouth => GamepadInput.FaceButtonA,
+                GamepadButton.ButtonEast => GamepadInput.FaceButtonB,
+                GamepadButton.ButtonWest => GamepadInput.FaceButtonX,
+                GamepadButton.ButtonNorth => GamepadInput.FaceButtonY,   
+                GamepadButton.LeftShoulder => GamepadInput.BumperL,
+                GamepadButton.RightShoulder => GamepadInput.BumperR,
                 GamepadButton.LeftTrigger => GamepadInput.TriggerL,
                 GamepadButton.RightTrigger => GamepadInput.TriggerR,
+                GamepadButton.SelectButton => GamepadInput.Select,
+                GamepadButton.StartButton => GamepadInput.Start,
+                GamepadButton.LeftStickButton => GamepadInput.StickLButton,
+                GamepadButton.RightStickButton => GamepadInput.StickRButton,
                 _ => GamepadInput.None
             };
         }
@@ -274,6 +284,51 @@ namespace Jotunn.Utils
         }
 
         /// <summary>
+        ///     Translate a <see cref="GamepadInput"/> to its
+        ///     <see cref="UnityEngine.InputSystem.InputBinding.path">UnityEngine.InputSystem.InputBinding.path</see> value
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string GetGamepadInputPath(GamepadInput input)
+        {
+            return input switch
+            {
+                GamepadInput.DPadLeft => "<Gamepad>/dpad/left",
+                GamepadInput.DPadRight => "<Gamepad>/dpad/right",
+                GamepadInput.DPadDown => "<Gamepad>/dpad/down",
+                GamepadInput.DPadUp => "<Gamepad>/dpad/up",
+                GamepadInput.FaceButtonA => "<Gamepad>/buttonSouth",
+                GamepadInput.FaceButtonB => "<Gamepad>/buttonEast",
+                GamepadInput.FaceButtonX => "<Gamepad>/buttonWest",
+                GamepadInput.FaceButtonY => "<Gamepad>/buttonNorth",
+                GamepadInput.StickLHorizontal => "<Gamepad>/leftStick/x",
+                GamepadInput.StickLVertical => "<Gamepad>/leftStick/y",
+                GamepadInput.StickLButton => "<Gamepad>/leftStickPress",
+                GamepadInput.StickRHorizontal => "<Gamepad>/rightStick/x",
+                GamepadInput.StickRVertical => "<Gamepad>/rightStick/y",
+                GamepadInput.StickRButton => "<Gamepad>/rightStickPress",
+                GamepadInput.BumperL => "<Gamepad>/leftShoulder",
+                GamepadInput.BumperR => "<Gamepad>/rightShoulder",
+                GamepadInput.TriggerL => "<Gamepad>/leftTrigger",
+                GamepadInput.TriggerR => "<Gamepad>/rightTrigger",
+                GamepadInput.Select => "<Gamepad>/select",
+                GamepadInput.Start => "<Gamepad>/start",
+                GamepadInput.DualShockTouchpad => "<Gamepad>/touchpadButton",
+                GamepadInput.StickRUp => "<Gamepad>/rightStick/up",
+                GamepadInput.StickRDown => "<Gamepad>/rightStick/down",
+                GamepadInput.StickRLeft => "<Gamepad>/rightStick/left",
+                GamepadInput.StickRRight => "<Gamepad>/rightStick/right",
+                GamepadInput.StickLUp => "<Gamepad>/leftStick/up",
+                GamepadInput.StickLDown => "<Gamepad>/leftStick/down",
+                GamepadInput.StickLLeft => "<Gamepad>/leftStick/left",
+                GamepadInput.StickLRight => "<Gamepad>/leftStick/right",
+                GamepadInput.StickR => "<Gamepad>/rightStick",
+                GamepadInput.StickL => "<Gamepad>/leftStick",
+                _ => string.Empty
+            };
+        }
+
+        /// <summary>
         ///     Translates a <see cref="KeyCode"/> to its <see cref="GamepadButton"/> value
         /// </summary>
         public static GamepadButton GetGamepadButton(KeyCode key)
@@ -322,18 +377,16 @@ namespace Jotunn.Utils
 
             if (entry.SettingType == typeof(GamepadButton) && ZInput.instance.m_buttons.TryGetValue($"Joy!{buttonName}", out def))
             {
-                var keyCode = GetGamepadKeyCode((GamepadButton)entry.BoxedValue);
                 var input = GetGamepadInput((GamepadButton)entry.BoxedValue);
+                var keyCode = GetGamepadKeyCode((GamepadButton)entry.BoxedValue);
 
-                // Input TODO
                 if (input != GamepadInput.None)
                 {
-                    // buttonActionBackingField.SetValue(def,
-                    // def.m_gamepadInput = input;
+                    def.Rebind(GetGamepadInputPath(input));
                 }
                 else
                 {
-                    // def.m_key = KeyCodeToKey(ZInput.KeyCodeToPath(keyCode));
+                    def.Rebind(ZInput.KeyCodeToPath(keyCode));
                 }
             }
         }

--- a/JotunnLib/Utils/ModQuery.cs
+++ b/JotunnLib/Utils/ModQuery.cs
@@ -128,14 +128,14 @@ namespace Jotunn.Utils
             FindAndPatchPatches(AccessTools.Method(typeof(ZNetScene), nameof(ZNetScene.Awake)));
             FindAndPatchPatches(AccessTools.Method(typeof(ObjectDB), nameof(ObjectDB.Awake)));
             FindAndPatchPatches(AccessTools.Method(typeof(ObjectDB), nameof(ObjectDB.CopyOtherDB)));
-            FindAndPatchPatches(AccessTools.Method(typeof(ObjectDB), nameof(ObjectDB.UpdateItemHashes)));
+            FindAndPatchPatches(AccessTools.Method(typeof(ObjectDB), nameof(ObjectDB.UpdateRegisters)));
         }
 
         [HarmonyPatch(typeof(ObjectDB), nameof(ObjectDB.Awake)), HarmonyPrefix, HarmonyPriority(1000)]
         private static void ObjectDBAwake(ObjectDB __instance)
         {
             // make sure vanilla prefabs are already added to not assign them to the first mod that call this function in a prefix
-            __instance.UpdateItemHashes();
+            __instance.UpdateRegisters();
         }
 
         private static void FindAndPatchPatches(MethodBase methodInfo)


### PR DESCRIPTION
- [x] Rename UpdateItemHashes -> UpdateRegisters
- [x] ZoneManager moved methods to static context
- [x] Main custom category changes
- [x] Add vanilla categories to UI if needed by a mod (extend UpdatePieceTableCategories with the vanilla tab names)
- [x] Update Jotunn.Configs.PieceCategories/Jotunn.Configs.CraftingStations
- [x] Fix InputManager. Valheim apparently completely switched to the new Unity Input System. 4 open issues annotated with `// Input TODO`
- [x] catch ambiguous asset name for the hammer prefab
- [x] Update Valheim data

~Maybe depreciate CustomPieceTable.Categories + related PieceTableConfig properties? Not needed anymore (since the last big category rework). Not a priority~