### PR TITLE
ConfigFile extension with a convenience method to bind config entries. 

### DIFF
--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -1,0 +1,69 @@
+using System;
+using BepInEx.Configuration;
+
+namespace Jotunn.Extensions
+{
+
+    /// <summary>
+    ///     Extends ConfigFile with a convenience method to bind config entries with less boilerplate code 
+    ///     and explicitly expose commonly used configuration manager attributes.
+    /// </summary>
+    public static class ConfigFileExtensions
+    {
+        internal static string GetExtendedDescription(string description, bool synchronizedSetting)
+        {
+            return description + (synchronizedSetting ? " [Synced with Server]" : " [Not Synced with Server]");
+        }
+
+        /// <summary>
+        ///     Bind a new config entry to the config file and modify description to state whether the config entry is synced or not.
+        /// </summary>
+        /// <typeparam name="T">Type of the value the config entry holds.</typeparam>
+        /// <param name="configFile">Configuration file to bind the config entry to.</param>
+        /// <param name="section">Configuration file section to list the config entry in.</param>
+        /// <param name="name">Display name of the config entry.</param>
+        /// <param name="value">Default value of the config entry.</param>
+        /// <param name="description">Plain text description of the config entry to display as hover text in configuration manager.</param>
+        /// <param name="acceptVals">Acceptable values for config entry as either an AcceptableValueRange or AcceptableValueList.</param>
+        /// <param name="synced">Whether the config entry IsAdminOnly and should be synced with server.</param>
+        /// <param name="order">Order of the setting on the settings list relative to other settings in a category. 0 by default, higher number is higher on the list.</param>
+        /// <param name="drawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
+        /// <param name="configAttributes">Optional config manager attributes for additional user specified functionality. Any optional fields specified by the arguments of BindConfig will be overwritten by the parameters passed to BindConfig.</param>
+        /// <returns>ConfigEntry bound to the config file.</returns>
+        public static ConfigEntry<T> BindConfig<T>(
+            this ConfigFile configFile,
+            string section,
+            string name,
+            T value,
+            string description,
+            AcceptableValueBase acceptVals = null,
+            bool synced = true,
+            int order = 0,
+            Action<ConfigEntryBase> drawer = null,
+            ConfigurationManagerAttributes configAttributes = null
+        )
+        {
+            string extendedDescription = GetExtendedDescription(description, synced);
+
+            configAttributes ??= new ConfigurationManagerAttributes();         
+            configAttributes.IsAdminOnly = synced;
+            configAttributes.Order = order;
+            if (drawer != null)
+            {
+                configAttributes.CustomDrawer = drawer;
+            }
+
+            ConfigEntry<T> configEntry = configFile.Bind(
+                section,
+                name,
+                value,
+                new ConfigDescription(
+                    extendedDescription,
+                    acceptVals,
+                    configAttributes
+                )
+            );
+            return configEntry;
+        }    
+    }
+}

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -19,26 +19,26 @@ namespace Jotunn.Extensions
         /// </summary>
         /// <typeparam name="T">Type of the value the config entry holds.</typeparam>
         /// <param name="configFile">Configuration file to bind the config entry to.</param>
-        /// <param name="section">Configuration file section to list the config entry in.</param>
-        /// <param name="name">Display name of the config entry.</param>
+        /// <param name="section">Configuration file section to list the config entry in. Settings are grouped by this.</param>
+        /// <param name="key">Name of the setting.</param>
         /// <param name="defaultValue">Default value of the config entry.</param>
         /// <param name="description">Plain text description of the config entry to display as hover text in configuration manager.</param>
-        /// <param name="acceptableValues">Acceptable values for config entry as an AcceptableValueRange, AcceptableValueList, or custom subclass.</param>
         /// <param name="synced">Whether the config entry IsAdminOnly and should be synced with server.</param>
         /// <param name="order">Order of the setting on the settings list relative to other settings in a category. 0 by default, higher number is higher on the list.</param>
-        /// <param name="drawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
-        /// <param name="configAttributes">Optional config manager attributes for additional user specified functionality. Any optional fields specified by the arguments of BindConfig will be overwritten by the parameters passed to BindConfig.</param>
+        /// <param name="acceptableValues">Acceptable values for config entry as an AcceptableValueRange, AcceptableValueList, or custom subclass.</param>
+        /// <param name="customDrawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
+        /// <param name="configAttributes">Config manager attributes for additional user specified functionality. Any fields of BindConfig will overwrite properties in configAttributes.</param>
         /// <returns>ConfigEntry bound to the config file.</returns>
         public static ConfigEntry<T> BindConfig<T>(
             this ConfigFile configFile,
             string section,
-            string name,
+            string key,
             T defaultValue,
             string description,
-            AcceptableValueBase acceptableValues = null,
             bool synced = true,
-            int order = 0,
-            Action<ConfigEntryBase> drawer = null,
+            int? order = null,
+            AcceptableValueBase acceptableValues = null,
+            Action<ConfigEntryBase> customDrawer = null,
             ConfigurationManagerAttributes configAttributes = null
         )
         {
@@ -47,22 +47,15 @@ namespace Jotunn.Extensions
             configAttributes ??= new ConfigurationManagerAttributes();
             configAttributes.IsAdminOnly = synced;
             configAttributes.Order = order;
-
-            if (drawer != null)
-            {
-                configAttributes.CustomDrawer = drawer;
-            }
+            configAttributes.CustomDrawer = customDrawer;
 
             ConfigEntry<T> configEntry = configFile.Bind(
                 section,
-                name,
+                key,
                 defaultValue,
-                new ConfigDescription(
-                    extendedDescription,
-                    acceptableValues,
-                    configAttributes
-                )
+                new ConfigDescription(extendedDescription, acceptableValues, configAttributes)
             );
+
             return configEntry;
         }
     }

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using BepInEx.Configuration;
 
 namespace Jotunn.Extensions

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -64,7 +64,7 @@ namespace Jotunn.Extensions
         /// <param name="customDrawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
         /// <param name="configAttributes">Config manager attributes for additional user specified functionality. Any fields of BindConfig will overwrite properties in configAttributes.</param>
         /// <returns>ConfigEntry bound to the config file.</returns>
-        public static ConfigEntry<T> BindConfig<T>(
+        public static ConfigEntryInOrder<T> BindConfig<T>(
             this ConfigFile configFile,
             string section,
             string key,

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -9,9 +9,78 @@ namespace Jotunn.Extensions
     /// </summary>
     public static class ConfigFileExtensions
     {
+         private static readonly Dictionary<string, int> _sectionToSectionNumber = [];
+         private static readonly Dictionary<string, int> _sectionToSettingOrder = [];
+        
+         /// <summary>
+         ///     Formats section name as "{sectionNumber} - {section}" based on how
+         ///     many sections have been bound to this config.
+         /// </summary>
+         /// <param name="section"></param>
+         /// <returns></returns>
+         private static string GetOrderedSectionName(string section)
+         {
+             if (!_sectionToSectionNumber.TryGetValue(section, out int number))
+             {
+                 number = _sectionToSectionNumber.Count + 1;
+                 _sectionToSectionNumber[section] = number;
+             }
+             return $"{number} - {section}";
+         }
+        
+         /// <summary>
+         ///     Orders settings within a section.
+         /// </summary>
+         /// <param name="section"></param>
+         /// <returns></returns>
+         private static int GetSettingOrder(string section)
+         {
+             if (!_sectionToSettingOrder.TryGetValue(section, out int order))
+             {
+                 order = 0;
+             }
+             _sectionToSettingOrder[section] = order - 1;
+             return order;
+         }
+        
         internal static string GetExtendedDescription(string description, bool synchronizedSetting)
         {
             return description + (synchronizedSetting ? " [Synced with Server]" : " [Not Synced with Server]");
+        }
+
+        /// <summary>
+        ///     Bind a new config entry to the config file and modify description to state whether the config entry is synced or not.
+        /// </summary>
+        /// <typeparam name="T">Type of the value the config entry holds.</typeparam>
+        /// <param name="configFile">Configuration file to bind the config entry to.</param>
+        /// <param name="section">Configuration file section to list the config entry in. Settings are grouped by this.</param>
+        /// <param name="key">Name of the setting.</param>
+        /// <param name="defaultValue">Default value of the config entry.</param>
+        /// <param name="description">Plain text description of the config entry to display as hover text in configuration manager.</param>
+        /// <param name="synced">Whether the config entry IsAdminOnly and should be synced with server.</param>
+        /// <param name="sectionOrder">Whether to number the section names using a prefix based on the order they are bound to the config file.</param>
+        /// <param name="settingOrder">Whether to order the settings in each section based on the order they are bound to the config file.</param>
+        /// <param name="acceptableValues">Acceptable values for config entry as an AcceptableValueRange, AcceptableValueList, or custom subclass.</param>
+        /// <param name="customDrawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
+        /// <param name="configAttributes">Config manager attributes for additional user specified functionality. Any fields of BindConfig will overwrite properties in configAttributes.</param>
+        /// <returns>ConfigEntry bound to the config file.</returns>
+        public static ConfigEntry<T> BindConfig<T>(
+            this ConfigFile configFile,
+            string section,
+            string key,
+            T defaultValue,
+            string description,
+            bool synced = true,
+            bool sectionOrder = true,
+            bool settingOrder = true,
+            AcceptableValueBase acceptableValues = null,
+            Action<ConfigEntryBase> customDrawer = null,
+            ConfigurationManagerAttributes configAttributes = null
+        )
+        {
+            section = sectionOrder ? GetOrderedSectionName(section) : section;
+            int order = settingOrder ? GetSettingOrder(section) : 0;
+            return configFile.BindConfig(section, key, defaultValue, description, synced, order, acceptableValues, customDrawer, configAttributes);
         }
 
         /// <summary>

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -3,7 +3,6 @@ using BepInEx.Configuration;
 
 namespace Jotunn.Extensions
 {
-
     /// <summary>
     ///     Extends ConfigFile with a convenience method to bind config entries with less boilerplate code 
     ///     and explicitly expose commonly used configuration manager attributes.
@@ -12,7 +11,6 @@ namespace Jotunn.Extensions
     {
         internal static string GetExtendedDescription(string description, bool synchronizedSetting)
         {
-            // these two hardcoded strings should probably be localized
             return description + (synchronizedSetting ? " [Synced with Server]" : " [Not Synced with Server]");
         }
 
@@ -23,9 +21,9 @@ namespace Jotunn.Extensions
         /// <param name="configFile">Configuration file to bind the config entry to.</param>
         /// <param name="section">Configuration file section to list the config entry in.</param>
         /// <param name="name">Display name of the config entry.</param>
-        /// <param name="value">Default value of the config entry.</param>
+        /// <param name="defaultValue">Default value of the config entry.</param>
         /// <param name="description">Plain text description of the config entry to display as hover text in configuration manager.</param>
-        /// <param name="acceptVals">Acceptable values for config entry as an AcceptableValueRange, AcceptableValueList, or custom subclass.</param>
+        /// <param name="acceptableValues">Acceptable values for config entry as an AcceptableValueRange, AcceptableValueList, or custom subclass.</param>
         /// <param name="synced">Whether the config entry IsAdminOnly and should be synced with server.</param>
         /// <param name="order">Order of the setting on the settings list relative to other settings in a category. 0 by default, higher number is higher on the list.</param>
         /// <param name="drawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
@@ -35,9 +33,9 @@ namespace Jotunn.Extensions
             this ConfigFile configFile,
             string section,
             string name,
-            T value,
+            T defaultValue,
             string description,
-            AcceptableValueBase acceptVals = null,
+            AcceptableValueBase acceptableValues = null,
             bool synced = true,
             int order = 0,
             Action<ConfigEntryBase> drawer = null,
@@ -46,9 +44,10 @@ namespace Jotunn.Extensions
         {
             string extendedDescription = GetExtendedDescription(description, synced);
 
-            configAttributes ??= new ConfigurationManagerAttributes();         
+            configAttributes ??= new ConfigurationManagerAttributes();
             configAttributes.IsAdminOnly = synced;
             configAttributes.Order = order;
+
             if (drawer != null)
             {
                 configAttributes.CustomDrawer = drawer;
@@ -57,14 +56,14 @@ namespace Jotunn.Extensions
             ConfigEntry<T> configEntry = configFile.Bind(
                 section,
                 name,
-                value,
+                defaultValue,
                 new ConfigDescription(
                     extendedDescription,
-                    acceptVals,
+                    acceptableValues,
                     configAttributes
                 )
             );
             return configEntry;
-        }    
+        }
     }
 }

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -9,8 +9,8 @@ namespace Jotunn.Extensions
     /// </summary>
     public static class ConfigFileExtensions
     {
-         private static readonly Dictionary<string, int> _sectionToSectionNumber = [];
-         private static readonly Dictionary<string, int> _sectionToSettingOrder = [];
+         private static readonly Dictionary<string, int> _sectionToSectionNumber = new Dictionary<string, int>();
+         private static readonly Dictionary<string, int> _sectionToSettingOrder = new Dictionary<string, int>();
         
          /// <summary>
          ///     Formats section name as "{sectionNumber} - {section}" based on how

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -24,7 +24,7 @@ namespace Jotunn.Extensions
         /// <param name="name">Display name of the config entry.</param>
         /// <param name="value">Default value of the config entry.</param>
         /// <param name="description">Plain text description of the config entry to display as hover text in configuration manager.</param>
-        /// <param name="acceptVals">Acceptable values for config entry as either an AcceptableValueRange or AcceptableValueList.</param>
+        /// <param name="acceptVals">Acceptable values for config entry as an AcceptableValueRange, AcceptableValueList, or custom subclass.</param>
         /// <param name="synced">Whether the config entry IsAdminOnly and should be synced with server.</param>
         /// <param name="order">Order of the setting on the settings list relative to other settings in a category. 0 by default, higher number is higher on the list.</param>
         /// <param name="drawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -12,6 +12,7 @@ namespace Jotunn.Extensions
     {
         internal static string GetExtendedDescription(string description, bool synchronizedSetting)
         {
+            // these two hardcoded strings should probably be localized
             return description + (synchronizedSetting ? " [Synced with Server]" : " [Not Synced with Server]");
         }
 

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -64,7 +64,7 @@ namespace Jotunn.Extensions
         /// <param name="customDrawer">Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).</param>
         /// <param name="configAttributes">Config manager attributes for additional user specified functionality. Any fields of BindConfig will overwrite properties in configAttributes.</param>
         /// <returns>ConfigEntry bound to the config file.</returns>
-        public static ConfigEntryInOrder<T> BindConfig<T>(
+        public static ConfigEntry<T> BindConfigInOrder<T>(
             this ConfigFile configFile,
             string section,
             string key,


### PR DESCRIPTION
In the examples of how to use Jotunn for syncing configs it usually comes up that mod authors need to make their own method to wrap bind calls to handling setting `IsAdminOnly`. This would remove the need to include that in each mod while also reducing boilerplate code and explicitly exposing common config attributes for newer mod authors.