### PR TITLE
Add SynchronizationModeAttribute to allow mod authors to control how AdminOnly configs are handled.

### DIFF
--- a/JotunnLib/Documentation/tutorials/config.md
+++ b/JotunnLib/Documentation/tutorials/config.md
@@ -67,6 +67,23 @@ Local settings will be overriden by the servers values as long as the client is 
 
 Changing the configs at runtime will sync the changes to all clients connected to the server.
 
+## Admin Only Strictness
+
+Usually, the `IsAdminOnly` flag is enforcing players to be admin on the server to change the configuration.
+However, without having Jotunn installed on the server the admin status cannot be detected reliably.
+
+To change this behaviour, the `SynchronizationMode` can be set to `AdminOnlyStrictness.IfOnServer`.
+This means `IsAdminOnly` configs are only synced and enforced if the server has Jotunn installed.
+If not installed on the server, all players are free to change any config values.
+This can useful for mods that want to behave like client-only mods on vanilla servers but still sync configs on modded servers.
+```cs
+[SynchronizationMode(AdminOnlyStrictness.IfOnServer)]
+internal class TestMod : BaseUnityPlugin
+{
+...
+}
+```
+
 ## Synced admin status
 
 Upon connection to a server, Jötunn checks the admin status of the connecting player on that server, given that Jötunn is installed on both sides.

--- a/JotunnLib/Extensions/PluginExtensions.cs
+++ b/JotunnLib/Extensions/PluginExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BepInEx;
+using Jotunn.Utils;
+
+namespace Jotunn.Extensions
+{
+    internal static class PluginExtensions
+    {
+
+        internal static NetworkCompatibilityAttribute GetNetworkCompatibilityAttribute(this BaseUnityPlugin plugin) 
+        {
+            return plugin.GetType()
+                    .GetCustomAttributes(typeof(NetworkCompatibilityAttribute), true)
+                    .Cast<NetworkCompatibilityAttribute>()
+                    .FirstOrDefault();
+        }
+
+        internal static SynchronizationModeAttribute GetSynchronizationModeAttribute(this BaseUnityPlugin plugin)
+        {
+            return plugin.GetType()
+                    .GetCustomAttributes(typeof(SynchronizationModeAttribute), true)
+                    .Cast<SynchronizationModeAttribute>()
+                    .FirstOrDefault();
+        }
+    }
+
+
+}

--- a/JotunnLib/Extensions/PluginExtensions.cs
+++ b/JotunnLib/Extensions/PluginExtensions.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BepInEx;
 using Jotunn.Utils;
 
@@ -10,23 +7,20 @@ namespace Jotunn.Extensions
 {
     internal static class PluginExtensions
     {
-
-        internal static NetworkCompatibilityAttribute GetNetworkCompatibilityAttribute(this BaseUnityPlugin plugin) 
+        internal static NetworkCompatibilityAttribute GetNetworkCompatibilityAttribute(this BaseUnityPlugin plugin)
         {
             return plugin.GetType()
-                    .GetCustomAttributes(typeof(NetworkCompatibilityAttribute), true)
-                    .Cast<NetworkCompatibilityAttribute>()
-                    .FirstOrDefault();
+                .GetCustomAttributes(typeof(NetworkCompatibilityAttribute), true)
+                .Cast<NetworkCompatibilityAttribute>()
+                .FirstOrDefault();
         }
 
         internal static SynchronizationModeAttribute GetSynchronizationModeAttribute(this BaseUnityPlugin plugin)
         {
             return plugin.GetType()
-                    .GetCustomAttributes(typeof(SynchronizationModeAttribute), true)
-                    .Cast<SynchronizationModeAttribute>()
-                    .FirstOrDefault();
+                .GetCustomAttributes(typeof(SynchronizationModeAttribute), true)
+                .Cast<SynchronizationModeAttribute>()
+                .FirstOrDefault();
         }
     }
-
-
 }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -498,10 +498,6 @@ namespace Jotunn.Managers
         /// <returns></returns>
         private bool ShouldManageConfig(ConfigFile config)
         {
-            if (ModCompatibility.IsJotunnOnServer())
-            {
-                return true;
-            }
             if (!GetPluginGUID(config, out var pluginGUID))
             {
                 return false;

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -874,6 +874,11 @@ namespace Jotunn.Managers
         {
             foreach (var config in GetConfigFiles())
             {
+                if (!ShouldManageConfig(config))
+                {
+                    continue;
+                }
+
                 foreach (var configDefinition in config.Keys)
                 {
                     var configEntry = config[configDefinition.Section, configDefinition.Key];

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -473,11 +473,12 @@ namespace Jotunn.Managers
         {
             var loadedPlugins = BepInExUtils.GetDependentPlugins(true);
 
-            foreach (BaseUnityPlugin plugin in loadedPlugins.Values)
+            foreach (var plugin in loadedPlugins.Values)
             {
                 yield return plugin.Config;
             }
-            foreach (ConfigFile customConfigFile in CustomConfigs.Values)
+
+            foreach (var customConfigFile in CustomConfigs.Values)
             {
                 yield return customConfigFile;
             }
@@ -495,10 +496,12 @@ namespace Jotunn.Managers
             {
                 return false;
             }
+
             if (!BepInExUtils.GetDependentPlugins().TryGetValue(pluginGUID, out var plugin))
             {
                 return false;
             }
+
             return ShouldManageConfig(plugin);
         }
 
@@ -520,11 +523,7 @@ namespace Jotunn.Managers
             // not been set for the mod then return true to mimic current behaviour and 
             // maintain backwards compatibility.
             SynchronizationModeAttribute syncMode = plugin.GetSynchronizationModeAttribute();
-            if (syncMode == null || syncMode.ShouldAlwaysEnforceAdminOnly())
-            {
-                return true;
-            }
-            return false;
+            return syncMode == null || syncMode.ShouldAlwaysEnforceAdminOnly();
         }
 
         private static string GetFileIdentifier(ConfigFile config)

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -466,8 +466,7 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
-        ///     Gets an IEnumerable of all default and custom config files that should be managed by SynchronizationManager. 
-        ///     Ignores config files for plugins with AdminOnlyStrictness == Low if Jotunn is not installed on the server.
+        ///     Gets an IEnumerable of all default and custom config files that associated with plugins that have Jotunn as a dependency.
         /// </summary>
         /// <returns></returns>
         private IEnumerable<ConfigFile> GetConfigFiles()
@@ -476,17 +475,11 @@ namespace Jotunn.Managers
 
             foreach (BaseUnityPlugin plugin in loadedPlugins.Values)
             {
-                if (ShouldManageConfig(plugin))
-                {
-                    yield return plugin.Config;
-                }
+                yield return plugin.Config;
             }
             foreach (ConfigFile customConfigFile in CustomConfigs.Values)
             {
-                if (ShouldManageConfig(customConfigFile))
-                {
-                    yield return customConfigFile;
-                }
+                yield return customConfigFile;
             }
         }
 

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -484,6 +484,24 @@ namespace Jotunn.Managers
             return config.ConfigFilePath.Replace(BepInEx.Paths.ConfigPath, "").Replace("\\", "/").Trim('/');
         }
 
+        /// <summary>
+        ///     Gets the corresponding Plugin GUID for a config file (works for custom config files) 
+        ///     and returns a boolean indicating success or failure.
+        /// </summary>
+        /// <param name="config"></param>
+        /// <param name="pluginGUID"></param>
+        private bool GetPluginGUID(ConfigFile config, out string pluginGUID)
+        {
+            var configFileIdentifier = GetFileIdentifier(config);
+            return GetPluginGUID(configFileIdentifier, out pluginGUID);
+        }
+
+        /// <summary>
+        ///     Gets the corresponding Plugin GUID for a config file identifier (works for custom config files) 
+        ///     and returns a boolean indicating success or failure.
+        /// </summary>
+        /// <param name="configFileIdentifier"></param>
+        /// <param name="pluginGUID"></param>
         private bool GetPluginGUID(string configFileIdentifier, out string pluginGUID)
         {
             if (IsDefaultModConfig(configFileIdentifier, out pluginGUID))

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -521,7 +521,7 @@ namespace Jotunn.Managers
         /// <returns></returns>
         private bool ShouldManageConfig(BaseUnityPlugin plugin)
         {
-            if (ModCompatibility.IsJotunnOnServer())
+            if (ModCompatibility.IsModuleOnServer(plugin))
             {
                 return true;
             }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -492,7 +492,7 @@ namespace Jotunn.Managers
 
         /// <summary>
         ///     Checks if AdminOnly config entries should be locked based the AdminOnlyStrictness value for the plugin that the
-        ///     config file is attached to (including custom config files) and whether Jotunn is installed on the server or not.
+        ///     config file is attached to (including custom config files) and whether the plugin is installed on the server or not.
         /// </summary>
         /// <param name="config"></param>
         /// <returns></returns>
@@ -511,7 +511,7 @@ namespace Jotunn.Managers
 
         /// <summary>
         ///     Checks if AdminOnly config entries should be locked based the AdminOnlyStrictness value for the plugin
-        ///     and whether Jotunn is installed on the server or not.
+        ///     and whether the plugin is installed on the server or not.
         /// </summary>
         /// <param name="plugin"></param>
         /// <returns></returns>

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -525,6 +525,11 @@ namespace Jotunn.Managers
             {
                 return true;
             }
+
+            // Current behaviour is that AdminOnly config entries are always locked
+            // if Jotunn is not on the server. So if SynchronizationModeAttribute has
+            // not been set for the mod then return true to mimic current behaviour and 
+            // maintain backwards compatibility.
             SynchronizationModeAttribute syncMode = plugin.GetSynchronizationModeAttribute();
             if (syncMode == null || syncMode.ShouldAlwaysEnforceAdminOnly())
             {

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -622,6 +622,11 @@ namespace Jotunn.Managers
         {
             foreach (var config in GetConfigFiles())
             {
+                if (!ShouldManageConfig(config))
+                {
+                    continue;
+                }
+
                 foreach (var configDefinition in config.Keys)
                 {
                     var configEntry = config[configDefinition.Section, configDefinition.Key];

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -217,20 +217,28 @@ namespace Jotunn.Utils
                 return true;
             }
 
-            bool result = true;
+            // Check for compatible ModModule data layout versions
+            if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
+            {
+                Logger.LogWarning("Jotunn version on server and client are not compatible.");
+                return false;
+            }
 
             // Check for supported ModModule data layout
+            // might be able to get read of this check as it
+            // would only ever trigger if both server and client had ModModuleDataLayout == -1
             if (!clientData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on client is higher than server version: {Main.Version}");
-                result = false;
+                return false;
             }
-
             if (!serverData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on server is higher than client version: {Main.Version}");
-                result = false;
-            }   
+                return false;
+            }
+
+            bool result = true;
 
             // Check server enforced mods
             foreach (var serverModule in FindNotInstalledMods(serverData, clientData))

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BepInEx;
 using HarmonyLib;
 using Jotunn.Extensions;
 using Jotunn.Managers;
@@ -34,6 +35,12 @@ namespace Jotunn.Utils
         public static bool IsJotunnOnServer()
         {
             return IsModuleOnServer(Main.ModGuid);
+        }
+
+
+        public static bool IsModuleOnServer(BaseUnityPlugin plugin)
+        {
+            return IsModuleOnServer(plugin.Info.Metadata.GUID);
         }
 
         public static bool IsModuleOnServer(string modGUID)

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -324,13 +324,30 @@ namespace Jotunn.Utils
         /// <returns></returns>
         private static string CreateErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
         {
-            return CreateVanillaVersionErrorMessage(serverData, clientData) +
+        
+            return CreateModModuleLayoutErrorMessage(serverData, clientData)+
+                   CreateVanillaVersionErrorMessage(serverData, clientData) +
                    CreateNotInstalledErrorMessage(serverData, clientData) +
                    CreateLowerVersionErrorMessage(serverData, clientData) +
                    CreateHigherVersionErrorMessage(serverData, clientData) +
                    CreateAdditionalModsErrorMessage(serverData, clientData) +
                    CreateFurtherStepsMessage();
         }
+
+        private static string CreateModModuleLayoutErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
+        {
+            if (!clientData.IsSupportedDataLayout)
+            {
+                return ColoredLine(Color.red, $"Jotunn version on client is higher than server version: {Main.Version}");
+            }
+            if (!serverData.IsSupportedDataLayout)
+            {
+                return ColoredLine(Color.red, $"Jotunn version on server is higher than client version: {Main.Version}");
+            }
+            
+            return string.Empty;
+        }
+
 
         private static string CreateVanillaVersionErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
         {

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -256,7 +256,7 @@ namespace Jotunn.Utils
             // Check versions
             foreach (var serverModule in FindLowerVersionMods(serverData, clientData).Union(FindHigherVersionMods(serverData, clientData)))
             {
-                var clientModule = clientData.FindModule(serverModule.ModID);
+                var clientModule = clientData.FindModule(serverModule);
                 Logger.LogWarning($"Mod version mismatch {serverModule.ModName}: Server {serverModule.Version}, Client {clientModule.Version}");
                 result = false;
             }
@@ -515,7 +515,7 @@ namespace Jotunn.Utils
         {
             foreach (ModModule baseModule in baseModules.Modules)
             {
-                ModModule additionalModule = additionalModules.FindModule(baseModule.ModID);
+                ModModule additionalModule = additionalModules.FindModule(baseModule);
 
                 if (predicate(baseModule, additionalModule))
                 {

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -195,6 +195,18 @@ namespace Jotunn.Utils
 
             bool result = true;
 
+            // Check for supported ModModule data layout
+            if (!clientData.IsSupportedDataLayout)
+            {
+                Logger.LogWarning($"Jotunn version on client is higher than server version: {Main.Version}");
+                result = false;
+            }
+            if (!serverData.IsSupportedDataLayout)
+            {
+                Logger.LogWarning($"Jotunn version on server is higher than client version: {Main.Version}");
+                result = false;
+            }   
+
             // Check server enforced mods
             foreach (var serverModule in FindNotInstalledMods(serverData, clientData))
             {

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -217,13 +217,6 @@ namespace Jotunn.Utils
                 return true;
             }
 
-            // Check for compatible ModModule data layout versions
-            //if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
-            //{
-            //    Logger.LogWarning("Jotunn versions on server and client are not compatible.");
-            //    return false;
-            //}
-
             bool result = true;
 
             // Check for supported ModModule data layout
@@ -349,14 +342,6 @@ namespace Jotunn.Utils
         /// <returns></returns>
         private static string CreateErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
         {
-            //string dataLayoutErrMsg = CreateModModuleLayoutErrorMessage(serverData, clientData);
-            //if (!string.IsNullOrEmpty(dataLayoutErrMsg))
-            //{
-            //    return CreateVanillaVersionErrorMessage(serverData, clientData) +
-            //           dataLayoutErrMsg +
-            //           CreateFurtherStepsMessage();
-            //}
-
             return CreateVanillaVersionErrorMessage(serverData, clientData) +
                    CreateNotInstalledErrorMessage(serverData, clientData) +
                    CreateLowerVersionErrorMessage(serverData, clientData) +

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -35,7 +35,13 @@ namespace Jotunn.Utils
         {
             if (ZNet.instance && ZNet.instance.IsClientInstance())
             {
-                return LastServerVersion != null;
+                if (LastServerVersion == null)
+                {
+                    return false;
+                }
+                var serverData = new ModuleVersionData(LastServerVersion);
+                var moduleNames = new HashSet<string>(serverData.Modules.Select(mod => mod.name).ToList());
+                return moduleNames.Contains(modGUID);
             }
             return true;
         }

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using HarmonyLib;
+using Jotunn.Extensions;
 using Jotunn.Managers;
 using UnityEngine;
 using UnityEngine.UI;
@@ -439,10 +440,7 @@ namespace Jotunn.Utils
         {
             foreach (var plugin in BepInExUtils.GetDependentPlugins(true).OrderBy(x => x.Key))
             {
-                var networkCompatibilityAttribute = plugin.Value.GetType()
-                    .GetCustomAttributes(typeof(NetworkCompatibilityAttribute), true)
-                    .Cast<NetworkCompatibilityAttribute>()
-                    .FirstOrDefault();
+                var networkCompatibilityAttribute = plugin.Value.GetNetworkCompatibilityAttribute();
 
                 if (networkCompatibilityAttribute != null)
                 {

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -245,10 +245,12 @@ namespace Jotunn.Utils
                 result = false;
             }
 
+            bool legacyDataLayout = Mathf.Min(serverData.ModModuleDataLayout, clientData.ModModuleDataLayout) == ModModule.LegacyDataLayoutVersion;
+
             // Check versions
             foreach (var serverModule in FindLowerVersionMods(serverData, clientData).Union(FindHigherVersionMods(serverData, clientData)))
             {
-                var clientModule = clientData.FindModule(serverModule);
+                var clientModule = clientData.FindModule(serverModule, legacyDataLayout);
                 Logger.LogWarning($"Mod version mismatch {serverModule.ModName}: Server {serverModule.Version}, Client {clientModule.Version}");
                 result = false;
             }
@@ -497,9 +499,11 @@ namespace Jotunn.Utils
 
         private static IEnumerable<ModModule> FindMods(ModuleVersionData baseModules, ModuleVersionData additionalModules, Func<ModModule, ModModule, bool> predicate)
         {
+            bool legacyDataLayout = Mathf.Min(baseModules.ModModuleDataLayout, additionalModules.ModModuleDataLayout) == ModModule.LegacyDataLayoutVersion;
+
             foreach (ModModule baseModule in baseModules.Modules)
             {
-                ModModule additionalModule = additionalModules.FindModule(baseModule);
+                ModModule additionalModule = additionalModules.FindModule(baseModule, legacyDataLayout);
 
                 if (predicate(baseModule, additionalModule))
                 {

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -217,24 +217,23 @@ namespace Jotunn.Utils
                 return true;
             }
 
-            // Check for compatible ModModule data layout versions
-            if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
-            {
-                Logger.LogWarning("Jotunn version on server and client are not compatible.");
-                return false;
-            }
-
             // Check for supported ModModule data layout
-            // might be able to get read of this check as it
-            // would only ever trigger if both server and client had ModModuleDataLayout == -1
             if (!clientData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on client is higher than server version: {Main.Version}");
                 return false;
             }
+
             if (!serverData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on server is higher than client version: {Main.Version}");
+                return false;
+            }
+
+            // Check for compatible ModModule data layout versions
+            if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
+            {
+                Logger.LogWarning("Jotunn versions on server and client are not compatible.");
                 return false;
             }
 

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -51,6 +51,8 @@ namespace Jotunn.Utils
                 {
                     return false;
                 }
+                // maybe the HashSet of Module GUIDs should be cached along with LastServerVersion
+                // and reset along with it to, just to avoid construction of the HashSet
                 var serverData = new ModuleVersionData(LastServerVersion);
                 var moduleGUIDs = new HashSet<string>(serverData.Modules.Select(mod => mod.guid).ToList());
                 return moduleGUIDs.Contains(modGUID);

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -217,27 +217,26 @@ namespace Jotunn.Utils
                 return true;
             }
 
+            // Check for compatible ModModule data layout versions
+            //if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
+            //{
+            //    Logger.LogWarning("Jotunn versions on server and client are not compatible.");
+            //    return false;
+            //}
+
+            bool result = true;
+
             // Check for supported ModModule data layout
             if (!clientData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on client is higher than server version: {Main.Version}");
-                return false;
+                result = false;
             }
-
             if (!serverData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on server is higher than client version: {Main.Version}");
-                return false;
+                result = false;
             }
-
-            // Check for compatible ModModule data layout versions
-            if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
-            {
-                Logger.LogWarning("Jotunn versions on server and client are not compatible.");
-                return false;
-            }
-
-            bool result = true;
 
             // Check server enforced mods
             foreach (var serverModule in FindNotInstalledMods(serverData, clientData))
@@ -350,13 +349,13 @@ namespace Jotunn.Utils
         /// <returns></returns>
         private static string CreateErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
         {
-            string dataLayoutErrMsg = CreateModModuleLayoutErrorMessage(serverData, clientData);
-            if (!string.IsNullOrEmpty(dataLayoutErrMsg))
-            {
-                return CreateVanillaVersionErrorMessage(serverData, clientData) +
-                       dataLayoutErrMsg +
-                       CreateFurtherStepsMessage();
-            }
+            //string dataLayoutErrMsg = CreateModModuleLayoutErrorMessage(serverData, clientData);
+            //if (!string.IsNullOrEmpty(dataLayoutErrMsg))
+            //{
+            //    return CreateVanillaVersionErrorMessage(serverData, clientData) +
+            //           dataLayoutErrMsg +
+            //           CreateFurtherStepsMessage();
+            //}
 
             return CreateVanillaVersionErrorMessage(serverData, clientData) +
                    CreateNotInstalledErrorMessage(serverData, clientData) +

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -52,7 +52,7 @@ namespace Jotunn.Utils
                     return false;
                 }
                 var serverData = new ModuleVersionData(LastServerVersion);
-                var moduleNames = new HashSet<string>(serverData.Modules.Select(mod => mod.name).ToList());
+                var moduleNames = new HashSet<string>(serverData.Modules.Select(mod => mod.guid).ToList());
                 return moduleNames.Contains(modGUID);
             }
             return true;

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -33,6 +33,11 @@ namespace Jotunn.Utils
 
         public static bool IsJotunnOnServer()
         {
+            return IsModuleOnServer(Main.ModGuid);
+        }
+
+        public static bool IsModuleOnServer(string modGUID)
+        {
             if (ZNet.instance && ZNet.instance.IsClientInstance())
             {
                 if (LastServerVersion == null)

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -52,8 +52,8 @@ namespace Jotunn.Utils
                     return false;
                 }
                 var serverData = new ModuleVersionData(LastServerVersion);
-                var moduleNames = new HashSet<string>(serverData.Modules.Select(mod => mod.guid).ToList());
-                return moduleNames.Contains(modGUID);
+                var moduleGUIDs = new HashSet<string>(serverData.Modules.Select(mod => mod.guid).ToList());
+                return moduleGUIDs.Contains(modGUID);
             }
             return true;
         }

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -30,6 +30,15 @@ namespace Jotunn.Utils
             Main.Harmony.PatchAll(typeof(ModCompatibility));
         }
 
+        public static bool IsJotunnOnServer()
+        {
+            if (ZNet.instance && ZNet.instance.IsClientInstance())
+            {
+                return LastServerVersion != null;
+            }
+            return true;
+        }
+       
         [HarmonyPatch(typeof(ZNet), nameof(ZNet.OnNewConnection)), HarmonyPrefix, HarmonyPriority(Priority.First)]
         private static void ZNet_OnNewConnection(ZNet __instance, ZNetPeer peer)
         {

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -185,7 +185,13 @@ namespace Jotunn.Utils
                 LastServerVersionData = new ServerVersionData(data);
             }
         }
-
+        
+        /// <summary>
+        ///     Compares version data on server and client.
+        /// </summary>
+        /// <param name="serverData"></param>
+        /// <param name="clientData"></param>
+        /// <returns></returns>
         internal static bool CompareVersionData(ModuleVersionData serverData, ModuleVersionData clientData)
         {
             if (ReferenceEquals(serverData, clientData))

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using BepInEx;
 using HarmonyLib;
 using Jotunn.Extensions;
@@ -22,7 +20,6 @@ namespace Jotunn.Utils
         /// <summary>
         ///     Stores the last server message.
         /// </summary>
-        //private static ZPackage LastServerVersion;
         private static ServerVersionData LastServerVersionData = new ServerVersionData();
 
         private static readonly Dictionary<string, ZPackage> ClientVersions = new Dictionary<string, ZPackage>();
@@ -38,7 +35,6 @@ namespace Jotunn.Utils
             return IsModuleOnServer(Main.ModGuid);
         }
 
-
         public static bool IsModuleOnServer(BaseUnityPlugin plugin)
         {
             return IsModuleOnServer(plugin.Info.Metadata.GUID);
@@ -48,16 +44,12 @@ namespace Jotunn.Utils
         {
             if (ZNet.instance && ZNet.instance.IsClientInstance())
             {
-                if (LastServerVersionData.IsValid())
-                {
-                    return LastServerVersionData.moduleGUIDs.Contains(modGUID);
-                }
-                return false;
-
+                return LastServerVersionData.IsValid() && LastServerVersionData.moduleGUIDs.Contains(modGUID);
             }
+
             return true;
         }
-       
+
         [HarmonyPatch(typeof(ZNet), nameof(ZNet.OnNewConnection)), HarmonyPrefix, HarmonyPriority(Priority.First)]
         private static void ZNet_OnNewConnection(ZNet __instance, ZNetPeer peer)
         {
@@ -207,6 +199,7 @@ namespace Jotunn.Utils
                 Logger.LogWarning($"Jotunn version on client is higher than server version: {Main.Version}");
                 result = false;
             }
+
             if (!serverData.IsSupportedDataLayout)
             {
                 Logger.LogWarning($"Jotunn version on server is higher than client version: {Main.Version}");
@@ -340,11 +333,12 @@ namespace Jotunn.Utils
             {
                 return ColoredLine(Color.red, $"Jotunn version on client is higher than server version: {Main.Version}");
             }
+
             if (!serverData.IsSupportedDataLayout)
             {
                 return ColoredLine(Color.red, $"Jotunn version on server is higher than client version: {Main.Version}");
             }
-            
+
             return string.Empty;
         }
 

--- a/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModCompatibility.cs
@@ -350,9 +350,15 @@ namespace Jotunn.Utils
         /// <returns></returns>
         private static string CreateErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
         {
-        
-            return CreateModModuleLayoutErrorMessage(serverData, clientData)+
-                   CreateVanillaVersionErrorMessage(serverData, clientData) +
+            string dataLayoutErrMsg = CreateModModuleLayoutErrorMessage(serverData, clientData);
+            if (!string.IsNullOrEmpty(dataLayoutErrMsg))
+            {
+                return CreateVanillaVersionErrorMessage(serverData, clientData) +
+                       dataLayoutErrMsg +
+                       CreateFurtherStepsMessage();
+            }
+
+            return CreateVanillaVersionErrorMessage(serverData, clientData) +
                    CreateNotInstalledErrorMessage(serverData, clientData) +
                    CreateLowerVersionErrorMessage(serverData, clientData) +
                    CreateHigherVersionErrorMessage(serverData, clientData) +
@@ -362,6 +368,7 @@ namespace Jotunn.Utils
 
         private static string CreateModModuleLayoutErrorMessage(ModuleVersionData serverData, ModuleVersionData clientData)
         {
+
             if (!clientData.IsSupportedDataLayout)
             {
                 return ColoredLine(Color.red, $"Jotunn version on client is higher than server version: {Main.Version}");
@@ -370,6 +377,11 @@ namespace Jotunn.Utils
             if (!serverData.IsSupportedDataLayout)
             {
                 return ColoredLine(Color.red, $"Jotunn version on server is higher than client version: {Main.Version}");
+            }
+
+            if (serverData.ModModuleDataLayout != clientData.ModModuleDataLayout)
+            {
+                return ColoredLine(Color.red, "Jotunn versions on server and client are not compatible.");
             }
 
             return string.Empty;

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -27,7 +27,7 @@ namespace Jotunn.Utils
             get
             {
                 return DataLayoutVersion == LegacyDataLayoutVersion ? ModName : guid;
-            }   
+            }
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Jotunn.Utils
                 VersionStrictness = (VersionStrictness)pkg.ReadInt();
                 return;
             }
-        
+
             // Handle deserialization based on dataLayoutVersion
             DataLayoutVersion = pkg.ReadInt();
 
@@ -105,7 +105,7 @@ namespace Jotunn.Utils
                 Version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
                 CompatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
                 VersionStrictness = (VersionStrictness)pkg.ReadInt();
-            }            
+            }
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx;
+using Jotunn.Extensions;
 
 namespace Jotunn.Utils
 {
@@ -46,26 +48,35 @@ namespace Jotunn.Utils
         
             // Handle deserialization based on dataLayoutVersion
             dataLayoutVersion = pkg.ReadInt();
-            switch (dataLayoutVersion)
+
+            if (!this.IsSupportedDataLayout())
             {
-                case 1:
-                    guid = pkg.ReadString();
-                    name = pkg.ReadString();
-                    int major = pkg.ReadInt();
-                    int minor = pkg.ReadInt();
-                    int build = pkg.ReadInt();
-                    version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
-                    compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
-                    versionStrictness = (VersionStrictness)pkg.ReadInt();
-                    break;
-                default:
-                    // This is a dataLayoutVersion that this version of Jotunn does not know how to handle.
-                    // Which means that data from a newer version of Jotunn has been received.
-                    // Currently unsure how best to handle this for backwards compatibility. 
-                    // This implementation simply leaves everything except for dataLayoutVersion as null.
-                    break;
-            }               
-            
+                // This is a dataLayoutVersion that this version of Jotunn does not know how to handle.
+                // Which means that data from a newer version of Jotunn has been received and everything
+                // except dataLayoutVersion will be left as null.
+
+                // Populate current layout of ModModule with a fake newer version of Jotunn that will trigger an error.
+                //guid = Main.ModGuid;
+                //name = "Unknown. Jotunn is not the same version on client and server.";
+                //var verNums = Array.ConvertAll(Main.Version.Split('.'), int.Parse);
+                //version = new System.Version(verNums[0], verNums[1], verNums[2] + 1);
+                //var netWorkCompat = Main.Instance.GetNetworkCompatibilityAttribute();
+                //compatibilityLevel = netWorkCompat.EnforceModOnClients;
+                //versionStrictness = netWorkCompat.EnforceSameVersion;
+                return;
+            }
+
+            if (dataLayoutVersion == 1)
+            {
+                guid = pkg.ReadString();
+                name = pkg.ReadString();
+                int major = pkg.ReadInt();
+                int minor = pkg.ReadInt();
+                int build = pkg.ReadInt();
+                version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
+                compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
+                versionStrictness = (VersionStrictness)pkg.ReadInt();
+            }            
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -7,6 +7,7 @@ namespace Jotunn.Utils
     internal class ModModule
     {
         public const int CurrentDataLayoutVersion = 1;
+        public readonly HashSet<int> SupportedDataLayouts = new HashSet<int>(Enumerable.Range(1, CurrentDataLayoutVersion));
 
         /// <summary>
         ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to -1 then it is a legacy format.
@@ -163,6 +164,15 @@ namespace Jotunn.Utils
 #pragma warning disable CS0618 // Type or member is obsolete
             return compatibilityLevel == CompatibilityLevel.OnlySyncWhenInstalled || compatibilityLevel == CompatibilityLevel.VersionCheckOnly;
 #pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        /// <summary>
+        ///     Module is formatted as in one of the supported data layout versions.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsSupportedDataLayout()
+        {
+            return SupportedDataLayouts.Contains(dataLayoutVersion);
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -25,16 +25,43 @@ namespace Jotunn.Utils
             this.versionStrictness = versionStrictness;
         }
 
-        public ModModule(ZPackage pkg)
+        public ModModule(ZPackage pkg, bool legacy)
         {
-            guid = pkg.ReadString();
-            name = pkg.ReadString();
-            int major = pkg.ReadInt();
-            int minor = pkg.ReadInt();
-            int build = pkg.ReadInt();
-            version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
-            compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
-            versionStrictness = (VersionStrictness)pkg.ReadInt();
+            if (legacy)
+            {
+                dataLayoutVersion = -1;
+                int major = pkg.ReadInt();
+                int minor = pkg.ReadInt();
+                int build = pkg.ReadInt();
+                version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
+                compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
+                versionStrictness = (VersionStrictness)pkg.ReadInt();
+                return;
+            }
+            else
+            {
+                dataLayoutVersion = pkg.ReadInt();
+               
+                switch (dataLayoutVersion)
+                {
+                    case 1:
+                        break;
+                    default:
+                        // This is a dataLayoutVersion that this version of Jotunn does not know how to handle.
+                        // Which means that data from a newer version of Jotunn has been recieved.
+                }
+                   
+                        
+                // do stuff based on dataLayoutVersion
+                guid = pkg.ReadString();
+                name = pkg.ReadString();
+                int major = pkg.ReadInt();
+                int minor = pkg.ReadInt();
+                int build = pkg.ReadInt();
+                version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
+                compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
+                versionStrictness = (VersionStrictness)pkg.ReadInt();
+            }
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -7,7 +7,7 @@ namespace Jotunn.Utils
     internal class ModModule
     {
         public const int CurrentDataLayoutVersion = 1;
-        public readonly HashSet<int> SupportedDataLayouts = new HashSet<int>(Enumerable.Range(1, CurrentDataLayoutVersion));
+        public static readonly HashSet<int> SupportedDataLayouts = new HashSet<int>(Enumerable.Range(1, CurrentDataLayoutVersion));
 
         /// <summary>
         ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to -1 then it is a legacy format.

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -50,6 +50,17 @@ namespace Jotunn.Utils
         /// </summary>
         public VersionStrictness VersionStrictness { get; }
 
+        /// <summary>
+        ///     Whether the data layout is a legacy format or not.
+        /// </summary>
+        public bool IsLegacyDataLayout
+        {
+            get
+            {
+                return CurrentDataLayoutVersion == LegacyDataLayoutVersion;
+            }
+        }
+
         public ModModule(string guid, string name, System.Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness)
         {
             this.DataLayoutVersion = CurrentDataLayoutVersion;

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -168,7 +168,8 @@ namespace Jotunn.Utils
         }
 
         /// <summary>
-        ///     Module is formatted as in one of the supported data layout versions.
+        ///     Module is formatted as in one of the supported data layout versions. 
+        ///     Should return false is data was received from a newer version of Jotunn.
         /// </summary>
         /// <returns></returns>
         public bool IsSupportedDataLayout()

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -4,13 +4,15 @@ namespace Jotunn.Utils
 {
     internal class ModModule
     {
+        public string guid;
         public string name;
         public System.Version version;
         public CompatibilityLevel compatibilityLevel;
         public VersionStrictness versionStrictness;
 
-        public ModModule(string name, System.Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness)
+        public ModModule(string guid, string name, System.Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness)
         {
+            this.guid = guid;
             this.name = name;
             this.version = version;
             this.compatibilityLevel = compatibilityLevel;
@@ -19,6 +21,7 @@ namespace Jotunn.Utils
 
         public ModModule(ZPackage pkg)
         {
+            guid = pkg.ReadString();
             name = pkg.ReadString();
             int major = pkg.ReadInt();
             int minor = pkg.ReadInt();
@@ -30,6 +33,7 @@ namespace Jotunn.Utils
 
         public void WriteToPackage(ZPackage pkg)
         {
+            pkg.Write(guid);
             pkg.Write(name);
             pkg.Write(version.Major);
             pkg.Write(version.Minor);
@@ -40,6 +44,7 @@ namespace Jotunn.Utils
 
         public ModModule(BepInPlugin plugin, NetworkCompatibilityAttribute networkAttribute)
         {
+            this.guid = plugin.GUID;
             this.name = plugin.Name;
             this.version = plugin.Version;
             this.compatibilityLevel = networkAttribute.EnforceModOnClients;
@@ -48,6 +53,7 @@ namespace Jotunn.Utils
 
         public ModModule(BepInPlugin plugin)
         {
+            this.guid = plugin.GUID;
             this.name = plugin.Name;
             this.version = plugin.Version;
             this.compatibilityLevel = CompatibilityLevel.NotEnforced;

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -51,19 +51,8 @@ namespace Jotunn.Utils
 
             if (!this.IsSupportedDataLayout())
             {
-                // This is a dataLayoutVersion that this version of Jotunn does not know how to handle.
-                // Which means that data from a newer version of Jotunn has been received and everything
-                // except dataLayoutVersion will be left as null.
-
-                // Populate current layout of ModModule with a fake newer version of Jotunn that will trigger an error.
-                //guid = Main.ModGuid;
-                //name = "Unknown. Jotunn is not the same version on client and server.";
-                //var verNums = Array.ConvertAll(Main.Version.Split('.'), int.Parse);
-                //version = new System.Version(verNums[0], verNums[1], verNums[2] + 1);
-                //var netWorkCompat = Main.Instance.GetNetworkCompatibilityAttribute();
-                //compatibilityLevel = netWorkCompat.EnforceModOnClients;
-                //versionStrictness = netWorkCompat.EnforceSameVersion;
-                return;
+                // Data from a newer version of Jotunn has been received and cannot be read.
+                throw new NotSupportedException($"{dataLayoutVersion} is not a supported data layout version.");
             }
 
             if (dataLayoutVersion == 1)

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -4,6 +4,12 @@ namespace Jotunn.Utils
 {
     internal class ModModule
     {
+        public const int DataLayoutVersion = 1;
+
+        /// <summary>
+        ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to -1 then it is a legacy format.
+        /// </summary>
+        public int dataLayoutVersion;
         public string guid;
         public string name;
         public System.Version version;

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -22,6 +22,7 @@ namespace Jotunn.Utils
 
         public ModModule(string guid, string name, System.Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness)
         {
+            this.dataLayoutVersion = CurrentDataLayoutVersion;
             this.guid = guid;
             this.name = name;
             this.version = version;

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -1,4 +1,6 @@
-﻿using BepInEx;
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx;
 
 namespace Jotunn.Utils
 {
@@ -38,30 +40,29 @@ namespace Jotunn.Utils
                 versionStrictness = (VersionStrictness)pkg.ReadInt();
                 return;
             }
-            else
+        
+            // Handle deserialization based on dataLayoutVersion
+            dataLayoutVersion = pkg.ReadInt();
+            switch (dataLayoutVersion)
             {
-                dataLayoutVersion = pkg.ReadInt();
-               
-                switch (dataLayoutVersion)
-                {
-                    case 1:
-                        break;
-                    default:
-                        // This is a dataLayoutVersion that this version of Jotunn does not know how to handle.
-                        // Which means that data from a newer version of Jotunn has been recieved.
-                }
-                   
-                        
-                // do stuff based on dataLayoutVersion
-                guid = pkg.ReadString();
-                name = pkg.ReadString();
-                int major = pkg.ReadInt();
-                int minor = pkg.ReadInt();
-                int build = pkg.ReadInt();
-                version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
-                compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
-                versionStrictness = (VersionStrictness)pkg.ReadInt();
-            }
+                case 1:
+                    guid = pkg.ReadString();
+                    name = pkg.ReadString();
+                    int major = pkg.ReadInt();
+                    int minor = pkg.ReadInt();
+                    int build = pkg.ReadInt();
+                    version = build >= 0 ? new System.Version(major, minor, build) : new System.Version(major, minor);
+                    compatibilityLevel = (CompatibilityLevel)pkg.ReadInt();
+                    versionStrictness = (VersionStrictness)pkg.ReadInt();
+                    break;
+                default:
+                    // This is a dataLayoutVersion that this version of Jotunn does not know how to handle.
+                    // Which means that data from a newer version of Jotunn has been received.
+                    // Currently unsure how best to handle this for backwards compatibility. 
+                    // This implementation simply leaves everything except for dataLayoutVersion as null.
+                    break;
+            }               
+            
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -37,8 +37,25 @@ namespace Jotunn.Utils
             versionStrictness = (VersionStrictness)pkg.ReadInt();
         }
 
-        public void WriteToPackage(ZPackage pkg)
+        /// <summary>
+        ///     Write to ZPkg
+        /// </summary>
+        /// <param name="pkg"></param>
+        /// <param name="legacy"></param>
+        public void WriteToPackage(ZPackage pkg, bool legacy)
         {
+            if (legacy)
+            {
+                pkg.Write(name);
+                pkg.Write(version.Major);
+                pkg.Write(version.Minor);
+                pkg.Write(version.Build);
+                pkg.Write((int)compatibilityLevel);
+                pkg.Write((int)versionStrictness);
+                return;
+            }
+
+            pkg.Write(dataLayoutVersion);
             pkg.Write(guid);
             pkg.Write(name);
             pkg.Write(version.Major);

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -9,7 +9,7 @@ namespace Jotunn.Utils
     {
         public const int LegacyDataLayoutVersion = 0;
         public const int CurrentDataLayoutVersion = 1;
-        public static readonly HashSet<int> SupportedDataLayouts = new HashSet<int>(Enumerable.Range(LegacyDataLayoutVersion, CurrentDataLayoutVersion));
+        public static readonly HashSet<int> SupportedDataLayouts = new HashSet<int> { LegacyDataLayoutVersion, CurrentDataLayoutVersion };
 
         /// <summary>
         ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to 0 then it is a legacy format.
@@ -65,6 +65,7 @@ namespace Jotunn.Utils
             if (legacy)
             {
                 DataLayoutVersion = LegacyDataLayoutVersion;
+                ModName = pkg.ReadString();
                 int major = pkg.ReadInt();
                 int minor = pkg.ReadInt();
                 int build = pkg.ReadInt();

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -50,6 +50,7 @@ namespace Jotunn.Utils
 
         public ModModule(BepInPlugin plugin, NetworkCompatibilityAttribute networkAttribute)
         {
+            this.dataLayoutVersion = CurrentDataLayoutVersion;
             this.guid = plugin.GUID;
             this.name = plugin.Name;
             this.version = plugin.Version;
@@ -59,6 +60,7 @@ namespace Jotunn.Utils
 
         public ModModule(BepInPlugin plugin)
         {
+            this.dataLayoutVersion = CurrentDataLayoutVersion;
             this.guid = plugin.GUID;
             this.name = plugin.Name;
             this.version = plugin.Version;

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -15,16 +15,50 @@ namespace Jotunn.Utils
         /// <summary>
         ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to 0 then it is a legacy format.
         /// </summary>
-        public int dataLayoutVersion;
-        public string guid;
-        public string name;
-        public System.Version version;
-        public CompatibilityLevel compatibilityLevel;
-        public VersionStrictness versionStrictness;
+        public int DataLayoutVersion { get; private set; }
 
+        private string guid;
+        private string name;
+        private System.Version version;
+        private CompatibilityLevel compatibilityLevel;
+        private VersionStrictness versionStrictness;
+
+        /// <summary>
+        ///     Identifier for mod based on DataLayoutVersion. 
+        ///     For legacy layout returns mod name, otherwise returns mod GUID. 
+        /// </summary>
+        public string ModID
+        {
+            get
+            {
+                return DataLayoutVersion == LegacyDataLayoutVersion ? name : guid;
+            }   
+        }
+
+        /// <summary>
+        ///     Friendly version of mod name.
+        /// </summary>
+        public string ModName { get { return name; } }
+
+        /// <summary>
+        ///     Version data for mod.
+        /// </summary>
+        public System.Version Version { get { return version; } }
+
+        /// <summary>
+        ///     Compatibility level of the mod.
+        /// </summary>
+        public CompatibilityLevel CompatibilityLevel { get { return compatibilityLevel; } }
+
+        /// <summary>
+        ///     Version strictness level of the mod.
+        /// </summary>
+        public VersionStrictness VersionStrictness { get { return VersionStrictness; } }
+
+        
         public ModModule(string guid, string name, System.Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness)
         {
-            this.dataLayoutVersion = CurrentDataLayoutVersion;
+            this.DataLayoutVersion = CurrentDataLayoutVersion;
             this.guid = guid;
             this.name = name;
             this.version = version;
@@ -36,7 +70,7 @@ namespace Jotunn.Utils
         {
             if (legacy)
             {
-                dataLayoutVersion = LegacyDataLayoutVersion;
+                DataLayoutVersion = LegacyDataLayoutVersion;
                 int major = pkg.ReadInt();
                 int minor = pkg.ReadInt();
                 int build = pkg.ReadInt();
@@ -47,15 +81,15 @@ namespace Jotunn.Utils
             }
         
             // Handle deserialization based on dataLayoutVersion
-            dataLayoutVersion = pkg.ReadInt();
+            DataLayoutVersion = pkg.ReadInt();
 
             if (!this.IsSupportedDataLayout())
             {
                 // Data from a newer version of Jotunn has been received and cannot be read.
-                throw new NotSupportedException($"{dataLayoutVersion} is not a supported data layout version.");
+                throw new NotSupportedException($"{DataLayoutVersion} is not a supported data layout version.");
             }
 
-            if (dataLayoutVersion == 1)
+            if (DataLayoutVersion == 1)
             {
                 guid = pkg.ReadString();
                 name = pkg.ReadString();
@@ -86,7 +120,7 @@ namespace Jotunn.Utils
                 return;
             }
 
-            pkg.Write(dataLayoutVersion);
+            pkg.Write(DataLayoutVersion);
             pkg.Write(guid);
             pkg.Write(name);
             pkg.Write(version.Major);
@@ -98,7 +132,7 @@ namespace Jotunn.Utils
 
         public ModModule(BepInPlugin plugin, NetworkCompatibilityAttribute networkAttribute)
         {
-            this.dataLayoutVersion = CurrentDataLayoutVersion;
+            this.DataLayoutVersion = CurrentDataLayoutVersion;
             this.guid = plugin.GUID;
             this.name = plugin.Name;
             this.version = plugin.Version;
@@ -108,7 +142,7 @@ namespace Jotunn.Utils
 
         public ModModule(BepInPlugin plugin)
         {
-            this.dataLayoutVersion = CurrentDataLayoutVersion;
+            this.DataLayoutVersion = CurrentDataLayoutVersion;
             this.guid = plugin.GUID;
             this.name = plugin.Name;
             this.version = plugin.Version;
@@ -175,7 +209,7 @@ namespace Jotunn.Utils
         /// <returns></returns>
         public bool IsSupportedDataLayout()
         {
-            return SupportedDataLayouts.Contains(dataLayoutVersion);
+            return SupportedDataLayouts.Contains(DataLayoutVersion);
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -4,7 +4,7 @@ namespace Jotunn.Utils
 {
     internal class ModModule
     {
-        public const int DataLayoutVersion = 1;
+        public const int CurrentDataLayoutVersion = 1;
 
         /// <summary>
         ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to -1 then it is a legacy format.

--- a/JotunnLib/Utils/ModCompatibility/ModModule.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModModule.cs
@@ -6,11 +6,12 @@ namespace Jotunn.Utils
 {
     internal class ModModule
     {
+        public const int LegacyDataLayoutVersion = 0;
         public const int CurrentDataLayoutVersion = 1;
-        public static readonly HashSet<int> SupportedDataLayouts = new HashSet<int>(Enumerable.Range(1, CurrentDataLayoutVersion));
+        public static readonly HashSet<int> SupportedDataLayouts = new HashSet<int>(Enumerable.Range(LegacyDataLayoutVersion, CurrentDataLayoutVersion));
 
         /// <summary>
-        ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to -1 then it is a legacy format.
+        ///     DataLayoutVersion indicates the version layout of data within the ZPkg. If equal to 0 then it is a legacy format.
         /// </summary>
         public int dataLayoutVersion;
         public string guid;
@@ -32,7 +33,7 @@ namespace Jotunn.Utils
         {
             if (legacy)
             {
-                dataLayoutVersion = -1;
+                dataLayoutVersion = LegacyDataLayoutVersion;
                 int major = pkg.ReadInt();
                 int minor = pkg.ReadInt();
                 int build = pkg.ReadInt();

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -211,22 +211,6 @@ namespace Jotunn.Utils
             return FindModule(name) != null;
         }
 
-        /// <summary>
-        ///     Checks if all ModModules are in a supported data layout.
-        /// </summary>
-        /// <returns></returns>
-        public bool IsSupportedDataLayout()
-        {
-            foreach (var mod in Modules) {
-            
-                if (!mod.IsSupportedDataLayout())
-                {
-                    return false;
-                } 
-            }
-            return true;
-        }
-
         private static string GetVersionString()
         {
             // ServerCharacters replaces the version string on the server but not client and does it's own checks afterwards

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -195,7 +195,7 @@ namespace Jotunn.Utils
 
             foreach (var mod in Modules)
             {
-                sb.AppendLine($"{mod.name} {mod.GetVersionString()}" + (showEnforce ? $" {mod.compatibilityLevel} {mod.versionStrictness}" : ""));
+                sb.AppendLine($"{mod.ModName} {mod.GetVersionString()}" + (showEnforce ? $" {mod.compatibilityLevel} {mod.versionStrictness}" : ""));
             }
 
             return sb.ToString();

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -96,11 +96,17 @@ namespace Jotunn.Utils
 
             foreach (var module in Modules)
             {
-                module.WriteToPackage(pkg);
+                module.WriteToPackage(pkg, legacy: true);
             }
 
             pkg.Write(VersionString);
             pkg.Write(NetworkVersion);
+
+            pkg.Write(Modules.Count);
+            foreach (var module in Modules)
+            {
+                module.WriteToPackage(pkg, legacy: false);
+            }
 
             return pkg;
         }

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -230,14 +230,19 @@ namespace Jotunn.Utils
             return sb.ToString();
         }
 
-        public ModModule FindModule(string modID)
+        public ModModule FindModule(ModModule modModule)
         {
-            return Modules.FirstOrDefault(x => x.ModID == modID);
+            if (this.IsLegacyDataLayout)
+            {
+                return Modules.FirstOrDefault(x => x.ModName == modModule.ModName);
+            }
+            return Modules.FirstOrDefault(x => x.ModID == modModule.ModID);
+
         }
 
-        public bool HasModule(string modID)
+        public bool HasModule(ModModule modModule)
         {
-            return FindModule(modID) != null;
+            return FindModule(modModule) != null;
         }
 
         private static string GetVersionString()

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -126,7 +126,7 @@ namespace Jotunn.Utils
                 if (Modules.Any(x => x.DataLayoutVersion != Modules.FirstOrDefault().DataLayoutVersion))
                 {
                     ModModuleDataLayout = -1;
-                    throw new NotSupportedException("DataVersionLayout is not the same of all ModModule instances. ModModuleDataLayout set to -1.");
+                    throw new NotSupportedException("DataVersionLayout is not the same for all ModModule instances. ModModuleDataLayout set to -1.");
                 }
                 ModModuleDataLayout = Modules.FirstOrDefault().DataLayoutVersion;
                 

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -26,6 +26,14 @@ namespace Jotunn.Utils
 
         public int ModModuleDataLayout { get; private set; }
 
+        public bool IsLegacyDataLayout
+        {
+            get
+            {
+                return ModModuleDataLayout == ModModule.LegacyDataLayoutVersion;
+            }
+        }
+
 
         /// <summary>
         ///     Whether all the ModModule instances were formatted in a supported 

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -24,26 +24,20 @@ namespace Jotunn.Utils
 
         public uint NetworkVersion { get; internal set; }
 
-        private bool? isLegacyDataLayout;
         public int ModModuleDataLayout { get; private set; }
 
 
         /// <summary>
-        ///     Whether any of the ModModule instances in Modules use the legacy data layout.
+        ///     Whether all the ModModule instances were formatted in a supported 
+        ///     data layout and all instances had the same data layout. 
         /// </summary>
-        public bool IsLegacyDataLayout
+        public bool IsSupportedDataLayout
         {
             get
             {
-                isLegacyDataLayout ??= Modules.Where(x => x.IsLegacyDataLayout).Any();
-                return isLegacyDataLayout.Value;
+                return ModModule.SupportedDataLayouts.Contains(ModModuleDataLayout);
             }
-        } 
-
-        /// <summary>
-        ///     Whether all the ModModule instances were in a layout that can be deserialized. 
-        /// </summary>
-        public bool IsSupportedDataLayout { get; private set; } = true;
+        }
 
         /// <summary>
         ///     Create from module data

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -201,14 +201,14 @@ namespace Jotunn.Utils
             return sb.ToString();
         }
 
-        public ModModule FindModule(string name)
+        public ModModule FindModule(string modID)
         {
-            return Modules.FirstOrDefault(x => x.name == name);
+            return Modules.FirstOrDefault(x => x.ModID == modID);
         }
 
-        public bool HasModule(string name)
+        public bool HasModule(string modID)
         {
-            return FindModule(name) != null;
+            return FindModule(modID) != null;
         }
 
         private static string GetVersionString()

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -26,15 +26,6 @@ namespace Jotunn.Utils
 
         public int ModModuleDataLayout { get; private set; }
 
-        public bool IsLegacyDataLayout
-        {
-            get
-            {
-                return ModModuleDataLayout == ModModule.LegacyDataLayoutVersion;
-            }
-        }
-
-
         /// <summary>
         ///     Whether all the ModModule instances were formatted in a supported 
         ///     data layout and all instances had the same data layout. 
@@ -230,19 +221,19 @@ namespace Jotunn.Utils
             return sb.ToString();
         }
 
-        public ModModule FindModule(ModModule modModule)
+        public ModModule FindModule(ModModule modModule, bool legacyDataLayout)
         {
-            if (this.IsLegacyDataLayout)
+            if (legacyDataLayout)
             {
                 return Modules.FirstOrDefault(x => x.ModName == modModule.ModName);
             }
-            return Modules.FirstOrDefault(x => x.ModID == modModule.ModID);
 
+            return Modules.FirstOrDefault(x => x.ModID == modModule.ModID);
         }
 
-        public bool HasModule(ModModule modModule)
+        public bool HasModule(ModModule modModule, bool legacyDataLayout)
         {
-            return FindModule(modModule) != null;
+            return FindModule(modModule, legacyDataLayout) != null;
         }
 
         private static string GetVersionString()

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -166,7 +166,7 @@ namespace Jotunn.Utils
 
             foreach (var mod in Modules)
             {
-                sb.AppendLine($"{mod.name} {mod.GetVersionString()} {mod.compatibilityLevel} {mod.versionStrictness}");
+                sb.AppendLine($"{mod.ModName} {mod.GetVersionString()} {mod.CompatibilityLevel} {mod.VersionStrictness}");
             }
 
             return sb.ToString();
@@ -195,7 +195,7 @@ namespace Jotunn.Utils
 
             foreach (var mod in Modules)
             {
-                sb.AppendLine($"{mod.ModName} {mod.GetVersionString()}" + (showEnforce ? $" {mod.compatibilityLevel} {mod.versionStrictness}" : ""));
+                sb.AppendLine($"{mod.ModName} {mod.GetVersionString()}" + (showEnforce ? $" {mod.CompatibilityLevel} {mod.VersionStrictness}" : ""));
             }
 
             return sb.ToString();

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -196,6 +196,22 @@ namespace Jotunn.Utils
             return FindModule(name) != null;
         }
 
+        /// <summary>
+        ///     Checks if all ModModules are in a supported data layout.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsSupportedDataLayout()
+        {
+            foreach (var mod in Modules) {
+            
+                if (!mod.IsSupportedDataLayout())
+                {
+                    return false;
+                } 
+            }
+            return true;
+        }
+
         private static string GetVersionString()
         {
             // ServerCharacters replaces the version string on the server but not client and does it's own checks afterwards

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -24,6 +24,8 @@ namespace Jotunn.Utils
 
         public uint NetworkVersion { get; internal set; }
 
+        public bool IsSupportedDataLayout { get; private set; } = true;
+
         /// <summary>
         ///     Create from module data
         /// </summary>

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -56,12 +56,12 @@ namespace Jotunn.Utils
                 pkg.SetPos(0);
                 ValheimVersion = new System.Version(pkg.ReadInt(), pkg.ReadInt(), pkg.ReadInt());
 
-                var numberOfModules = pkg.ReadInt();
-
-                while (numberOfModules > 0)
+                // Read encoded ModModules in legacy format
+                var numberOfLegacyModules = pkg.ReadInt();
+                while (numberOfLegacyModules > 0)
                 {
-                    Modules.Add(new ModModule(pkg));
-                    numberOfModules--;
+                    Modules.Add(new ModModule(pkg, legacy: true));
+                    numberOfLegacyModules--;
                 }
 
                 if (pkg.m_reader.BaseStream.Position != pkg.m_reader.BaseStream.Length)

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -24,8 +24,22 @@ namespace Jotunn.Utils
 
         public uint NetworkVersion { get; internal set; }
 
+        private bool? isLegacyDataLayout;
+
         /// <summary>
-        ///     Flag indicating if the ModModule was in a layout that can be deserialized. 
+        ///     Whether any of the ModModule instances in Modules use the legacy data layout.
+        /// </summary>
+        public bool IsLegacyDataLayout
+        {
+            get
+            {
+                isLegacyDataLayout ??= Modules.Where(x => x.IsLegacyDataLayout).Any();
+                return isLegacyDataLayout.Value;
+            }
+        } 
+
+        /// <summary>
+        ///     Whether all the ModModule instances were in a layout that can be deserialized. 
         /// </summary>
         public bool IsSupportedDataLayout { get; private set; } = true;
 

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -49,6 +49,7 @@ namespace Jotunn.Utils
             VersionString = GetVersionString();
             NetworkVersion = GameVersions.NetworkVersion;
             Modules = new List<ModModule>(versionData);
+            ModModuleDataLayout = GetModModuleDataLayoutVersion(Modules);
         }
 
         internal ModuleVersionData(System.Version valheimVersion, List<ModModule> versionData)
@@ -57,6 +58,7 @@ namespace Jotunn.Utils
             VersionString = GetVersionString();
             NetworkVersion = GameVersions.NetworkVersion;
             Modules = new List<ModModule>(versionData);
+            ModModuleDataLayout = GetModModuleDataLayoutVersion(Modules);
         }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -73,6 +73,21 @@ namespace Jotunn.Utils
                 {
                     NetworkVersion = pkg.ReadUInt();
                 }
+
+
+                if (pkg.m_reader.BaseStream.Position != pkg.m_reader.BaseStream.Length)
+                {
+                    Modules.Clear(); // Discard legacy modules
+
+                    // Read and store the relevant ModModules
+                    var numberOfModules = pkg.ReadInt();
+                    while (numberOfModules > 0)
+                    {
+                        Modules.Add(new ModModule(pkg, legacy: false));
+                        numberOfModules--;
+                    }
+                }
+                
             }
             catch (Exception ex)
             {

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -74,7 +74,7 @@ namespace Jotunn.Utils
                     NetworkVersion = pkg.ReadUInt();
                 }
 
-
+                // Get current data layout ModModules if present
                 if (pkg.m_reader.BaseStream.Position != pkg.m_reader.BaseStream.Length)
                 {
                     Modules.Clear(); // Discard legacy modules

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -79,7 +79,7 @@ namespace Jotunn.Utils
                 // Get current data layout ModModules if present
                 if (pkg.m_reader.BaseStream.Position != pkg.m_reader.BaseStream.Length)
                 {
-                    Modules.Clear(); // Discard legacy modules
+                    var modModules = new List<ModModule>();
 
                     // Read and store the relevant ModModules
                     var numberOfModules = pkg.ReadInt();
@@ -88,7 +88,7 @@ namespace Jotunn.Utils
                         try
                         {
                             var modModule = new ModModule(pkg, legacy: false);
-                            Modules.Add(modModule);
+                            modModules.Add(modModule);
                             numberOfModules--;
                         }
                         catch (NotSupportedException ex)
@@ -101,6 +101,9 @@ namespace Jotunn.Utils
                             break;
                         }
                     }
+
+                    // overwrite Modules to replace legacy ModModule formatted data with current ModModule formatted data
+                    Modules = modModules;
                 }
                 
             }

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -24,6 +24,9 @@ namespace Jotunn.Utils
 
         public uint NetworkVersion { get; internal set; }
 
+        /// <summary>
+        ///     Flag indicating if the ModModule was in a layout that can be deserialized. 
+        /// </summary>
         public bool IsSupportedDataLayout { get; private set; } = true;
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -120,16 +120,8 @@ namespace Jotunn.Utils
 
                     // overwrite Modules to replace legacy ModModule formatted data with current ModModule formatted data
                     Modules = modModules;
-                }
-
-                // Handle tracking ModModule data layouts 
-                if (Modules.Any(x => x.DataLayoutVersion != Modules.FirstOrDefault().DataLayoutVersion))
-                {
-                    ModModuleDataLayout = -1;
-                    throw new NotSupportedException("DataVersionLayout is not the same for all ModModule instances. ModModuleDataLayout set to -1.");
-                }
-                ModModuleDataLayout = Modules.FirstOrDefault().DataLayoutVersion;
-                
+                    ModModuleDataLayout = GetModModuleDataLayoutVersion(Modules);
+                }               
             }
             catch (Exception ex)
             {
@@ -242,6 +234,16 @@ namespace Jotunn.Utils
         {
             // ServerCharacters replaces the version string on the server but not client and does it's own checks afterwards
             return Version.GetVersionString().Replace("-ServerCharacters", "");
+        }
+
+        private static int GetModModuleDataLayoutVersion(List<ModModule> modules)
+        {
+            // Handle tracking ModModule data layouts 
+            if (modules.Any(x => x.DataLayoutVersion != modules.FirstOrDefault().DataLayoutVersion))
+            {
+                throw new NotSupportedException("DataVersionLayout is not the same for all ModModule instances.");
+            }
+            return modules.FirstOrDefault().DataLayoutVersion;
         }
     }
 }

--- a/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ModuleVersionData.cs
@@ -85,8 +85,21 @@ namespace Jotunn.Utils
                     var numberOfModules = pkg.ReadInt();
                     while (numberOfModules > 0)
                     {
-                        Modules.Add(new ModModule(pkg, legacy: false));
-                        numberOfModules--;
+                        try
+                        {
+                            var modModule = new ModModule(pkg, legacy: false);
+                            Modules.Add(modModule);
+                            numberOfModules--;
+                        }
+                        catch (NotSupportedException ex)
+                        {
+                            this.IsSupportedDataLayout = false;
+                            Logger.LogError("Could not parse unsupported data layout from zPackage");
+                            Logger.LogError(ex.Message);
+
+                            // abort reading as the start of the next ModModule is unknown
+                            break;
+                        }
                     }
                 }
                 

--- a/JotunnLib/Utils/ModCompatibility/NetworkCompatibilityAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/NetworkCompatibilityAttribute.cs
@@ -14,27 +14,33 @@ namespace Jotunn.Utils
         /// </summary>
         [Obsolete("Use NotEnforced instead")]
         NoNeedForSync = 0,
+
         /// <summary>
         ///     Mod is checked only if the client and server have loaded it and ignores if just one side has it.
         /// </summary>
         [Obsolete("Use VersionCheckOnly")]
         OnlySyncWhenInstalled = 1,
+
         /// <summary>
         ///     Mod must be loaded on server and client. Version checking depends on the VersionStrictness.
         /// </summary>
         EveryoneMustHaveMod = 2,
+
         /// <summary>
         ///     If mod is installed on the server, every client has to have it. VersionStrictness does apply when both sides have it.
         /// </summary>
         ClientMustHaveMod = 3,
+
         /// <summary>
         ///     If mod is installed on the client, the server has to have it. VersionStrictness does apply when both sides have it.
         /// </summary>
         ServerMustHaveMod = 4,
+
         /// <summary>
         ///     Version check is performed when both server and client have the mod, no check if the mod is actually installed.
         /// </summary>
         VersionCheckOnly = 5,
+
         /// <summary>
         ///     Mod is not checked at all, VersionsStrictness does not apply.
         /// </summary>
@@ -51,14 +57,17 @@ namespace Jotunn.Utils
         ///     No version check is done
         /// </summary>
         None = 0,
+
         /// <summary>
         ///     Mod must have the same Major version
         /// </summary>
         Major = 1,
+
         /// <summary>
         ///     Mods must have the same Minor version
         /// </summary>
         Minor = 2,
+
         /// <summary>
         ///     Mods must have the same Patch version
         /// </summary>
@@ -66,16 +75,14 @@ namespace Jotunn.Utils
     }
 
     /// <summary>
-    /// Mod compatibility attribute<br />
-    /// <br/>
-    /// PLEASE READ<br />
-    /// Example usage:<br />
-    /// If your mod adds its own RPCs, EnforceModOnClients is likely a must (otherwise clients would just discard the messages from the server), same version you do have to determine, if your sent data changed<br />
-    /// If your mod adds items, you always should enforce mods on client and same version (there could be nasty side effects with different versions of an item)<br />
-    /// If your mod is just GUI changes (for example bigger inventory, additional equip slots) there is no need to set this attribute
+    ///     Mod compatibility attribute<br />
+    ///     <br/>
+    ///     If your mod adds its own RPCs, EnforceModOnClients is likely a must (otherwise clients would just discard the messages from the server), same version you do have to determine, if your sent data changed.<br />
+    ///     If your mod adds items, you always should enforce mods on client and same version (there could be nasty side effects with different versions of an item).<br />
+    ///     If your mod is just GUI changes (for example bigger inventory, additional equip slots) there is no need to set this attribute
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
-    public class NetworkCompatibilityAttribute: Attribute
+    public class NetworkCompatibilityAttribute : Attribute
     {
         /// <summary>
         ///     Compatibility Level

--- a/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
@@ -24,13 +24,13 @@ namespace Jotunn.Utils
         internal ServerVersionData(List<ModModule> versionData)
         {
             moduleVersionData = new ModuleVersionData(versionData);
-            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Select(mod => mod.guid).ToList());
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.guid != null).Select(x => x.guid).ToList());
         }
 
         internal ServerVersionData(System.Version valheimVersion, List<ModModule> versionData)
         {
             moduleVersionData = new ModuleVersionData(valheimVersion, versionData);
-            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Select(mod => mod.guid).ToList());
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.guid != null).Select(x => x.guid).ToList());
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Jotunn.Utils
         internal ServerVersionData(ZPackage pkg)
         {
             moduleVersionData = new ModuleVersionData(pkg);
-            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Select(mod => mod.guid).ToList());
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.guid != null).Select(x => x.guid).ToList());
         }
 
         internal bool IsValid()

--- a/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
@@ -24,13 +24,13 @@ namespace Jotunn.Utils
         internal ServerVersionData(List<ModModule> versionData)
         {
             moduleVersionData = new ModuleVersionData(versionData);
-            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.guid != null).Select(x => x.guid).ToList());
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.ModID != null).Select(x => x.ModID).ToList());
         }
 
         internal ServerVersionData(System.Version valheimVersion, List<ModModule> versionData)
         {
             moduleVersionData = new ModuleVersionData(valheimVersion, versionData);
-            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.guid != null).Select(x => x.guid).ToList());
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.ModID != null).Select(x => x.ModID).ToList());
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Jotunn.Utils
         internal ServerVersionData(ZPackage pkg)
         {
             moduleVersionData = new ModuleVersionData(pkg);
-            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.guid != null).Select(x => x.guid).ToList());
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Where(x => x.ModID != null).Select(x => x.ModID).ToList());
         }
 
         internal bool IsValid()

--- a/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jotunn.Utils
+{
+    internal class ServerVersionData
+    {
+        public ModuleVersionData moduleVersionData { get; set; }
+        //public HashSet<string> moduleNames { get; set; }
+        public HashSet<string> moduleGUIDs { get; set; }
+
+        /// <summary>
+        ///     Create empty ServerData
+        /// </summary>
+        internal ServerVersionData() { }
+
+        /// <summary>
+        ///     Create from module data
+        /// </summary>
+        /// <param name="versionData"></param>
+        internal ServerVersionData(List<ModModule> versionData)
+        {
+            moduleVersionData = new ModuleVersionData(versionData);
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Select(mod => mod.guid).ToList());
+        }
+
+        internal ServerVersionData(System.Version valheimVersion, List<ModModule> versionData)
+        {
+            moduleVersionData = new ModuleVersionData(valheimVersion, versionData);
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Select(mod => mod.guid).ToList());
+        }
+
+        /// <summary>
+        ///     Create from ZPackage
+        /// </summary>
+        /// <param name="pkg"></param>
+        internal ServerVersionData(ZPackage pkg)
+        {
+            moduleVersionData = new ModuleVersionData(pkg);
+            moduleGUIDs = new HashSet<string>(moduleVersionData.Modules.Select(mod => mod.guid).ToList());
+        }
+
+        internal bool IsValid()
+        {
+            return moduleVersionData != null && moduleGUIDs != null;
+        }
+
+        internal void Reset()
+        {
+            moduleVersionData = null;
+            moduleGUIDs = null;
+        }
+    }
+}

--- a/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
+++ b/JotunnLib/Utils/ModCompatibility/ServerVersionData.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Jotunn.Utils
 {
     internal class ServerVersionData
     {
         public ModuleVersionData moduleVersionData { get; set; }
-        //public HashSet<string> moduleNames { get; set; }
         public HashSet<string> moduleGUIDs { get; set; }
 
         /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -13,7 +13,7 @@ namespace Jotunn.Utils
         /// <summary>
         ///     AdminOnly is only enforced for Config Entries if Jotunn is installed on the server.
         /// </summary>
-        IfJotunnOnServer = 0,
+        IfOnServer = 0,
         
         /// <summary>
         ///     AdminOnly is always enforced for Config Entries even if Jotunn is not installed on the server. 

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -22,6 +22,16 @@ namespace Jotunn.Utils
         Always = 1,
 
     }
+
+    /// <summary>
+    /// Synchronization Mode attribute<br />
+    /// <br/>
+    /// PLEASE READ<br />
+    /// Example usage:<br />
+    /// If your mod should behave as a client-side only mod in multiplayer whenever Jotunn is not installed on the server then IfJotunnOnServer is a must.<br />
+    /// Otherwise the default behaviour is to the same as if you set this to Always and players will not be able to change any AdminOnly Config Entries when 
+    /// connected to a server where they are not an admin even if Jotunn is not installed on the server. 
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class SynchronizationModeAttribute : Attribute
     {

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -13,12 +13,13 @@ namespace Jotunn.Utils
         /// <summary>
         ///     AdminOnly is only enforced for Config Entries if Jotunn is installed on the server.
         /// </summary>
-        Low = 0,
+        IfJotunnOnServer = 0,
+        
         /// <summary>
         ///     AdminOnly is always enforced for Config Entries even if Jotunn is not installed on the server. 
         ///     This means that AdminOnly configs cannot be editted in multiplayer if Jotunn is not on the server.
         /// </summary>
-        High = 1,
+        Always = 1,
 
     }
     internal class SynchronizationModeAttribute
@@ -43,7 +44,7 @@ namespace Jotunn.Utils
         /// <returns></returns>
         public bool ShouldAlwaysEnforceAdminOnly()
         {
-            return EnforceAdminOnly == AdminOnlyStrictness.High;
+            return EnforceAdminOnly == AdminOnlyStrictness.Always;
         }
     }
 }

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -3,7 +3,6 @@ using System;
 
 namespace Jotunn.Utils
 {
-
     /// <summary>
     ///     Enum used for telling whether AdminOnly settings for Config Entries should always be enforced 
     ///     or if they should only be enforced when the mod is installed on the server.
@@ -14,13 +13,12 @@ namespace Jotunn.Utils
         ///     AdminOnly is only enforced for Config Entries if the mod is installed on the server.
         /// </summary>
         IfOnServer = 0,
-        
+
         /// <summary>
         ///     AdminOnly is always enforced for Config Entries even if the mod is not installed on the server. 
         ///     This means that AdminOnly configs cannot be edited in multiplayer if the mod is not on the server.
         /// </summary>
         Always = 1,
-
     }
 
     /// <summary>

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -22,7 +22,8 @@ namespace Jotunn.Utils
         Always = 1,
 
     }
-    internal class SynchronizationModeAttribute
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+    public class SynchronizationModeAttribute : Attribute
     {
         /// <summary>
         ///     AdminOnly ConfigEntry Strictness

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -1,0 +1,49 @@
+using System;
+
+
+namespace Jotunn.Utils
+{
+
+    /// <summary>
+    ///     Enum used for telling whether AdminOnly settings for Config Entries should always be enforced 
+    ///     or if they should only be enforced when Jotunn is installed on the server.
+    /// </summary>
+    public enum AdminOnlyStrictness : int
+    {
+        /// <summary>
+        ///     AdminOnly is only enforced for Config Entries if Jotunn is installed on the server.
+        /// </summary>
+        Low = 0,
+        /// <summary>
+        ///     AdminOnly is always enforced for Config Entries even if Jotunn is not installed on the server. 
+        ///     This means that AdminOnly configs cannot be editted in multiplayer if Jotunn is not on the server.
+        /// </summary>
+        High = 1,
+
+    }
+    internal class SynchronizationModeAttribute
+    {
+        /// <summary>
+        ///     AdminOnly ConfigEntry Strictness
+        /// </summary>
+        public AdminOnlyStrictness EnforceAdminOnly { get; set; }
+
+        /// <summary>
+        ///     Synchronization mode Attribute
+        /// </summary>
+        /// <param name="enforceAdminOnly"></param>
+        public SynchronizationModeAttribute(AdminOnlyStrictness enforceAdminOnly)
+        {
+            EnforceAdminOnly = enforceAdminOnly;
+        }
+
+        /// <summary>
+        ///     Check if AdminOnly Config Entries should always be locked if player is not an admin.
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldAlwaysEnforceAdminOnly()
+        {
+            return EnforceAdminOnly == AdminOnlyStrictness.High;
+        }
+    }
+}

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -4,31 +4,26 @@ using System;
 namespace Jotunn.Utils
 {
     /// <summary>
-    ///     Enum used for telling whether AdminOnly settings for Config Entries should always be enforced 
+    ///     Enum used for telling whether AdminOnly settings for Config Entries should always be enforced
     ///     or if they should only be enforced when the mod is installed on the server.
     /// </summary>
     public enum AdminOnlyStrictness : int
     {
         /// <summary>
-        ///     AdminOnly is only enforced for Config Entries if the mod is installed on the server.
-        /// </summary>
-        IfOnServer = 0,
-
-        /// <summary>
-        ///     AdminOnly is always enforced for Config Entries even if the mod is not installed on the server. 
+        ///     AdminOnly is always enforced for Config Entries even if the mod is not installed on the server.
         ///     This means that AdminOnly configs cannot be edited in multiplayer if the mod is not on the server.
         /// </summary>
-        Always = 1,
+        Always = 0,
+
+        /// <summary>
+        ///     AdminOnly is only enforced for Config Entries if the mod is installed on the server.
+        /// </summary>
+        IfOnServer = 1,
     }
 
     /// <summary>
-    /// Synchronization Mode attribute<br />
-    /// <br/>
-    /// PLEASE READ<br />
-    /// Example usage:<br />
-    /// If your mod should behave as a client-side only mod in multiplayer whenever the mod is not installed on the server then IfOnServer is a must.<br />
-    /// Otherwise the default behaviour is to the same as if you set this to Always and players will not be able to change any AdminOnly Config Entries when 
-    /// connected to a server where they are not an admin even if the mod is not installed on the server. 
+    ///     This attribute is used to determine how Jotunn should enforce synchronization of Config Entries.<br/>
+    ///     Only relevant for Config Entries that have the <see cref="ConfigurationManagerAttributes.IsAdminOnly"/> applied.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class SynchronizationModeAttribute : Attribute

--- a/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
+++ b/JotunnLib/Utils/ModCompatibility/SynchronizationModeAttribute.cs
@@ -6,18 +6,18 @@ namespace Jotunn.Utils
 
     /// <summary>
     ///     Enum used for telling whether AdminOnly settings for Config Entries should always be enforced 
-    ///     or if they should only be enforced when Jotunn is installed on the server.
+    ///     or if they should only be enforced when the mod is installed on the server.
     /// </summary>
     public enum AdminOnlyStrictness : int
     {
         /// <summary>
-        ///     AdminOnly is only enforced for Config Entries if Jotunn is installed on the server.
+        ///     AdminOnly is only enforced for Config Entries if the mod is installed on the server.
         /// </summary>
         IfOnServer = 0,
         
         /// <summary>
-        ///     AdminOnly is always enforced for Config Entries even if Jotunn is not installed on the server. 
-        ///     This means that AdminOnly configs cannot be editted in multiplayer if Jotunn is not on the server.
+        ///     AdminOnly is always enforced for Config Entries even if the mod is not installed on the server. 
+        ///     This means that AdminOnly configs cannot be edited in multiplayer if the mod is not on the server.
         /// </summary>
         Always = 1,
 
@@ -28,9 +28,9 @@ namespace Jotunn.Utils
     /// <br/>
     /// PLEASE READ<br />
     /// Example usage:<br />
-    /// If your mod should behave as a client-side only mod in multiplayer whenever Jotunn is not installed on the server then IfJotunnOnServer is a must.<br />
+    /// If your mod should behave as a client-side only mod in multiplayer whenever the mod is not installed on the server then IfOnServer is a must.<br />
     /// Otherwise the default behaviour is to the same as if you set this to Always and players will not be able to change any AdminOnly Config Entries when 
-    /// connected to a server where they are not an admin even if Jotunn is not installed on the server. 
+    /// connected to a server where they are not an admin even if the mod is not installed on the server. 
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class SynchronizationModeAttribute : Attribute

--- a/JotunnTests/CompatibilityLevelTest.cs
+++ b/JotunnTests/CompatibilityLevelTest.cs
@@ -124,8 +124,8 @@ namespace Jotunn.Utils
         {
             var moduleA = new ModModule("", "", v_1_1_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Minor);
             var moduleB = new ModModule("", "", v_2_0_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Minor);
-            Assert.False(ModModule.IsLowerVersion(moduleA, moduleB, moduleA.versionStrictness));
-            Assert.True(ModModule.IsLowerVersion(moduleB, moduleA, moduleA.versionStrictness));
+            Assert.False(ModModule.IsLowerVersion(moduleA, moduleB, moduleA.VersionStrictness));
+            Assert.True(ModModule.IsLowerVersion(moduleB, moduleA, moduleA.VersionStrictness));
         }
 
         [Fact]
@@ -133,13 +133,13 @@ namespace Jotunn.Utils
         {
             var moduleA = new ModModule("", "", v_1_1_1, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
             var moduleB = new ModModule("", "", v_2_2_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
-            Assert.False(ModModule.IsLowerVersion(moduleA, moduleB, moduleA.versionStrictness));
-            Assert.True(ModModule.IsLowerVersion(moduleB, moduleA, moduleA.versionStrictness));
+            Assert.False(ModModule.IsLowerVersion(moduleA, moduleB, moduleA.VersionStrictness));
+            Assert.True(ModModule.IsLowerVersion(moduleB, moduleA, moduleA.VersionStrictness));
 
             var moduleC = new ModModule("", "", v_1_1_1, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
             var moduleD = new ModModule("", "", v_2_1_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
-            Assert.False(ModModule.IsLowerVersion(moduleC, moduleD, moduleC.versionStrictness));
-            Assert.True(ModModule.IsLowerVersion(moduleD, moduleC, moduleC.versionStrictness));
+            Assert.False(ModModule.IsLowerVersion(moduleC, moduleD, moduleC.VersionStrictness));
+            Assert.True(ModModule.IsLowerVersion(moduleD, moduleC, moduleC.VersionStrictness));
         }
 
         private void TestVersionCompare(System.Version v1, System.Version v2, CompatibilityLevel level, VersionStrictness strictness,

--- a/JotunnTests/CompatibilityLevelTest.cs
+++ b/JotunnTests/CompatibilityLevelTest.cs
@@ -47,7 +47,7 @@ namespace Jotunn.Utils
         {
             clientVersionData.Modules = new List<ModModule>
             {
-                new ModModule("TestMod", v_1_0_0, compatibilityLevel, VersionStrictness.Minor)
+                new ModModule("TestMod", "TestMod", v_1_0_0, compatibilityLevel, VersionStrictness.Minor)
             };
             Assert.Equal(expected, ModCompatibility.CompareVersionData(serverVersionData, clientVersionData));
         }
@@ -66,7 +66,7 @@ namespace Jotunn.Utils
         {
             serverVersionData.Modules = new List<ModModule>
             {
-                new ModModule("TestMod", v_1_0_0, compatibilityLevel, VersionStrictness.Minor)
+                new ModModule("TestMod", "TestMod", v_1_0_0, compatibilityLevel, VersionStrictness.Minor)
             };
             Assert.Equal(expected, ModCompatibility.CompareVersionData(serverVersionData, clientVersionData));
         }
@@ -122,8 +122,8 @@ namespace Jotunn.Utils
         [Fact]
         public void OnlyLowerOrHigherVersion_Minor()
         {
-            var moduleA = new ModModule("", v_1_1_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Minor);
-            var moduleB = new ModModule("", v_2_0_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Minor);
+            var moduleA = new ModModule("", "", v_1_1_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Minor);
+            var moduleB = new ModModule("", "", v_2_0_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Minor);
             Assert.False(ModModule.IsLowerVersion(moduleA, moduleB, moduleA.versionStrictness));
             Assert.True(ModModule.IsLowerVersion(moduleB, moduleA, moduleA.versionStrictness));
         }
@@ -131,13 +131,13 @@ namespace Jotunn.Utils
         [Fact]
         public void OnlyLowerOrHigherVersion_Patch()
         {
-            var moduleA = new ModModule("", v_1_1_1, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
-            var moduleB = new ModModule("", v_2_2_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
+            var moduleA = new ModModule("", "", v_1_1_1, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
+            var moduleB = new ModModule("", "", v_2_2_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
             Assert.False(ModModule.IsLowerVersion(moduleA, moduleB, moduleA.versionStrictness));
             Assert.True(ModModule.IsLowerVersion(moduleB, moduleA, moduleA.versionStrictness));
 
-            var moduleC = new ModModule("", v_1_1_1, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
-            var moduleD = new ModModule("", v_2_1_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
+            var moduleC = new ModModule("", "", v_1_1_1, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
+            var moduleD = new ModModule("", "", v_2_1_0, CompatibilityLevel.VersionCheckOnly, VersionStrictness.Patch);
             Assert.False(ModModule.IsLowerVersion(moduleC, moduleD, moduleC.versionStrictness));
             Assert.True(ModModule.IsLowerVersion(moduleD, moduleC, moduleC.versionStrictness));
         }
@@ -145,12 +145,12 @@ namespace Jotunn.Utils
         private void TestVersionCompare(System.Version v1, System.Version v2, CompatibilityLevel level, VersionStrictness strictness,
             bool expected)
         {
-            serverVersionData.Modules = new List<ModModule> { new ModModule("TestMod", v1, level, strictness) };
-            clientVersionData.Modules = new List<ModModule> { new ModModule("TestMod", v2, level, strictness) };
+            serverVersionData.Modules = new List<ModModule> { new ModModule("TestMod", "TestMod", v1, level, strictness) };
+            clientVersionData.Modules = new List<ModModule> { new ModModule("TestMod", "TestMod", v2, level, strictness) };
             Assert.Equal(expected, ModCompatibility.CompareVersionData(serverVersionData, clientVersionData));
 
-            serverVersionData.Modules = new List<ModModule> { new ModModule("TestMod", v2, level, strictness) };
-            clientVersionData.Modules = new List<ModModule> { new ModModule("TestMod", v1, level, strictness) };
+            serverVersionData.Modules = new List<ModModule> { new ModModule("TestMod", "TestMod", v2, level, strictness) };
+            clientVersionData.Modules = new List<ModModule> { new ModModule("TestMod", "TestMod", v1, level, strictness) };
             Assert.Equal(expected, ModCompatibility.CompareVersionData(serverVersionData, clientVersionData));
         }
     }

--- a/JotunnTests/CompatibilityZPackageTest.cs
+++ b/JotunnTests/CompatibilityZPackageTest.cs
@@ -25,6 +25,7 @@ namespace Jotunn.Utils
             ModModule result = new ModModule(pkg, legacy: false);
 
             Assert.Equal(module.ModID, result.ModID);
+            Assert.Equal(module.ModName, result.ModName);
             Assert.Equal(module.Version, result.Version);
             Assert.Equal(module.CompatibilityLevel, result.CompatibilityLevel);
             Assert.Equal(module.VersionStrictness, result.VersionStrictness);

--- a/JotunnTests/CompatibilityZPackageTest.cs
+++ b/JotunnTests/CompatibilityZPackageTest.cs
@@ -17,7 +17,7 @@ namespace Jotunn.Utils
         [Fact]
         public void ModModuleZPackage()
         {
-            ModModule module = new ModModule("TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor);
+            ModModule module = new ModModule("TestMod", "TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor);
 
             ZPackage pkg = new ZPackage();
             module.WriteToPackage(pkg);
@@ -35,7 +35,7 @@ namespace Jotunn.Utils
         {
             moduleData.ValheimVersion = v_1_0_5;
             moduleData.VersionString = "1.2.3-Test";
-            moduleData.Modules = new List<ModModule> { new ModModule("TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor) };
+            moduleData.Modules = new List<ModModule> { new ModModule("TestMod", "TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor) };
 
             ZPackage pkg = moduleData.ToZPackage();
             pkg.SetPos(0);
@@ -52,7 +52,7 @@ namespace Jotunn.Utils
         {
             moduleData.ValheimVersion = v_1_0_5;
             moduleData.VersionString = "1.2.3-Test";
-            moduleData.Modules = new List<ModModule> { new ModModule("TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor) };
+            moduleData.Modules = new List<ModModule> { new ModModule("TestMod", "TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor) };
 
             var pkg = new ZPackage();
             pkg.Write(moduleData.ValheimVersion.Major);

--- a/JotunnTests/CompatibilityZPackageTest.cs
+++ b/JotunnTests/CompatibilityZPackageTest.cs
@@ -20,9 +20,9 @@ namespace Jotunn.Utils
             ModModule module = new ModModule("TestMod", "TestMod", v_1_0_5, CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.Minor);
 
             ZPackage pkg = new ZPackage();
-            module.WriteToPackage(pkg);
+            module.WriteToPackage(pkg, legacy: false);
             pkg.SetPos(0);
-            ModModule result = new ModModule(pkg);
+            ModModule result = new ModModule(pkg, legacy: false);
 
             Assert.Equal(module.name, result.name);
             Assert.Equal(module.version, result.version);
@@ -63,7 +63,7 @@ namespace Jotunn.Utils
 
             foreach (var module in moduleData.Modules)
             {
-                module.WriteToPackage(pkg);
+                module.WriteToPackage(pkg, legacy: true);
             }
 
             pkg.SetPos(0);

--- a/JotunnTests/CompatibilityZPackageTest.cs
+++ b/JotunnTests/CompatibilityZPackageTest.cs
@@ -24,10 +24,10 @@ namespace Jotunn.Utils
             pkg.SetPos(0);
             ModModule result = new ModModule(pkg, legacy: false);
 
-            Assert.Equal(module.name, result.name);
-            Assert.Equal(module.version, result.version);
-            Assert.Equal(module.compatibilityLevel, result.compatibilityLevel);
-            Assert.Equal(module.versionStrictness, result.versionStrictness);
+            Assert.Equal(module.ModID, result.ModID);
+            Assert.Equal(module.Version, result.Version);
+            Assert.Equal(module.CompatibilityLevel, result.CompatibilityLevel);
+            Assert.Equal(module.VersionStrictness, result.VersionStrictness);
         }
 
         [Fact]


### PR DESCRIPTION
This adds a new attribute that can be applied to the base plugin which is checked by `SynchronizationManager` during `SynchronizationManager.Instance.GetConfigFiles()` to determine if each config file should be handled by `SynchronizationManager` or not based on the SynchronizationModeAttribute and if Jotunn is installed on the server. 

If mod authors do not set the SynchronizationModeAttribute then it defaults to the current behaviour (which is the same as explicitly setting `EnforceAdminOnly = AdminOnlyStrictness.Always` ). 

If mod authors set or set `EnforceAdminOnly = AdminOnlyStrictness.IfJotunnOnServer` then when Jotunn is not present on the server SynchronizationManager will not manage the config file at all and the mod will behave as if there is no synchronization and it is running as a purely client side mod. If Jotunn is present though it will enforce the AdminOnly restriction and sync all configuration changes.

I've tested it with existing mods and those tests suggest these features are backwards compatible and preserve the current configuration behaviour when used with mods built against the currently live version of Jotunn. I've also written the code to handle mapping custom config files to their related plugins so that the SynchronizationModeAttribute can still be checked.

Please let me know if you'd like any additional testing to be done and I'm happy to hear any other feedback or suggestions.