### PR TITLE
Fix: Remove exposing user info on config reload

### DIFF
--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -75,9 +75,12 @@ namespace Jotunn.Utils
                 return;
             }
 
+            // Only log file name to avoid exposing user info if it located within AppData (such as when using r2modman)
+            string configFileName = Path.GetFileName(configFile.ConfigFilePath);
             try
             {
-                Logger.LogInfo(sourceMod, $"Reloading {configFile.ConfigFilePath}");
+                
+                Logger.LogInfo(sourceMod, $"Reloading {configFileName}");
                 bool saveOnConfigSet = configFile.SetSaveOnConfigSet(false); // turn off saving on config entry set
                 configFile.Reload();
                 configFile.SaveOnConfigSet = saveOnConfigSet; // reset config saving state
@@ -86,7 +89,7 @@ namespace Jotunn.Utils
             }
             catch
             {
-                Logger.LogError(sourceMod, $"There was an issue loading {configFile.ConfigFilePath}");
+                Logger.LogError(sourceMod, $"There was an issue loading {configFileName}");
                 Logger.LogError(sourceMod, "Please check your config entries for spelling and format!");
             }
         }

--- a/JotunnLib/Utils/ConfigFileWatcher.cs
+++ b/JotunnLib/Utils/ConfigFileWatcher.cs
@@ -76,10 +76,8 @@ namespace Jotunn.Utils
             }
 
             // Only log file name to avoid exposing user info if it located within AppData (such as when using r2modman)
-            string configFileName = Path.GetFileName(configFile.ConfigFilePath);
             try
             {
-                
                 Logger.LogInfo(sourceMod, $"Reloading {configFileName}");
                 bool saveOnConfigSet = configFile.SetSaveOnConfigSet(false); // turn off saving on config entry set
                 configFile.Reload();


### PR DESCRIPTION
I was looking at the Vanilla logging in Valheim and realized it exposed User name and that made me realize that the ConfigFileWatcher class also does that when the config file it is watching is located within a subfolder of AppData, such as when people use r2modman. This is just a quick fix to change it to only log the file name rather than the full path.