### PR TITLE
Cache Local AdminOnly Configs Just Before Client Connects

### DIFF
--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -178,10 +178,6 @@ namespace Jotunn.Managers
             [HarmonyPatch(typeof(ZNet), nameof(ZNet.Awake)), HarmonyPostfix]
             private static void ZNet_Awake(ZNet __instance) => Instance.ZNet_Awake(__instance);
 
-            // Hook ZNet.Start for handling lock/unlock of admin configs
-            [HarmonyPatch(typeof(ZNet), nameof(ZNet.Start)), HarmonyPrefix]
-            private static void ZNet_Start() => Instance.SetAdminConfigs_OnZNetStart();
-
             // Hook RPC_PeerInfo for initial retrieval of admin status and configuration
             [HarmonyPatch(typeof(ZNet), nameof(ZNet.RPC_PeerInfo)), HarmonyPrefix]
             private static void ZNet_RPC_Pre_PeerInfo(ZNet __instance, ZRpc rpc, ref PeerInfoBlockingSocket __state) => Instance.ZNet_RPC_Pre_PeerInfo(__instance, rpc, ref __state);
@@ -200,41 +196,42 @@ namespace Jotunn.Managers
             [HarmonyPatch(typeof(Menu), nameof(Menu.IsVisible)), HarmonyPostfix]
             private static void Menu_IsVisible(ref bool __result) => Instance.Menu_IsVisible(ref __result);
 
-            // Hook Fejd for ConfigReloaded event subscription
             [HarmonyPatch(typeof(FejdStartup), nameof(FejdStartup.Awake)), HarmonyPrefix]
-            private static void FejdStartup_Awake() => Instance.FejdStartup_Awake();
+            private static void FejdStartup_Awake()
+            {
+                Instance.ResetAdminState();
+                Instance.FejdStartup_Awake();
+            }
+
+            [HarmonyPatch(typeof(ZNet), nameof(ZNet.Start)), HarmonyPrefix]
+            private static void ZNet_Start()
+            {
+                Instance.InitAdminState();
+            }
         }
 
-        /// <summary>
-        ///     Init or reset admin and configuration state
-        /// </summary>
-        private void SetAdminConfigs_OnZNetStart()
+        private void ResetAdminState()
         {
-            // main menu
-            if (SceneManager.GetActiveScene().name == "start")
+            PlayerIsAdmin = true;
+            UnlockConfigurationEntries();
+            ResetAdminConfigs();
+            CacheConfigurationValues();
+        }
+
+        private void InitAdminState()
+        {
+            InitAdminConfigs();
+
+            if (ZNet.instance && ZNet.instance.IsServer())
             {
                 PlayerIsAdmin = true;
                 UnlockConfigurationEntries();
-                ResetAdminConfigs();
-                CacheConfigurationValues();
             }
-
-            // load into world
-            if (SceneManager.GetActiveScene().name == "main")
+            else
             {
-                InitAdminConfigs();
-
-                if (ZNet.instance && ZNet.instance.IsServer())
-                {
-                    PlayerIsAdmin = true;
-                    UnlockConfigurationEntries();
-                }
-                else
-                {
-                    PlayerIsAdmin = false;
-                    LockConfigurationEntries();
-                    SetToDefaultConfigEntries();
-                }
+                PlayerIsAdmin = false;
+                LockConfigurationEntries();
+                SetToDefaultConfigEntries();
             }
         }
 

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -86,9 +86,6 @@ namespace Jotunn.Managers
 
             Main.Harmony.PatchAll(typeof(Patches));
 
-            // Hook start scene to reset config
-            SceneManager.sceneLoaded += SceneManager_sceneLoaded;
-
             if (ConfigManagerUtils.Plugin)
             {
                 var eventinfo = ConfigManagerUtils.Plugin.GetType().GetEvent("DisplayingWindowChanged");
@@ -181,6 +178,10 @@ namespace Jotunn.Managers
             [HarmonyPatch(typeof(ZNet), nameof(ZNet.Awake)), HarmonyPostfix]
             private static void ZNet_Awake(ZNet __instance) => Instance.ZNet_Awake(__instance);
 
+            // Hook ZNet.Start for handling lock/unlock of admin configs
+            [HarmonyPatch(typeof(ZNet), nameof(ZNet.Start)), HarmonyPrefix]
+            private static void ZNet_Start() => Instance.SetAdminConfigs_OnZNetStart();
+
             // Hook RPC_PeerInfo for initial retrieval of admin status and configuration
             [HarmonyPatch(typeof(ZNet), nameof(ZNet.RPC_PeerInfo)), HarmonyPrefix]
             private static void ZNet_RPC_Pre_PeerInfo(ZNet __instance, ZRpc rpc, ref PeerInfoBlockingSocket __state) => Instance.ZNet_RPC_Pre_PeerInfo(__instance, rpc, ref __state);
@@ -207,12 +208,10 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Init or reset admin and configuration state
         /// </summary>
-        /// <param name="scene"></param>
-        /// <param name="loadMode"></param>
-        private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadMode)
+        private void SetAdminConfigs_OnZNetStart()
         {
             // main menu
-            if (scene.name == "start")
+            if (SceneManager.GetActiveScene().name == "start")
             {
                 PlayerIsAdmin = true;
                 UnlockConfigurationEntries();
@@ -221,7 +220,7 @@ namespace Jotunn.Managers
             }
 
             // load into world
-            if (scene.name == "main")
+            if (SceneManager.GetActiveScene().name == "main")
             {
                 InitAdminConfigs();
 


### PR DESCRIPTION
Goal: 
Cache local configs as late as possible before connecting to a server and syncing config settings to avoid server settings overwriting local configs that are bound after the start scene.

Technical Details:
Replaced the `SceneManager_sceneLoaded` method that handled init/reset of admin with configs with `SetAdminConfigs_OnZNetStart`. Removed the event hook on scene change and added a patch to the internal private Patch class of `SynchronizationManager` to trigger a call to `SetAdminConfigs_OnZNetStart`. 