### PR TITLE
ci: Update deprecated workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -108,12 +108,12 @@ jobs:
           msbuild JotunnLib.sln /p:Configuration=Release
 
       # Upload artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Jotunn-${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.dll
           path: JotunnLib/bin/Release/net462/Jotunn.dll
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg
           path: JotunnLib/bin/Release/JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -99,12 +99,12 @@ jobs:
           msbuild JotunnLib.sln /p:Configuration=Debug
 
       # Upload artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Jotunn-${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.dll
           path: JotunnLib/bin/Debug/net462/Jotunn.dll
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg
           path: JotunnLib/bin/Debug/JotunnLib.${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}.nupkg

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -119,13 +119,13 @@ jobs:
           mv JotunnLib/bin/Debug/net462/Jotunn.dll Jotunn-DEBUG-${{ steps.get_version.outputs.VERSION }}.dll
 
       - name: Upload Nexusmods zip as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Jotunn-${{ steps.get_version.outputs.VERSION }}-Nexusmods.zip
           path: JotunnLib/_package/Nexusmods/Jotunn-${{ steps.get_version.outputs.VERSION }}.zip
 
       - name: Upload Thunderstore zip as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Jotunn-${{ steps.get_version.outputs.VERSION }}-Thunderstore.zip
           path: JotunnLib/_package/Thunderstore/Jotunn-${{ steps.get_version.outputs.VERSION }}.zip


### PR DESCRIPTION
upload-artifact@v3 will stop working at the end of this month.  This updates to @v4.