### PR TITLE
Add a ConfigFileWatcher Class

### DIFF
--- a/JotunnLib/Documentation/tutorials/config.md
+++ b/JotunnLib/Documentation/tutorials/config.md
@@ -79,10 +79,10 @@ private void CreateConfigValues()
 
     // Add server config which gets pushed to all clients connecting and can only be edited by admins
     // In local/single player games the player is always considered the admin
-    Config.BindConfig("Server config", "StringValue1", "StringValue", "Server side string", true);
-    Config.BindConfig("Server config", "FloatValue1", 750f, "Server side float", true, floatRange);
-    Config.BindConfig("Server config", "IntegerValue1", 200, "Server side integer", synced: true, acceptableValues: floatRange);
-    Config.BindConfig("Server config", "BoolValue1", false, "Server side bool", true);
+    Config.BindConfig("Server config", "StringValue1", "StringValue", "Server side string", synced: true);
+    Config.BindConfig("Server config", "FloatValue1", 750f, "Server side float", synced: true, acceptableValues: floatRange);
+    Config.BindConfig("Server config", "IntegerValue1", 200, "Server side integer", synced: true);
+    Config.BindConfig("Server config", "BoolValue1", false, "Server side bool", synced: true);
 }
 ```
 
@@ -195,7 +195,7 @@ private void CreateConfigWatcher()
     // Create config file watcher
     ConfigFileWatcher configFileWatcher = new(Config, reloadDelay: 1000);  // set delay before a subsequent reload can trigger in ms
 
-    // Subsrcibe to the event that fires whenever the config is reloaded.
+    // Subscribe to the event that fires whenever the config is reloaded.
     configFileWatcher.OnConfigFileReloaded += () =>
     {
         // code to call a method goes here

--- a/JotunnLib/Documentation/tutorials/config.md
+++ b/JotunnLib/Documentation/tutorials/config.md
@@ -67,6 +67,27 @@ Local settings will be overriden by the servers values as long as the client is 
 
 Changing the configs at runtime will sync the changes to all clients connected to the server.
 
+## Bind Config Extensions
+
+Jotunn provides the extension methods `BindConfig` and `BindConfigInOrder` for `ConfigFile` to make binding config entries easier. The above example can be replicated using `BindConfig` for convenience.
+
+```cs
+// Create some sample configuration values to check server sync
+private void CreateConfigValues()
+{
+    AcceptableValueRange<float> floatRange = new AcceptableValueRange<float>(0f, 1000f);
+
+    // Add server config which gets pushed to all clients connecting and can only be edited by admins
+    // In local/single player games the player is always considered the admin
+    Config.BindConfig("Server config", "StringValue1", "StringValue", "Server side string", true);
+    Config.BindConfig("Server config", "FloatValue1", 750f, "Server side float", true, floatRange);
+    Config.BindConfig("Server config", "IntegerValue1", 200, "Server side integer", synced: true, acceptableValues: floatRange);
+    Config.BindConfig("Server config", "BoolValue1", false, "Server side bool", true);
+}
+```
+
+The extension method `BindConfigInOrder` can be used in the same manner as `BindConfig` but it will automatically set the `Order` value in the `ConfigurationManagerAttributes` for that config entry to ensure it will be sorted in the order that the config entry was bound for that config section and it will prefix the config section name with the number of the section based on how many sections have already been bound to this config. It is possible to disable ordering of the config entry by setting `settingOrder: false` and the prefixing of the section name can be disabled by setting `sectionOrder: false`.
+
 ## Admin Only Strictness
 
 Usually, the `IsAdminOnly` flag is enforcing players to be admin on the server to change the configuration.
@@ -163,3 +184,21 @@ Note that `customConfig.Reload()` may be called to initiate a config sync if ent
 
 You can provide localized versions of the menu entry string.
 Please see our [localization tutorial](localization.md#localizable-content-in-jötunn) on how to do this.
+
+## File watcher for ConfigFile
+While many people use the official BepInEx configuration manager to change their mod configurations from in-game. Users also like the ability to make live changes to configuration files and see that data update live and saved when they shut down the game. Updating the in-game config settings when the configuration file is edited on the disk can be achieved by setting up a `FileWatcher` for your `ConfigFile` that triggers events when the file is changed, renamed, or saved. The `ConfigFileWatcher` class provides a convenient way to set up a `FileWatcher` and events with minimal boilerplate code. By default, after triggering a reload event, the `ConfigFileWatcher` will not trigger another reload untill 1000 ms have passed, you can modify this behaviour by changing the `reloadDelay` argument in the `ConfigFileWatcher` constructor.
+
+```cs
+// Create config file watcher as a method within the main plugin class
+private void CreateConfigWatcher()
+{
+    // Create config file watcher
+    ConfigFileWatcher configFileWatcher = new(Config, reloadDelay: 1000);  // set delay before a subsequent reload can trigger in ms
+
+    // Subsrcibe to the event that fires whenever the config is reloaded.
+    configFileWatcher.OnConfigFileReloaded += () =>
+    {
+        // code to call a method goes here
+    };
+}
+```

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -21,6 +21,7 @@ namespace Jotunn.Extensions
         ///     Formats section name as "{sectionNumber} - {section}" based on how
         ///     many sections have been bound to this config.
         /// </summary>
+        /// <param name="configFile"></param>
         /// <param name="section"></param>
         /// <returns></returns>
         private static string GetOrderedSectionName(this ConfigFile configFile, string section)
@@ -43,6 +44,7 @@ namespace Jotunn.Extensions
         /// <summary>
         ///     Orders settings within a section.
         /// </summary>
+        /// <param name="configFile"></param>
         /// <param name="section"></param>
         /// <returns></returns>
         private static int GetSettingOrder(this ConfigFile configFile, string section)

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -148,14 +148,13 @@ namespace Jotunn.Extensions
         }
 
         /// <summary>
-        ///     Sets SaveOnConfigSet to false and returns
-        ///     the Value from before this method was called.
+        ///     Sets SaveOnConfigSet and returns the original value before this method was called.
         /// </summary>
         /// <returns></returns>
-        public static bool DisableSaveOnConfigSet(this ConfigFile configFile)
+        public static bool SetSaveOnConfigSet(this ConfigFile configFile, bool saveOnConfigSet)
         {
             bool val = configFile.SaveOnConfigSet;
-            configFile.SaveOnConfigSet = false;
+            configFile.SaveOnConfigSet = saveOnConfigSet;
             return val;
         }
     }

--- a/JotunnLib/Extensions/ConfigFileExtensions.cs
+++ b/JotunnLib/Extensions/ConfigFileExtensions.cs
@@ -146,5 +146,17 @@ namespace Jotunn.Extensions
 
             return configEntry;
         }
+
+        /// <summary>
+        ///     Sets SaveOnConfigSet to false and returns
+        ///     the Value from before this method was called.
+        /// </summary>
+        /// <returns></returns>
+        public static bool DisableSaveOnConfigSet(this ConfigFile configFile)
+        {
+            bool val = configFile.SaveOnConfigSet;
+            configFile.SaveOnConfigSet = false;
+            return val;
+        }
     }
 }

--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -6,7 +6,10 @@ using Jotunn.Extensions;
 
 namespace Jotunn.Utils
 {
-    internal sealed class ConfigFileWatcher
+    /// <summary>
+    ///     Watches a <see cref="ConfigFile"/> for changes and raises events when the configuration file is modified.
+    /// </summary>
+    public class ConfigFileWatcher
     {
         private const long TICKS_PER_MILISEC = 10000; // One milisecond
 
@@ -17,12 +20,11 @@ namespace Jotunn.Utils
         private readonly long ReloadDelay;
 
         /// <summary>
-        ///     Create a file watcher to triger reloads of the config file when 
-        ///     it is chaned, created, or renamed.
+        ///     Create a file watcher to trigger reloads of the config file when it is changed, created, or renamed.
         /// </summary>
         /// <param name="configFile"></param>
-        /// <param name="reloadDelay">Time in miliseconds before another event can be fired.</param>
-        internal ConfigFileWatcher(ConfigFile configFile, long reloadDelay = 1000)
+        /// <param name="reloadDelay">Time in milliseconds before another event can be fired.</param>
+        public ConfigFileWatcher(ConfigFile configFile, long reloadDelay = 1000)
         {
             this.configFile = configFile;
             this.ReloadDelay = reloadDelay * TICKS_PER_MILISEC;
@@ -40,7 +42,7 @@ namespace Jotunn.Utils
         /// <summary>
         ///     Event triggered after the file watcher reloads the configuration file.
         /// </summary>
-        internal event Action OnConfigFileReloaded;
+        public event Action OnConfigFileReloaded;
 
         /// <summary>
         ///     Safely invoke the <see cref="OnConfigFileReloaded"/> event
@@ -51,9 +53,8 @@ namespace Jotunn.Utils
         }
 
         /// <summary>
-        ///     Reloads config file if and only if the last write time difers from the last read time.
+        ///     Reloads config file if and only if the last write time differs from the last read time.
         /// </summary>
-        /// <param name="configFile"></param>
         /// <param name="sender"></param>
         /// <param name="eventArgs"></param>
         internal void ReloadConfigFile(object sender, FileSystemEventArgs eventArgs)

--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using BepInEx.Configuration;
 using BepInEx;
 using Jotunn.Extensions;
@@ -15,6 +16,7 @@ namespace Jotunn.Utils
 
         private DateTime lastReadTime = DateTime.MinValue;
         private readonly ConfigFile configFile;
+        private readonly BepInPlugin sourceMod;
         private readonly string configFileDir;
         private readonly string configFileName;
         private readonly long reloadDelay;
@@ -26,10 +28,17 @@ namespace Jotunn.Utils
         /// <param name="reloadDelay">Time in milliseconds before another event can be fired.</param>
         public ConfigFileWatcher(ConfigFile configFile, long reloadDelay = 1000)
         {
+            sourceMod = BepInExUtils.GetPluginInfoFromAssembly(Assembly.GetCallingAssembly())?.Metadata;
+            if (sourceMod == null || sourceMod.GUID == Main.Instance.Info.Metadata.GUID)
+            {
+                sourceMod = BepInExUtils.GetSourceModMetadata();
+            }
+
             this.configFile = configFile;
             this.reloadDelay = reloadDelay * TICKS_PER_MILISEC;
             configFileDir = Directory.GetParent(configFile.ConfigFilePath).FullName;
             configFileName = Path.GetFileName(configFile.ConfigFilePath);
+
             var watcher = new FileSystemWatcher(configFileDir, configFileName);
             watcher.Changed += ReloadConfigFile;
             watcher.Created += ReloadConfigFile;
@@ -68,7 +77,7 @@ namespace Jotunn.Utils
 
             try
             {
-                Logger.LogInfo($"Reloading {configFile.ConfigFilePath}");
+                Logger.LogInfo(sourceMod, $"Reloading {configFile.ConfigFilePath}");
                 bool saveOnConfigSet = configFile.SetSaveOnConfigSet(false); // turn off saving on config entry set
                 configFile.Reload();
                 configFile.SaveOnConfigSet = saveOnConfigSet; // reset config saving state
@@ -77,8 +86,8 @@ namespace Jotunn.Utils
             }
             catch
             {
-                Logger.LogError($"There was an issue loading {configFile.ConfigFilePath}");
-                Logger.LogError("Please check your config entries for spelling and format!");
+                Logger.LogError(sourceMod, $"There was an issue loading {configFile.ConfigFilePath}");
+                Logger.LogError(sourceMod, "Please check your config entries for spelling and format!");
             }
         }
     }

--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using BepInEx.Configuration;
+using BepInEx;
+using Jotunn.Extensions;
+
+namespace Jotunn.Utils
+{
+    internal sealed class ConfigFileWatcher
+    {
+        private const long TICKS_PER_SEC = 10000000; // One second
+
+        private DateTime lastReadTime = DateTime.MinValue;
+        private readonly ConfigFile configFile;
+        private readonly string ConfigFileDir;
+        private readonly string ConfigFileName;
+        private readonly long ReloadDelay;
+
+        /// <summary>
+        ///     Create a file watcher to triger reloads of the config file when 
+        ///     it is chaned, created, or renamed.
+        /// </summary>
+        /// <param name="configFile"></param>
+        /// <param name="reloadDelay">Time in miliseconds before another event can be fired.</param>
+        internal ConfigFileWatcher(ConfigFile configFile, long reloadDelay = 1000)
+        {
+            this.configFile = configFile;
+            this.ReloadDelay = reloadDelay * TICKS_PER_SEC;
+            ConfigFileDir = Directory.GetParent(configFile.ConfigFilePath).FullName;
+            ConfigFileName = Path.GetFileName(configFile.ConfigFilePath);
+            var watcher = new FileSystemWatcher(ConfigFileDir, ConfigFileName);
+            watcher.Changed += ReloadConfigFile;
+            watcher.Created += ReloadConfigFile;
+            watcher.Renamed += ReloadConfigFile;
+            watcher.IncludeSubdirectories = true;
+            watcher.SynchronizingObject = ThreadingHelper.SynchronizingObject;
+            watcher.EnableRaisingEvents = true;
+        }
+
+        /// <summary>
+        ///     Event triggered after the file watcher reloads the configuration file.
+        /// </summary>
+        internal event Action OnConfigFileReloaded;
+
+        /// <summary>
+        ///     Safely invoke the <see cref="OnConfigFileReloaded"/> event
+        /// </summary>
+        private void InvokeOnConfigFileReloaded()
+        {
+            OnConfigFileReloaded?.SafeInvoke();
+        }
+
+        /// <summary>
+        ///     Reloads config file if and only if the last write time difers from the last read time.
+        /// </summary>
+        /// <param name="configFile"></param>
+        /// <param name="sender"></param>
+        /// <param name="eventArgs"></param>
+        internal void ReloadConfigFile(object sender, FileSystemEventArgs eventArgs)
+        {
+            DateTime now = DateTime.Now;
+            long deltaTime = now.Ticks - lastReadTime.Ticks;
+            if (!File.Exists(configFile.ConfigFilePath) || deltaTime < this.ReloadDelay)
+            {
+                return;
+            }
+
+            try
+            {
+                Logger.LogInfo($"Reloading {configFile.ConfigFilePath}");
+                bool saveOnConfigSet = configFile.DisableSaveOnConfigSet(); // turn off saving on config entry set
+                configFile.Reload();
+                configFile.SaveOnConfigSet = saveOnConfigSet; // reset config saving state
+                lastReadTime = now;
+                InvokeOnConfigFileReloaded(); // fire event
+            }
+            catch
+            {
+                Logger.LogError($"There was an issue loading {configFile.ConfigFilePath}");
+                Logger.LogError("Please check your config entries for spelling and format!");
+            }
+        }
+    }
+}

--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -11,13 +11,13 @@ namespace Jotunn.Utils
     /// </summary>
     public class ConfigFileWatcher
     {
-        private const long TICKS_PER_MILISEC = 10000; // One milisecond
+        private const long TICKS_PER_MILISEC = 10_000; // One millisecond
 
         private DateTime lastReadTime = DateTime.MinValue;
         private readonly ConfigFile configFile;
-        private readonly string ConfigFileDir;
-        private readonly string ConfigFileName;
-        private readonly long ReloadDelay;
+        private readonly string configFileDir;
+        private readonly string configFileName;
+        private readonly long reloadDelay;
 
         /// <summary>
         ///     Create a file watcher to trigger reloads of the config file when it is changed, created, or renamed.
@@ -27,10 +27,10 @@ namespace Jotunn.Utils
         public ConfigFileWatcher(ConfigFile configFile, long reloadDelay = 1000)
         {
             this.configFile = configFile;
-            this.ReloadDelay = reloadDelay * TICKS_PER_MILISEC;
-            ConfigFileDir = Directory.GetParent(configFile.ConfigFilePath).FullName;
-            ConfigFileName = Path.GetFileName(configFile.ConfigFilePath);
-            var watcher = new FileSystemWatcher(ConfigFileDir, ConfigFileName);
+            this.reloadDelay = reloadDelay * TICKS_PER_MILISEC;
+            configFileDir = Directory.GetParent(configFile.ConfigFilePath).FullName;
+            configFileName = Path.GetFileName(configFile.ConfigFilePath);
+            var watcher = new FileSystemWatcher(configFileDir, configFileName);
             watcher.Changed += ReloadConfigFile;
             watcher.Created += ReloadConfigFile;
             watcher.Renamed += ReloadConfigFile;
@@ -61,7 +61,7 @@ namespace Jotunn.Utils
         {
             DateTime now = DateTime.Now;
             long deltaTime = now.Ticks - lastReadTime.Ticks;
-            if (!File.Exists(configFile.ConfigFilePath) || deltaTime < this.ReloadDelay)
+            if (!File.Exists(configFile.ConfigFilePath) || deltaTime < this.reloadDelay)
             {
                 return;
             }
@@ -69,7 +69,7 @@ namespace Jotunn.Utils
             try
             {
                 Logger.LogInfo($"Reloading {configFile.ConfigFilePath}");
-                bool saveOnConfigSet = configFile.DisableSaveOnConfigSet(); // turn off saving on config entry set
+                bool saveOnConfigSet = configFile.SetSaveOnConfigSet(false); // turn off saving on config entry set
                 configFile.Reload();
                 configFile.SaveOnConfigSet = saveOnConfigSet; // reset config saving state
                 lastReadTime = now;

--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -8,7 +8,7 @@ namespace Jotunn.Utils
 {
     internal sealed class ConfigFileWatcher
     {
-        private const long TICKS_PER_SEC = 10000000; // One second
+        private const long TICKS_PER_MILISEC = 10000; // One milisecond
 
         private DateTime lastReadTime = DateTime.MinValue;
         private readonly ConfigFile configFile;
@@ -25,7 +25,7 @@ namespace Jotunn.Utils
         internal ConfigFileWatcher(ConfigFile configFile, long reloadDelay = 1000)
         {
             this.configFile = configFile;
-            this.ReloadDelay = reloadDelay * TICKS_PER_SEC;
+            this.ReloadDelay = reloadDelay * TICKS_PER_MILISEC;
             ConfigFileDir = Directory.GetParent(configFile.ConfigFilePath).FullName;
             ConfigFileName = Path.GetFileName(configFile.ConfigFilePath);
             var watcher = new FileSystemWatcher(ConfigFileDir, ConfigFileName);


### PR DESCRIPTION
Goal:
Reduce unneeded boilerplate code that is copied between mods and provide a re-usable ConfigFile FileWatcher with events for mod authors.

Details:
Adds a new extension method `DisableSaveOnConfigSet()` to `ConfigFile` to disable save on config set while returning the value prior to calling the method so it can be cached and restored later.

Adds a new `ConfigFileWatcher` class to create a ConfigFile FileWatcher with events on a per config file basis. 