### PR TITLE
Fix: Config Sync Resetting for Local Worlds

### DIFF
--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -213,7 +213,7 @@ namespace Jotunn.Managers
             ///     Return the cached local value of a bep config thats locked
             /// </summary>
             [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.GetSerializedValue)), HarmonyPrefix]
-            private bool GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
+            private static bool GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
             {
                 if (ReadWriteConfigFromDisk() || !__instance.IsSyncable() || __instance.GetLocalValue() == null)
                 {
@@ -229,7 +229,7 @@ namespace Jotunn.Managers
             ///     Prevent overwriting bep config value when the setting is locked on config file reload.
             /// </summary>
             [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.SetSerializedValue)), HarmonyPrefix]
-            private bool BlockSetForSyncedConfigs(ConfigEntryBase __instance)
+            private static bool BlockSetForSyncedConfigs(ConfigEntryBase __instance)
             {
                 return ReadWriteConfigFromDisk() || !__instance.IsSyncable();
             }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -207,33 +207,56 @@ namespace Jotunn.Managers
             [HarmonyPatch(typeof(Menu), nameof(Menu.IsVisible)), HarmonyPostfix]
             private static void Menu_IsVisible(ref bool __result) => Instance.Menu_IsVisible(ref __result);
 
-            [HarmonyPatch(typeof(FejdStartup), nameof(FejdStartup.Awake)), HarmonyPrefix]
-            private static void FejdStartup_Awake()
+
+            /// <summary>
+            ///     Harmony patch BepInEx to ensure locked values are not overwritten.
+            ///     Return the cached local value of a bep config thats locked
+            /// </summary>
+            [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.GetSerializedValue)), HarmonyPrefix]
+            private void GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
             {
-                Instance.ResetAdminState();
-                Instance.FejdStartup_Awake();
+                if (ReadWriteConfigFromDisk() || !__instance.IsSyncable() || __instance.GetLocalValue() == null)
+                {
+                    return true;
+                }
+
+                __result = TomlTypeConverter.ConvertToString(__instance.GetLocalValue(), __instance.SettingType);
+                return false;
             }
 
+            /// <summary>
+            ///     Harmony patch BepInEx to ensure locked values are not overwritten.
+            ///     Prevent overwriting bep config value when the setting is locked on config file reload.
+            /// </summary>
+            [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.SetSerializedValue)), HarmonyPrefix]
+            private void BlockSetForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
+            {
+                return ReadWriteConfigFromDisk() || !__instance.IsSyncable();
+            }
+
+            // Hooks for locking and unlocking synced configs
             [HarmonyPatch(typeof(ZNet), nameof(ZNet.Start)), HarmonyPrefix]
-            private static void ZNet_Start()
+            private static void ZNet_Start(ZNet __instance)
             {
-                Instance.InitAdminState();
+                Instance.InitAdminState(__instance);
+                Instance.SubscribeToConfigReload();
+            }
+
+            [HarmonyPatch(typeof(ZNet), nameof(ZNet.OnDestroy)), HarmonyPrefix]
+            private static void Znet_OnDestroy(ZNet __instance)
+            {
+                Instance.UnsubscribeToConfigReload();
+                Instance.ResetAdminState(__instance);               
             }
         }
 
-        private void ResetAdminState()
+        private void InitAdminState(ZNet zNet)
         {
-            PlayerIsAdmin = true;
-            UnlockConfigurationEntries();
-            ResetAdminConfigs();
-            CacheConfigurationValues();
-        }
-
-        private void InitAdminState()
-        {
+            // I think `InitAdminConfigs` can be moved into the else clause since local configs
+            // do not need to cached or reset if this ZNet.instance is the server
             InitAdminConfigs();
 
-            if (ZNet.instance && ZNet.instance.IsServer())
+            if (zNet && zNet.IsServer())
             {
                 PlayerIsAdmin = true;
                 UnlockConfigurationEntries();
@@ -244,6 +267,50 @@ namespace Jotunn.Managers
                 LockConfigurationEntries();
                 SetToDefaultConfigEntries();
             }
+        }
+
+        private void ResetAdminState(ZNet zNet)
+        {
+            PlayerIsAdmin = true;
+            UnlockConfigurationEntries();
+            ResetAdminConfigs(zNet);
+            CacheConfigurationValues();
+        }
+
+        /// <summary>
+        ///     Cache local config values for synced entries.
+        /// </summary>
+        private void InitAdminConfigs()
+        {
+            foreach (var config in GetConfigFiles())
+            {
+                foreach (var configDefinition in config.Keys)
+                {
+                    var configEntry = config[configDefinition.Section, configDefinition.Key];
+                    var configAttribute = configEntry.GetConfigurationManagerAttributes();
+
+                    if (configAttribute?.IsAdminOnly == true && configEntry.BoxedValue != null)
+                    {
+                        localValues[configEntry] = configEntry.BoxedValue;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Reset configs which may have been overwritten with server values to the local value
+        ///     if this machine is not the server.
+        /// </summary>
+        private void ResetAdminConfigs(ZNet zNet)
+        {
+            if (zNet && !zNet.IsServer())
+            {
+                foreach (var localValue in localValues)
+                {
+                    localValue.Key.BoxedValue = localValue.Value;
+                }
+            }
+            localValues.Clear();
         }
 
         /// <summary>
@@ -666,24 +733,25 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
-        ///     Initial cache the config values of dependent plugins and register ourself to config change events
+        ///     Register ourself to config reload events to trigger synchronizing configs
         /// </summary>
-        private void FejdStartup_Awake()
+        private void SubscribeToConfigReload()
         {
             foreach (var config in GetConfigFiles())
             {
                 config.ConfigReloaded += Config_ConfigReloaded;
             }
+        }
 
-            // Harmony patch BepInEx to ensure locked values are not overwritten
-            Main.Harmony.Patch(
-                AccessTools.DeclaredMethod(typeof(ConfigEntryBase), nameof(ConfigEntryBase.GetSerializedValue)),
-                new HarmonyMethod(AccessTools.DeclaredMethod(typeof(SynchronizationManager),
-                    nameof(ConfigEntryBase_GetSerializedValue))));
-            Main.Harmony.Patch(
-                AccessTools.DeclaredMethod(typeof(ConfigEntryBase), nameof(ConfigEntryBase.SetSerializedValue)),
-                new HarmonyMethod(AccessTools.DeclaredMethod(typeof(SynchronizationManager),
-                    nameof(ConfigEntryBase_SetSerializedValue))));
+        /// <summary>
+        ///     Un-Register ourself to config reload events to trigger synchronizing configs
+        /// </summary>
+        private void UnsubscribeToConfigReload()
+        {
+            foreach (var config in GetConfigFiles())
+            {
+                config.ConfigReloaded -= Config_ConfigReloaded;
+            }
         }
 
         /// <summary>
@@ -724,7 +792,7 @@ namespace Jotunn.Managers
         }
 
         /// <summary>
-        ///     Cache the synchronizable configuration values for comparison
+        ///     Cache the current synchronizable configuration values for comparison
         /// </summary>
         internal void CacheConfigurationValues()
         {
@@ -829,39 +897,6 @@ namespace Jotunn.Managers
                 // Rebuild config cache
                 CacheConfigurationValues();
             }
-        }
-
-        /// <summary>
-        ///     Cache local config values for synced entries
-        /// </summary>
-        private void InitAdminConfigs()
-        {
-            foreach (var config in GetConfigFiles())
-            {
-                foreach (var configDefinition in config.Keys)
-                {
-                    var configEntry = config[configDefinition.Section, configDefinition.Key];
-                    var configAttribute = configEntry.GetConfigurationManagerAttributes();
-
-                    if (configAttribute?.IsAdminOnly == true && configEntry.BoxedValue != null)
-                    {
-                        localValues[configEntry] = configEntry.BoxedValue;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///     Reset configs which may have been overwritten with server values to the local value
-        /// </summary>
-        private void ResetAdminConfigs()
-        {
-            foreach (var localValue in localValues)
-            {
-                localValue.Key.BoxedValue = localValue.Value;
-            }
-
-            localValues.Clear();
         }
 
         private void SetToDefaultConfigEntries()

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -213,7 +213,7 @@ namespace Jotunn.Managers
             ///     Return the cached local value of a bep config thats locked
             /// </summary>
             [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.GetSerializedValue)), HarmonyPrefix]
-            private void GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
+            private bool GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
             {
                 if (ReadWriteConfigFromDisk() || !__instance.IsSyncable() || __instance.GetLocalValue() == null)
                 {
@@ -229,7 +229,7 @@ namespace Jotunn.Managers
             ///     Prevent overwriting bep config value when the setting is locked on config file reload.
             /// </summary>
             [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.SetSerializedValue)), HarmonyPrefix]
-            private void BlockSetForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
+            private bool BlockSetForSyncedConfigs(ConfigEntryBase __instance)
             {
                 return ReadWriteConfigFromDisk() || !__instance.IsSyncable();
             }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -239,9 +239,6 @@ namespace Jotunn.Managers
 
         private void InitAdminState(ZNet zNet)
         {
-            // I think `InitAdminConfigs` can be moved into the else clause since local configs
-            // do not need to cached or reset if this ZNet.instance is the server
-            InitAdminConfigs();
             CacheConfigurationValues();
 
             if (zNet && zNet.IsServer())
@@ -252,6 +249,7 @@ namespace Jotunn.Managers
             else
             {
                 PlayerIsAdmin = false;
+                InitAdminConfigs();
                 LockConfigurationEntries();
                 SetToDefaultConfigEntries();
             }

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -255,6 +255,7 @@ namespace Jotunn.Managers
             // I think `InitAdminConfigs` can be moved into the else clause since local configs
             // do not need to cached or reset if this ZNet.instance is the server
             InitAdminConfigs();
+            CacheConfigurationValues();
 
             if (zNet && zNet.IsServer())
             {
@@ -274,7 +275,6 @@ namespace Jotunn.Managers
             PlayerIsAdmin = true;
             UnlockConfigurationEntries();
             ResetAdminConfigs(zNet);
-            CacheConfigurationValues();
         }
 
         /// <summary>

--- a/JotunnLib/Managers/SynchronizationManager.cs
+++ b/JotunnLib/Managers/SynchronizationManager.cs
@@ -207,32 +207,19 @@ namespace Jotunn.Managers
             [HarmonyPatch(typeof(Menu), nameof(Menu.IsVisible)), HarmonyPostfix]
             private static void Menu_IsVisible(ref bool __result) => Instance.Menu_IsVisible(ref __result);
 
-
             /// <summary>
             ///     Harmony patch BepInEx to ensure locked values are not overwritten.
             ///     Return the cached local value of a bep config thats locked
             /// </summary>
             [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.GetSerializedValue)), HarmonyPrefix]
-            private static bool GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result)
-            {
-                if (ReadWriteConfigFromDisk() || !__instance.IsSyncable() || __instance.GetLocalValue() == null)
-                {
-                    return true;
-                }
-
-                __result = TomlTypeConverter.ConvertToString(__instance.GetLocalValue(), __instance.SettingType);
-                return false;
-            }
+            private static bool GetCachedValueForSyncedConfigs(ConfigEntryBase __instance, ref string __result) => ConfigEntryBase_GetSerializedValue(__instance, ref __result);
 
             /// <summary>
             ///     Harmony patch BepInEx to ensure locked values are not overwritten.
             ///     Prevent overwriting bep config value when the setting is locked on config file reload.
             /// </summary>
             [HarmonyPatch(typeof(ConfigEntryBase), nameof(ConfigEntryBase.SetSerializedValue)), HarmonyPrefix]
-            private static bool BlockSetForSyncedConfigs(ConfigEntryBase __instance)
-            {
-                return ReadWriteConfigFromDisk() || !__instance.IsSyncable();
-            }
+            private static bool BlockSetForSyncedConfigs(ConfigEntryBase __instance) => ConfigEntryBase_SetSerializedValue(__instance);
 
             // Hooks for locking and unlocking synced configs
             [HarmonyPatch(typeof(ZNet), nameof(ZNet.Start)), HarmonyPrefix]
@@ -246,7 +233,7 @@ namespace Jotunn.Managers
             private static void Znet_OnDestroy(ZNet __instance)
             {
                 Instance.UnsubscribeToConfigReload();
-                Instance.ResetAdminState(__instance);               
+                Instance.ResetAdminState(__instance);
             }
         }
 
@@ -781,7 +768,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Prevent overwriting bep config value when the setting is locked on config file reload
         /// </summary>
-        private static bool ConfigEntryBase_SetSerializedValue(ConfigEntryBase __instance, string value)
+        private static bool ConfigEntryBase_SetSerializedValue(ConfigEntryBase __instance)
         {
             return ReadWriteConfigFromDisk() || !__instance.IsSyncable();
         }


### PR DESCRIPTION
Currently, local configs are cached whenever a player joins a server (including a solo world) and it resets the configs to the cached values when the player reaches the start menu. This means that when playing in a solo world, any config changes made while in the world are reset to the values they were during the main menu. 

I've addressed this by changing the hook for resetting the configs to the cached local values to trigger on `ZNet.OnDestroy` so that the reset logic can skip resetting to cached values if `ZNet.instance.IsServer() == true`. This should prevent configs being overwritten for solo play. I think it should also work to skip caching local values when joining a server if  `ZNet.instance.IsServer() == true` and I have left a comment to that effect.

The method `CacheConfigurationValues` has also been moved into `InitAdminState` as `ResetAdminState` now only runs for the first time when exiting a server rather than when entering the main menu.

While working on that I noticed a few likely unintended behaviours for config syncing as well. Config reloaded events were being subscribed to every single time a player reached the main menu so I have added a method to unsubscribe from the event and trigger the subscribing on `ZNet.Start` and the unsubscribing on `ZNet.OnDestroy`.

Similarly, the patches to `ConfigEntryBase` were being applied every time the main menu was reached so I have moved those patches into the `Patches` class so they are only applied once when `SynchronizationManager` first initializes.