### PR TITLE
Add compatibility with SoftReferenceableAssets for customLocations

### DIFF
--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -4,6 +4,7 @@ using Jotunn.Configs;
 using Jotunn.Managers;
 using SoftReferenceableAssets;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Jotunn.Entities
 {
@@ -122,8 +123,9 @@ namespace Jotunn.Entities
                 Logger.LogError($"SoftReference invalid for prefab: {softReferencePrefab.Name}");
                 return;
             }
-            
-            AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab.m_assetID, ZoneManager.Instance.LocationContainer.transform);
+
+            var parent = ZoneManager.Instance.LocationContainer.transform;
+            AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab.m_assetID, parent, OnLocationResolve);
             Name = softReferencePrefab.Name;
             ZoneLocation = locationConfig.GetZoneLocation();
             ZoneLocation.m_prefab = softReferencePrefab;
@@ -131,7 +133,15 @@ namespace Jotunn.Entities
             FixReference = fixReference;
             SoftReference = true;
         }
-        
+
+        private void OnLocationResolve(Object asset)
+        {
+            if (asset is GameObject gameObject && gameObject.TryGetComponent<ZoneSystem.ZoneLocation>(out var zoneLocation))
+            {
+                ZoneManager.Instance.PrepareLocation(zoneLocation, SourceMod);
+            }
+        }
+
         /// <summary>
         ///     Helper method to determine if a location prefab with a given name is a custom location created with Jötunn.
         /// </summary>

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -103,7 +103,7 @@ namespace Jotunn.Entities
             }
 
             ZoneLocation = locationConfig.GetZoneLocation();
-            ZoneLocation.m_prefab = AssetManager.Instance.InjectLoadedAsset(exteriorPrefab);
+            ZoneLocation.m_prefab = new SoftReference<GameObject>(AssetManager.Instance.AddAsset(exteriorPrefab));
             ZoneLocation.m_prefabName = exteriorPrefab.name;
 
             FixReference = fixReference;

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -38,6 +38,12 @@ namespace Jotunn.Entities
         ///     Indicator if references from <see cref="Entities.Mock{T}"/>s will be replaced at runtime.
         /// </summary>
         public bool FixReference { get; set; }
+        
+        /// <summary>
+        ///     Indicator if location is added from SoftReferenceableAssets.<br />
+        ///     Used to delay mocking prefabs until ZoneSystem.SpawnLocation()
+        /// </summary>
+        public bool SoftReference { get; set; }
 
         /// <summary>
         ///     Custom location from a prefab with a <see cref="LocationConfig"/> attached.<br />

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -110,6 +110,30 @@ namespace Jotunn.Entities
         }
         
         /// <summary>
+        ///     Custom location from a prefab with a <see cref="LocationConfig"/> attached. Using SoftReference system.
+        /// </summary>
+        /// <param name="exteriorPrefab">The exterior prefab for this custom location.</param>
+        /// <param name="fixReference">If true references for <see cref="Entities.Mock{T}"/> objects get resolved at runtime by Jötunn.</param>
+        /// <param name="locationConfig">The <see cref="LocationConfig"/> for this custom location.</param>
+        public CustomLocation(string prefabName, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
+        {
+            SoftReference<GameObject> softPrefab = AssetManager.Instance.GetSoftReference<GameObject>(prefabName);
+
+            if (!softPrefab.IsValid)
+            {
+                Logger.LogError($"[CustomLocation] SoftReference invalid for prefab: {prefabName}");
+                return;
+            }
+            
+            Name = prefabName;
+            ZoneLocation = locationConfig.GetZoneLocation();
+            ZoneLocation.m_prefab = softPrefab;
+            ZoneLocation.m_prefabName = prefabName;
+            FixReference = fixReference;
+            SoftReference = true;
+        }
+        
+        /// <summary>
         ///     Helper method to determine if a location prefab with a given name is a custom location created with Jötunn.
         /// </summary>
         /// <param name="prefabName">Name of the prefab to test.</param>

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -112,7 +112,7 @@ namespace Jotunn.Entities
         /// <summary>
         ///     Custom location from a prefab with a <see cref="LocationConfig"/> attached. Using SoftReference system.
         /// </summary>
-        /// <param name="exteriorPrefab">The exterior prefab for this custom location.</param>
+        /// <param name="prefabName">The exterior prefab for this custom location.</param>
         /// <param name="fixReference">If true references for <see cref="Entities.Mock{T}"/> objects get resolved at runtime by Jötunn.</param>
         /// <param name="locationConfig">The <see cref="LocationConfig"/> for this custom location.</param>
         public CustomLocation(string prefabName, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
@@ -121,7 +121,7 @@ namespace Jotunn.Entities
 
             if (!softPrefab.IsValid)
             {
-                Logger.LogError($"[CustomLocation] SoftReference invalid for prefab: {prefabName}");
+                Logger.LogError($"SoftReference invalid for prefab: {prefabName}");
                 return;
             }
             

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -97,35 +97,8 @@ namespace Jotunn.Entities
             }
 
             ZoneLocation = locationConfig.GetZoneLocation();
-            ZoneLocation.m_prefab = new SoftReference<GameObject>(AssetManager.Instance.AddAsset(exteriorPrefab));
+            ZoneLocation.m_prefab = AssetManager.Instance.InjectLoadedAsset(exteriorPrefab);
             ZoneLocation.m_prefabName = exteriorPrefab.name;
-
-            FixReference = fixReference;
-        }
-        
-        public CustomLocation(SoftReference<GameObject> exteriorPrefab, SoftReference<GameObject> interiorPrefab, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
-        {
-            Prefab = exteriorPrefab.Asset;
-            Name = exteriorPrefab.Asset.name;
-
-            if (exteriorPrefab.Asset.TryGetComponent<Location>(out var location))
-            {
-                Location = location;
-            }
-            else
-            {
-                Location = exteriorPrefab.Asset.AddComponent<Location>();
-                Location.m_clearArea = locationConfig.ClearArea;
-                Location.m_exteriorRadius = locationConfig.ExteriorRadius;
-                Location.m_interiorPrefab = interiorPrefab.Asset;
-                Location.m_hasInterior = locationConfig.HasInterior;
-                Location.m_interiorRadius = locationConfig.InteriorRadius;
-                Location.m_interiorEnvironment = locationConfig.InteriorEnvironment;
-            }
-
-            ZoneLocation = locationConfig.GetZoneLocation();
-            ZoneLocation.m_prefab = new SoftReference<GameObject>(AssetManager.Instance.AddAsset(exteriorPrefab.Asset));
-            ZoneLocation.m_prefabName = exteriorPrefab.Asset.name;
 
             FixReference = fixReference;
         }

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -103,6 +103,33 @@ namespace Jotunn.Entities
             FixReference = fixReference;
         }
         
+        public CustomLocation(SoftReference<GameObject> exteriorPrefab, SoftReference<GameObject> interiorPrefab, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
+        {
+            Prefab = exteriorPrefab.Asset;
+            Name = exteriorPrefab.Asset.name;
+
+            if (exteriorPrefab.Asset.TryGetComponent<Location>(out var location))
+            {
+                Location = location;
+            }
+            else
+            {
+                Location = exteriorPrefab.Asset.AddComponent<Location>();
+                Location.m_clearArea = locationConfig.ClearArea;
+                Location.m_exteriorRadius = locationConfig.ExteriorRadius;
+                Location.m_interiorPrefab = interiorPrefab.Asset;
+                Location.m_hasInterior = locationConfig.HasInterior;
+                Location.m_interiorRadius = locationConfig.InteriorRadius;
+                Location.m_interiorEnvironment = locationConfig.InteriorEnvironment;
+            }
+
+            ZoneLocation = locationConfig.GetZoneLocation();
+            ZoneLocation.m_prefab = new SoftReference<GameObject>(AssetManager.Instance.AddAsset(exteriorPrefab.Asset));
+            ZoneLocation.m_prefabName = exteriorPrefab.Asset.name;
+
+            FixReference = fixReference;
+        }
+        
         /// <summary>
         ///     Helper method to determine if a location prefab with a given name is a custom location created with Jötunn.
         /// </summary>

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -125,7 +125,7 @@ namespace Jotunn.Entities
             }
 
             var parent = ZoneManager.Instance.LocationContainer.transform;
-            AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab.m_assetID, parent, OnLocationResolve);
+            AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab, parent, OnLocationResolve);
             Name = softReferencePrefab.Name;
             ZoneLocation = locationConfig.GetZoneLocation();
             ZoneLocation.m_prefab = softReferencePrefab;
@@ -134,9 +134,9 @@ namespace Jotunn.Entities
             SoftReference = true;
         }
 
-        private void OnLocationResolve(Object asset)
+        private void OnLocationResolve(GameObject gameObject)
         {
-            if (asset is GameObject gameObject && gameObject.TryGetComponent<ZoneSystem.ZoneLocation>(out var zoneLocation))
+            if (gameObject.TryGetComponent<ZoneSystem.ZoneLocation>(out var zoneLocation))
             {
                 ZoneManager.Instance.PrepareLocation(zoneLocation, SourceMod);
             }

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -112,7 +112,7 @@ namespace Jotunn.Entities
         /// <summary>
         ///     Custom location from a prefab with a <see cref="LocationConfig"/> attached. Using SoftReference system.
         /// </summary>
-        /// <param name="prefabName">The exterior prefab for this custom location.</param>
+        /// <param name="softReferencePrefab">The exterior prefab for this custom location.</param>
         /// <param name="fixReference">If true references for <see cref="Entities.Mock{T}"/> objects get resolved at runtime by Jötunn.</param>
         /// <param name="locationConfig">The <see cref="LocationConfig"/> for this custom location.</param>
         public CustomLocation(SoftReference<GameObject> softReferencePrefab, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
@@ -123,6 +123,7 @@ namespace Jotunn.Entities
                 return;
             }
             
+            AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab.m_assetID, ZoneManager.Instance.LocationContainer.transform);
             Name = softReferencePrefab.Name;
             ZoneLocation = locationConfig.GetZoneLocation();
             ZoneLocation.m_prefab = softReferencePrefab;

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -115,20 +115,18 @@ namespace Jotunn.Entities
         /// <param name="prefabName">The exterior prefab for this custom location.</param>
         /// <param name="fixReference">If true references for <see cref="Entities.Mock{T}"/> objects get resolved at runtime by Jötunn.</param>
         /// <param name="locationConfig">The <see cref="LocationConfig"/> for this custom location.</param>
-        public CustomLocation(string prefabName, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
+        public CustomLocation(SoftReference<GameObject> softReferencePrefab, bool fixReference, LocationConfig locationConfig) : base(Assembly.GetCallingAssembly())
         {
-            SoftReference<GameObject> softPrefab = AssetManager.Instance.GetSoftReference<GameObject>(prefabName);
-
-            if (!softPrefab.IsValid)
+            if (!softReferencePrefab.IsValid)
             {
-                Logger.LogError($"SoftReference invalid for prefab: {prefabName}");
+                Logger.LogError($"SoftReference invalid for prefab: {softReferencePrefab.Name}");
                 return;
             }
             
-            Name = prefabName;
+            Name = softReferencePrefab.Name;
             ZoneLocation = locationConfig.GetZoneLocation();
-            ZoneLocation.m_prefab = softPrefab;
-            ZoneLocation.m_prefabName = prefabName;
+            ZoneLocation.m_prefab = softReferencePrefab;
+            ZoneLocation.m_prefabName = softReferencePrefab.Name;
             FixReference = fixReference;
             SoftReference = true;
         }

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -10,7 +10,6 @@ using Jotunn.Utils;
 using SoftReferenceableAssets;
 using UnityEngine;
 using UnityEngine.Audio;
-using AssetBundleManifest = SoftReferenceableAssets.AssetBundleManifest;
 using Object = UnityEngine.Object;
 
 namespace Jotunn.Managers
@@ -175,7 +174,7 @@ namespace Jotunn.Managers
             return AddAsset(asset, null);
         }
 
-        public static void AddAssetToBundleLoader(AssetBundleLoader assetBundleLoader, AssetID assetID, AssetRef assetRef)
+        private static void AddAssetToBundleLoader(AssetBundleLoader assetBundleLoader, AssetID assetID, AssetRef assetRef)
         {
             // create fake bundle, since an AssetBundle can't be created at runtime
             string bundleName = $"JVL_BundleWrapper_{assetRef.asset.name}";
@@ -241,7 +240,7 @@ namespace Jotunn.Managers
         /// </summary>
         /// <param name="asset"></param>
         /// <returns>AssetID generated from the string</returns>
-        public static AssetID GenerateAssetID(string asset)
+        public AssetID GenerateAssetID(string asset)
         {
             uint u = (uint)asset.GetStableHashCode();
             return new AssetID(u, u, u, u);
@@ -447,7 +446,7 @@ namespace Jotunn.Managers
             }
         }
 
-        public struct AssetRef
+        private struct AssetRef
         {
             public BepInPlugin sourceMod;
             public Object asset;

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -32,6 +32,9 @@ namespace Jotunn.Managers
         private Dictionary<Type, Dictionary<string, AssetID>> mapNameToAssetID;
         internal Dictionary<Type, Dictionary<string, AssetID>> MapNameToAssetID => mapNameToAssetID ??= CreateNameToAssetID();
 
+        private GameObject ResolvedAssetsContainer;
+        private Dictionary<AssetID, MockResolutionContext> assetsToResolve = new Dictionary<AssetID, MockResolutionContext>();
+
         /// <summary>
         ///     Hide .ctor
         /// </summary>
@@ -45,6 +48,11 @@ namespace Jotunn.Managers
         void IManager.Init()
         {
             Main.LogInit(nameof(AssetManager));
+
+            ResolvedAssetsContainer = new GameObject("Resolved Assets");
+            ResolvedAssetsContainer.transform.parent = Main.RootObject.transform;
+            ResolvedAssetsContainer.SetActive(false);
+
             Main.Harmony.PatchAll(typeof(Patches));
         }
 
@@ -83,6 +91,32 @@ namespace Jotunn.Managers
                     .MatchForward(false, new CodeMatch(i => i.Calls(addMethod)))
                     .SetInstruction(new CodeInstruction(OpCodes.Call, addSafeMethod))
                     .InstructionEnumeration();
+            }
+
+            [HarmonyPatch(typeof(AssetLoader), nameof(AssetLoader.HoldReference)), HarmonyPostfix]
+            private static void AssetLoader_HoldReference(ref AssetLoader __instance)
+            {
+                if (__instance.ReferenceCount == 1)
+                {
+                    if (Instance.assetsToResolve.TryGetValue(__instance.m_assetID, out var mockedAsset))
+                    {
+                        __instance.Load();
+                        mockedAsset.InstantiateAndResolveAsset(__instance.m_asset);
+                        __instance.m_asset = mockedAsset.Asset;
+                    }
+                }
+            }
+
+            [HarmonyPatch(typeof(AssetLoader), nameof(AssetLoader.Release)), HarmonyPostfix]
+            private static void AssetLoader_Release(ref AssetLoader __instance)
+            {
+                if (__instance.ReferenceCount == 0)
+                {
+                    if (Instance.assetsToResolve.TryGetValue(__instance.m_assetID, out var mockedAsset))
+                    {
+                        mockedAsset.DestroyAsset();
+                    }
+                }
             }
         }
 
@@ -133,6 +167,20 @@ namespace Jotunn.Managers
         public AssetID AddAsset(Object asset)
         {
             return AddAsset(asset, null);
+        }
+
+        /// <summary>
+        ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
+        ///     Must be called before the asset is loaded the first time.
+        /// </summary>
+        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
+        /// <param name="parent">Optional transform under which the asset will be instantiated, otherwise a default container is used</param>
+        public void ResolveMocksOnLoad(AssetID assetID, Transform parent = null)
+        {
+            if (!assetsToResolve.ContainsKey(assetID))
+            {
+                assetsToResolve.Add(assetID, new MockResolutionContext(parent ?? ResolvedAssetsContainer.transform));
+            }
         }
 
         private static void AddAssetToBundleLoader(AssetBundleLoader assetBundleLoader, AssetID assetID, AssetRef assetRef)
@@ -407,6 +455,46 @@ namespace Jotunn.Managers
                 this.sourceMod = sourceMod;
                 this.asset = asset;
                 this.originalID = original && Instance.IsReady() ? Instance.GetAssetID(original.GetType(), original.name) : default;
+            }
+        }
+
+        internal class MockResolutionContext
+        {
+            public Object Asset { get; private set; }
+            public Transform Parent { get; private set; }
+
+            public MockResolutionContext(Transform parent)
+            {
+                this.Parent = parent;
+            }
+
+            public bool IsResolved => (bool)Asset;
+
+            public void InstantiateAndResolveAsset(Object realAsset)
+            {
+                if (!Asset)
+                {
+                    Asset = Object.Instantiate(realAsset, Parent);
+                    Asset.name = realAsset.name;
+
+                    if (Asset is GameObject gameObject)
+                    {
+                        gameObject.FixReferences(true);
+                    }
+                    else
+                    {
+                        Asset.FixReferences();
+                    }
+                }
+            }
+
+            public void DestroyAsset()
+            {
+                if (Asset)
+                {
+                    Object.Destroy(Asset);
+                    Asset = null;
+                }
             }
         }
     }

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -124,44 +124,6 @@ namespace Jotunn.Managers
 
             return assetID;
         }
-        
-        public SoftReference<T> InjectLoadedAsset<T>(T obj) where T : UnityEngine.Object
-        {
-            AssetBundleLoader instance = AssetBundleLoader.Instance;
-            
-            string bundleName = $"JVL_BundleWrapper_{obj.name}";
-            string assetPath = $"JVL/Prefabs/{obj.name}";
-
-            if (!instance.m_bundleNameToLoaderIndex.ContainsKey(bundleName))
-            {
-                int nextIndex = instance.m_bundleLoaders.Length;
-                BundleLoader bundleLoader = new BundleLoader(bundleName, "");
-                bundleLoader.HoldReference();
-                
-                instance.m_bundleLoaders = instance.m_bundleLoaders.AddItem(bundleLoader).ToArray();
-                instance.m_bundleNameToLoaderIndex[bundleName] = nextIndex;
-            }
-
-            AssetID assetID = GenerateAssetID(obj.name);
-            AssetLocation location = new AssetLocation(bundleName, assetPath);
-            AssetLoader loader = new AssetLoader(assetID, location);
-            
-            loader.m_referenceCounter = new ReferenceCounter(2U);
-            loader.m_asset = obj;
-            loader.m_shouldBeLoaded = true;
-
-            int index = instance.m_assetIDToLoaderIndex.Count;
-
-            if (index >= instance.m_assetLoaders.Length)
-            {
-                Array.Resize(ref instance.m_assetLoaders, index + 256);
-            }
-
-            instance.m_assetLoaders[index] = loader;
-            instance.m_assetIDToLoaderIndex[assetID] = index;
-
-            return new SoftReference<T>(assetID) { m_name = obj.name };
-        }
 
         /// <summary>
         ///     Registers a new asset and generates a unique AssetID.<br />
@@ -232,17 +194,6 @@ namespace Jotunn.Managers
         public AssetID GenerateAssetID(Object asset)
         {
             uint u = (uint)asset.name.GetStableHashCode();
-            return new AssetID(u, u, u, u);
-        }
-        
-        /// <summary>
-        ///     Generates a unique AssetID, based on the asset name
-        /// </summary>
-        /// <param name="asset"></param>
-        /// <returns>AssetID generated from the string</returns>
-        public AssetID GenerateAssetID(string asset)
-        {
-            uint u = (uint)asset.GetStableHashCode();
             return new AssetID(u, u, u, u);
         }
 

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -236,6 +236,17 @@ namespace Jotunn.Managers
             uint u = (uint)asset.name.GetStableHashCode();
             return new AssetID(u, u, u, u);
         }
+        
+        /// <summary>
+        ///     Generates a unique AssetID, based on the asset name
+        /// </summary>
+        /// <param name="asset"></param>
+        /// <returns>AssetID generated from the string</returns>
+        public static AssetID GenerateAssetID(string asset)
+        {
+            uint u = (uint)asset.GetStableHashCode();
+            return new AssetID(u, u, u, u);
+        }
 
         /// <summary>
         ///     Clones a prefab and registers it in the SoftReference system with the same dependencies as the original asset

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -30,7 +30,6 @@ namespace Jotunn.Managers
         private Dictionary<AssetID, AssetRef> assets = new Dictionary<AssetID, AssetRef>();
 
         private Dictionary<Type, Dictionary<string, AssetID>> mapNameToAssetID;
-
         internal Dictionary<Type, Dictionary<string, AssetID>> MapNameToAssetID => mapNameToAssetID ??= CreateNameToAssetID();
 
         /// <summary>

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -93,14 +93,13 @@ namespace Jotunn.Managers
                     .InstructionEnumeration();
             }
 
-            [HarmonyPatch(typeof(AssetLoader), nameof(AssetLoader.HoldReference)), HarmonyPostfix]
-            private static void AssetLoader_HoldReference(ref AssetLoader __instance)
+            [HarmonyPatch(typeof(AssetLoader), nameof(AssetLoader.InvokeCallbacks)), HarmonyPrefix]
+            private static void SwapResolvedAsset(ref AssetLoader __instance, LoadResult result)
             {
-                if (__instance.ReferenceCount == 1)
+                if (result == LoadResult.Succeeded)
                 {
                     if (Instance.assetsToResolve.TryGetValue(__instance.m_assetID, out var mockedAsset))
                     {
-                        __instance.Load();
                         mockedAsset.InstantiateAndResolveAsset(__instance.m_asset);
                         __instance.m_asset = mockedAsset.Asset;
                     }
@@ -363,7 +362,7 @@ namespace Jotunn.Managers
         /// <param name="name">Asset name to search for</param>
         /// <typeparam name="T">Asset type to search for</typeparam>
         /// <returns></returns>
-        public SoftReference<T> GetSoftReference<T>(string name) where T: Object
+        public SoftReference<T> GetSoftReference<T>(string name) where T : Object
         {
             AssetID assetID = GetAssetID<T>(name);
             return assetID.IsValid ? new SoftReference<T>(assetID) : default;

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -173,7 +173,7 @@ namespace Jotunn.Managers
         ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
         ///     Must be called before the asset is loaded the first time.
         /// </summary>
-        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
+        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for on load</param>
         public void ResolveMocksOnLoad(AssetID assetID)
         {
             ResolveMocksOnLoad(assetID, null, null);
@@ -183,7 +183,7 @@ namespace Jotunn.Managers
         ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
         ///     Must be called before the asset is loaded the first time.
         /// </summary>
-        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
+        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for on load</param>
         /// <param name="parent">Optional transform under which the asset will be instantiated, otherwise a default container is used</param>
         public void ResolveMocksOnLoad(AssetID assetID, Transform parent)
         {
@@ -194,12 +194,29 @@ namespace Jotunn.Managers
         ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
         ///     Must be called before the asset is loaded the first time.
         /// </summary>
-        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
+        /// <param name="softReference">The <see cref="SoftReference{T}"/> to instantiate and resolve mocks for on load</param>
         /// <param name="parent">Optional transform under which the asset will be instantiated, otherwise a default container is used</param>
-        /// <param name="resolveCallback">Callback when the asset was resolved and instantiated</param>
+        /// <param name="resolveCallback">Adds a callback when the asset was resolved and instantiated</param>
+        public void ResolveMocksOnLoad<T>(SoftReference<T> softReference, Transform parent, Action<T> resolveCallback) where T : Object
+        {
+            ResolveMocksOnLoad(softReference.m_assetID, parent, (asset) => resolveCallback?.Invoke(asset as T));
+        }
+
+        /// <summary>
+        ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
+        ///     Must be called before the asset is loaded the first time.
+        /// </summary>
+        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for on load</param>
+        /// <param name="parent">Optional transform under which the asset will be instantiated, otherwise a default container is used</param>
+        /// <param name="resolveCallback">Adds a callback when the asset was resolved and instantiated</param>
         public void ResolveMocksOnLoad(AssetID assetID, Transform parent, Action<Object> resolveCallback)
         {
-            if (!assetsToResolve.ContainsKey(assetID))
+            if (assetsToResolve.TryGetValue(assetID, out var context))
+            {
+                context.Parent = parent ?? context.Parent ?? ResolvedAssetsContainer.transform;
+                context.ResolveCallback += resolveCallback;
+            }
+            else
             {
                 assetsToResolve.Add(assetID, new MockResolutionContext(parent ?? ResolvedAssetsContainer.transform, resolveCallback));
             }
@@ -483,13 +500,13 @@ namespace Jotunn.Managers
         internal class MockResolutionContext
         {
             public Object Asset { get; private set; }
-            public Transform Parent { get; private set; }
-            public Action<Object> ResolveCallback { get; private set; }
+            public Transform Parent { get; set; }
+            public Action<Object> ResolveCallback { get; set; }
 
             public MockResolutionContext(Transform parent, Action<Object> resolveCallback)
             {
                 this.Parent = parent;
-                this.ResolveCallback = resolveCallback;
+                this.ResolveCallback += resolveCallback;
             }
 
             public bool IsResolved => (bool)Asset;

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -174,12 +174,34 @@ namespace Jotunn.Managers
         ///     Must be called before the asset is loaded the first time.
         /// </summary>
         /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
+        public void ResolveMocksOnLoad(AssetID assetID)
+        {
+            ResolveMocksOnLoad(assetID, null, null);
+        }
+
+        /// <summary>
+        ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
+        ///     Must be called before the asset is loaded the first time.
+        /// </summary>
+        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
         /// <param name="parent">Optional transform under which the asset will be instantiated, otherwise a default container is used</param>
-        public void ResolveMocksOnLoad(AssetID assetID, Transform parent = null)
+        public void ResolveMocksOnLoad(AssetID assetID, Transform parent)
+        {
+            ResolveMocksOnLoad(assetID, parent, null);
+        }
+
+        /// <summary>
+        ///     Registers an asset to be instantiated under the given parent and have its mock references resolved on load.<b/>
+        ///     Must be called before the asset is loaded the first time.
+        /// </summary>
+        /// <param name="assetID">The <see cref="AssetID"/> of the asset to instantiate and resolve mocks for</param>
+        /// <param name="parent">Optional transform under which the asset will be instantiated, otherwise a default container is used</param>
+        /// <param name="resolveCallback">Callback when the asset was resolved and instantiated</param>
+        public void ResolveMocksOnLoad(AssetID assetID, Transform parent, Action<Object> resolveCallback)
         {
             if (!assetsToResolve.ContainsKey(assetID))
             {
-                assetsToResolve.Add(assetID, new MockResolutionContext(parent ?? ResolvedAssetsContainer.transform));
+                assetsToResolve.Add(assetID, new MockResolutionContext(parent ?? ResolvedAssetsContainer.transform, resolveCallback));
             }
         }
 
@@ -462,30 +484,36 @@ namespace Jotunn.Managers
         {
             public Object Asset { get; private set; }
             public Transform Parent { get; private set; }
+            public Action<Object> ResolveCallback { get; private set; }
 
-            public MockResolutionContext(Transform parent)
+            public MockResolutionContext(Transform parent, Action<Object> resolveCallback)
             {
                 this.Parent = parent;
+                this.ResolveCallback = resolveCallback;
             }
 
             public bool IsResolved => (bool)Asset;
 
             public void InstantiateAndResolveAsset(Object realAsset)
             {
-                if (!Asset)
+                if (IsResolved)
                 {
-                    Asset = Object.Instantiate(realAsset, Parent);
-                    Asset.name = realAsset.name;
-
-                    if (Asset is GameObject gameObject)
-                    {
-                        gameObject.FixReferences(true);
-                    }
-                    else
-                    {
-                        Asset.FixReferences();
-                    }
+                    return;
                 }
+
+                Asset = Object.Instantiate(realAsset, Parent);
+                Asset.name = realAsset.name;
+
+                if (Asset is GameObject gameObject)
+                {
+                    gameObject.FixReferences(true);
+                }
+                else
+                {
+                    Asset.FixReferences();
+                }
+
+                ResolveCallback?.Invoke(Asset);
             }
 
             public void DestroyAsset()
@@ -493,8 +521,9 @@ namespace Jotunn.Managers
                 if (Asset)
                 {
                     Object.Destroy(Asset);
-                    Asset = null;
                 }
+
+                Asset = null;
             }
         }
     }

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -32,8 +32,6 @@ namespace Jotunn.Managers
 
         private Dictionary<Type, Dictionary<string, AssetID>> mapNameToAssetID;
 
-        private static List<AssetBundleManifest> softReferenceManifests = new List<AssetBundleManifest>();
-
         internal Dictionary<Type, Dictionary<string, AssetID>> MapNameToAssetID => mapNameToAssetID ??= CreateNameToAssetID();
 
         /// <summary>
@@ -88,19 +86,6 @@ namespace Jotunn.Managers
                     .SetInstruction(new CodeInstruction(OpCodes.Call, addSafeMethod))
                     .InstructionEnumeration();
             }
-
-            [HarmonyPatch(typeof(AssetBundleDatabase))]
-            [HarmonyPatch(MethodType.Constructor)]
-            [HarmonyPatch(new Type[] { typeof(string[]) })]
-            private static void AssetBundleDatabase_Constructor(AssetBundleDatabase __instance)
-            {
-                FieldInfo fieldInfo = AccessTools.Field(typeof(AssetBundleDatabase), "m_assetBundleManifests");
-                AssetBundleManifest[] manifests = (AssetBundleManifest[])fieldInfo.GetValue(__instance);
-
-                Array.Resize(ref manifests, __instance.m_assetBundleManifests.Length + softReferenceManifests.Count);
-
-                fieldInfo.SetValue(__instance, manifests);
-            }
         }
 
         /// <summary>
@@ -152,31 +137,7 @@ namespace Jotunn.Managers
             return AddAsset(asset, null);
         }
 
-        public static void GenerateSoftRefManifest(AssetBundle bundle, UnityEngine.AssetBundleManifest assetBundleManifest)
-        {
-            if (bundle == null)
-            {
-                Debug.LogError("AssetBundle is null.");
-                return;
-            }
-
-            AssetBundleManifest manifest = new AssetBundleManifest("./Bundles");
-            
-            manifest.AddBundleDependencies(bundle.name, assetBundleManifest.GetAllDependencies(bundle.name));
-
-            string[] assetNames = bundle.GetAllAssetNames();
-            foreach (var asset in assetNames)
-            {
-                AssetID assetId = GenerateAssetID(asset);
-                AssetLocation assetLocation = new AssetLocation(bundle.name, asset);
-                manifest.AddAssetLocation(assetId, assetLocation);
-            }
-
-            bundle.Unload(false);
-            softReferenceManifests.Add(manifest);
-        }
-
-        private static void AddAssetToBundleLoader(AssetBundleLoader assetBundleLoader, AssetID assetID, AssetRef assetRef)
+        public static void AddAssetToBundleLoader(AssetBundleLoader assetBundleLoader, AssetID assetID, AssetRef assetRef)
         {
             // create fake bundle, since an AssetBundle can't be created at runtime
             string bundleName = $"JVL_BundleWrapper_{assetRef.asset.name}";

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -125,6 +125,44 @@ namespace Jotunn.Managers
 
             return assetID;
         }
+        
+        public SoftReference<T> InjectLoadedAsset<T>(T obj) where T : UnityEngine.Object
+        {
+            AssetBundleLoader instance = AssetBundleLoader.Instance;
+            
+            string bundleName = $"JVL_BundleWrapper_{obj.name}";
+            string assetPath = $"JVL/Prefabs/{obj.name}";
+
+            if (!instance.m_bundleNameToLoaderIndex.ContainsKey(bundleName))
+            {
+                int nextIndex = instance.m_bundleLoaders.Length;
+                BundleLoader bundleLoader = new BundleLoader(bundleName, "");
+                bundleLoader.HoldReference();
+                
+                instance.m_bundleLoaders = instance.m_bundleLoaders.AddItem(bundleLoader).ToArray();
+                instance.m_bundleNameToLoaderIndex[bundleName] = nextIndex;
+            }
+
+            AssetID assetID = GenerateAssetID(obj.name);
+            AssetLocation location = new AssetLocation(bundleName, assetPath);
+            AssetLoader loader = new AssetLoader(assetID, location);
+            
+            loader.m_referenceCounter = new ReferenceCounter(2U);
+            loader.m_asset = obj;
+            loader.m_shouldBeLoaded = true;
+
+            int index = instance.m_assetIDToLoaderIndex.Count;
+
+            if (index >= instance.m_assetLoaders.Length)
+            {
+                Array.Resize(ref instance.m_assetLoaders, index + 256);
+            }
+
+            instance.m_assetLoaders[index] = loader;
+            instance.m_assetIDToLoaderIndex[assetID] = index;
+
+            return new SoftReference<T>(assetID) { m_name = obj.name };
+        }
 
         /// <summary>
         ///     Registers a new asset and generates a unique AssetID.<br />
@@ -409,7 +447,7 @@ namespace Jotunn.Managers
             }
         }
 
-        private struct AssetRef
+        public struct AssetRef
         {
             public BepInPlugin sourceMod;
             public Object asset;

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -10,6 +10,7 @@ using Jotunn.Utils;
 using SoftReferenceableAssets;
 using UnityEngine;
 using UnityEngine.Audio;
+using AssetBundleManifest = SoftReferenceableAssets.AssetBundleManifest;
 using Object = UnityEngine.Object;
 
 namespace Jotunn.Managers
@@ -30,6 +31,9 @@ namespace Jotunn.Managers
         private Dictionary<AssetID, AssetRef> assets = new Dictionary<AssetID, AssetRef>();
 
         private Dictionary<Type, Dictionary<string, AssetID>> mapNameToAssetID;
+
+        private static List<AssetBundleManifest> softReferenceManifests = new List<AssetBundleManifest>();
+
         internal Dictionary<Type, Dictionary<string, AssetID>> MapNameToAssetID => mapNameToAssetID ??= CreateNameToAssetID();
 
         /// <summary>
@@ -83,6 +87,19 @@ namespace Jotunn.Managers
                     .MatchForward(false, new CodeMatch(i => i.Calls(addMethod)))
                     .SetInstruction(new CodeInstruction(OpCodes.Call, addSafeMethod))
                     .InstructionEnumeration();
+            }
+
+            [HarmonyPatch(typeof(AssetBundleDatabase))]
+            [HarmonyPatch(MethodType.Constructor)]
+            [HarmonyPatch(new Type[] { typeof(string[]) })]
+            private static void AssetBundleDatabase_Constructor(AssetBundleDatabase __instance)
+            {
+                FieldInfo fieldInfo = AccessTools.Field(typeof(AssetBundleDatabase), "m_assetBundleManifests");
+                AssetBundleManifest[] manifests = (AssetBundleManifest[])fieldInfo.GetValue(__instance);
+
+                Array.Resize(ref manifests, __instance.m_assetBundleManifests.Length + softReferenceManifests.Count);
+
+                fieldInfo.SetValue(__instance, manifests);
             }
         }
 

--- a/JotunnLib/Managers/AssetManager.cs
+++ b/JotunnLib/Managers/AssetManager.cs
@@ -135,6 +135,30 @@ namespace Jotunn.Managers
             return AddAsset(asset, null);
         }
 
+        public static void GenerateSoftRefManifest(AssetBundle bundle, UnityEngine.AssetBundleManifest assetBundleManifest)
+        {
+            if (bundle == null)
+            {
+                Debug.LogError("AssetBundle is null.");
+                return;
+            }
+
+            AssetBundleManifest manifest = new AssetBundleManifest("./Bundles");
+            
+            manifest.AddBundleDependencies(bundle.name, assetBundleManifest.GetAllDependencies(bundle.name));
+
+            string[] assetNames = bundle.GetAllAssetNames();
+            foreach (var asset in assetNames)
+            {
+                AssetID assetId = GenerateAssetID(asset);
+                AssetLocation assetLocation = new AssetLocation(bundle.name, asset);
+                manifest.AddAssetLocation(assetId, assetLocation);
+            }
+
+            bundle.Unload(false);
+            softReferenceManifests.Add(manifest);
+        }
+
         private static void AddAssetToBundleLoader(AssetBundleLoader assetBundleLoader, AssetID assetID, AssetRef assetRef)
         {
             // create fake bundle, since an AssetBundle can't be created at runtime

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -373,6 +373,12 @@ namespace Jotunn.Managers
             if (znet)
             {
                 string name = gameObject.name;
+
+                if (gameObject.name.StartsWith("JVLmock_"))
+                {
+                    return;
+                }
+                
                 int hash = name.GetStableHashCode();
 
                 if (znet.m_namedPrefabs.ContainsKey(hash))

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -374,7 +374,7 @@ namespace Jotunn.Managers
             {
                 string name = gameObject.name;
 
-                if (gameObject.name.StartsWith("JVLmock_"))
+                if (gameObject.name.StartsWith(MockManager.JVLMockPrefix))
                 {
                     return;
                 }

--- a/JotunnLib/Managers/RenderManager.cs
+++ b/JotunnLib/Managers/RenderManager.cs
@@ -451,8 +451,18 @@ namespace Jotunn.Managers
             HashSet<Type> visitedNodes = new HashSet<Type>();
             HashSet<Type> recursionStack = new HashSet<Type>();
 
+            if (!tranform || !tranform.gameObject)
+            {
+                return result;
+            }
+
             foreach (Component component in tranform.gameObject.GetComponents<Component>())
             {
+                if (!component)
+                {
+                    continue;
+                }
+
                 if (!TopologicalSortUtil(component.GetType(), visitedNodes, recursionStack, result))
                 {
                     Logger.LogWarning($"Cycles detected in component dependencies for type {component.GetType()}. Unable to determine deletion order for {tranform}.");

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -561,7 +561,8 @@ namespace Jotunn.Managers
                             $"Adding custom location {customLocation} in {string.Join(", ", GetMatchingBiomes(customLocation.ZoneLocation.m_biome))}");
 
                         // Fix references if needed
-                        if (customLocation.FixReference)
+                        // Skip if customLocation uses softReference system. If use softReference, fixReference is done in SpawnLocation Harmony patch.
+                        if (customLocation.FixReference && !customLocation.SoftReference)
                         {
                             customLocation.Prefab.FixReferences(true);
                             customLocation.FixReference = false;

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -290,10 +290,15 @@ namespace Jotunn.Managers
                 Logger.LogWarning(customLocation.SourceMod, $"Location {customLocation.Name} already exists");
                 return false;
             }
-            
-            // The root prefab needs to be active, otherwise ZNetViews are not prepared correctly
-            customLocation.Prefab.SetActive(true);
 
+            // Skip if location uses softReference system.
+            // If using softReference prefab is in assetbundle and therefore not immutable
+            if (!customLocation.SoftReference)
+            {
+                // The root prefab needs to be active, otherwise ZNetViews are not prepared correctly
+                customLocation.Prefab.SetActive(true);
+            }
+            
             Locations.Add(customLocation.Name, customLocation);
             return true;
         }

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -111,41 +111,35 @@ namespace Jotunn.Managers
             }
             
             [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.SpawnLocation)), HarmonyPrefix]
-            private static void ZoneSystem_PlaceLocations_Prefix(ZoneSystem __instance, ZoneSystem.ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
+            private static void ZoneSystem_PlaceLocations_Prefix(ZoneSystem __instance, ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
             {
-                
-                ZoneSystem.LocationInstance locationInstance;
-                    if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
+                if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
+                {
+                    CustomLocation customLocation = Instance.GetCustomLocation(location.m_prefab.Name);
+                    if (customLocation.FixReference && customLocation.SoftReference)
                     {
-                        CustomLocation customLocation = Instance.GetCustomLocation(location.m_prefab.Name);
-                        if (customLocation.FixReference && customLocation.SoftReference)
-                        {
-                            location.m_prefab.Load();
-                            GameObject mockLocationContainer = GameObject.Instantiate(location.m_prefab.Asset, ZoneManager.Instance.LocationContainer.transform);
-                            mockLocationContainer.FixReferences(true);
-                            location.m_prefab.m_loadedAsset = mockLocationContainer;
-                            Object.Destroy(mockLocationContainer);
-                            
-                        }
+                        location.m_prefab.Load();
+                        GameObject mockLocationContainer = Object.Instantiate(location.m_prefab.Asset, Instance.LocationContainer.transform);
+                        mockLocationContainer.FixReferences(true);
+                        location.m_prefab.m_loadedAsset = mockLocationContainer;
+                        Object.Destroy(mockLocationContainer);
                     }
-                
+                }
             }
 
             [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.SpawnLocation)), HarmonyPostfix]
-            private static void ZoneSystem_SpawnLocation_Postfix(ZoneSystem __instance, ZoneSystem.ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
-            {    
+            private static void ZoneSystem_SpawnLocation_Postfix(ZoneSystem __instance, ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
+            {
                 if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
                 {
-                    CustomLocation customLocation =
-                        Instance.GetCustomLocation(location.m_prefab.Name);
+                    CustomLocation customLocation = Instance.GetCustomLocation(location.m_prefab.Name);
                     if (customLocation.FixReference && customLocation.SoftReference)
                     {
                         location.m_prefab.Release();
                     }
                 }
             }
-            
-            
+
             [HarmonyPatch(typeof(ClutterSystem), nameof(ClutterSystem.Awake)), HarmonyPostfix]
             private static void ClutterSystem_Awake(ClutterSystem __instance) => Instance.ClutterSystem_Awake(__instance);
         }

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -200,25 +200,6 @@ namespace Jotunn.Managers
             container.transform.SetParent(LocationContainer.transform);
             return container;
         }
-        
-        /// <summary>
-        ///     Destroy a child GameObject of LocationContainer with the specified name.
-        /// </summary>
-        /// <param name="name">Name of the location container to destroy</param>
-        public void DestroyLocationContainer(string name)
-        {
-            // Find the container under the LocationContainer by name
-            Transform container = LocationContainer.transform.Find(name);
-    
-            if (container != null)
-            {
-                GameObject.Destroy(container.gameObject);
-            }
-            else
-            {
-                Debug.LogWarning($"LocationContainer with name '{name}' not found.");
-            }
-        }
 
         /// <summary>
         ///     Create a copy that is disabled, so any Components in instantiated child GameObjects will not start their lifecycle.<br />
@@ -368,6 +349,34 @@ namespace Jotunn.Managers
         /// <param name="name">Name of the CustomLocation to search for.</param>
         public bool RemoveCustomLocation(string name)
         {
+            return Locations.Remove(name);
+        }
+        
+        /// <summary>
+        ///     Destroy a CustomLocation by its name.<br />
+        ///     Removes the CustomLocation from the manager and from the <see cref="ZoneSystem"/> if instantiated.
+        /// </summary>
+        /// <param name="name">Name of the CustomLocation to search for.</param>
+        public bool DestroyCustomLocation(string name)
+        {
+            if (!Locations.TryGetValue(name, out CustomLocation customLocation))
+            {
+                return false;
+            }
+
+            int hash = name.GetStableHashCode();
+
+            if (ZoneSystem.instance && ZoneSystem.instance.m_locationsByHash.TryGetValue(hash, out ZoneLocation location))
+            {
+                ZoneSystem.instance.m_locationsByHash.Remove(hash);
+                ZoneSystem.instance.m_locations.Remove(location);
+            }
+
+            if (customLocation.Prefab)
+            {
+                Object.Destroy(customLocation.Prefab);
+            }
+
             return Locations.Remove(name);
         }
 

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -507,25 +507,25 @@ namespace Jotunn.Managers
                 {
                     try
                     {
-                        Logger.LogDebug(
-                            $"Adding custom location {customLocation} in {string.Join(", ", GetMatchingBiomes(customLocation.ZoneLocation.m_biome))}");
+                        Logger.LogDebug($"Adding custom location {customLocation} in {string.Join(", ", GetMatchingBiomes(customLocation.ZoneLocation.m_biome))}");
 
-                        // Fix references if needed
-                        // Skip if customLocation uses softReference system. If use softReference, fixReference is done in SpawnLocation Harmony patch.
                         if (customLocation.FixReference && !customLocation.SoftReference)
                         {
                             customLocation.Prefab.FixReferences(true);
                             customLocation.FixReference = false;
                         }
 
-                        var zoneLocation = customLocation.ZoneLocation;
+                        if (!customLocation.SoftReference)
+                        {
+                            PrepareLocation(customLocation.ZoneLocation, customLocation.SourceMod);
+                        }
 
-                        RegisterLocationInZoneSystem(self, zoneLocation, customLocation.SourceMod);
+                        RegisterLocationInZoneSystem(self, customLocation.ZoneLocation);
                     }
                     catch (Exception ex)
                     {
                         Logger.LogWarning(customLocation?.SourceMod, $"Exception caught while adding location: {ex}");
-                        toDelete.Add(customLocation.Name);
+                        toDelete.Add(customLocation?.Name);
                     }
                 }
 
@@ -585,61 +585,53 @@ namespace Jotunn.Managers
         ///     No mock references are fixed.
         /// </summary>
         /// <param name="zoneLocation"><see cref="ZoneLocation"/> to add to the <see cref="ZoneSystem"/></param>
-        public void RegisterLocationInZoneSystem(ZoneLocation zoneLocation) =>
-            RegisterLocationInZoneSystem(ZoneSystem.instance, zoneLocation, BepInExUtils.GetSourceModMetadata());
+        public void RegisterLocationInZoneSystem(ZoneLocation zoneLocation)
+        {
+            PrepareLocation(zoneLocation, BepInExUtils.GetSourceModMetadata());
+            RegisterLocationInZoneSystem(ZoneSystem.instance, zoneLocation);
+        }
 
-        /// <summary>
-        ///     Internal method for adding a ZoneLocation to a specific ZoneSystem.
-        /// </summary>
-        /// <param name="zoneSystem"><see cref="ZoneSystem"/> the location should be added to</param>
-        /// <param name="zoneLocation"><see cref="ZoneLocation"/> to add</param>
-        /// <param name="sourceMod"><see cref="BepInPlugin"/> which created the location</param>
-        private void RegisterLocationInZoneSystem(ZoneSystem zoneSystem, ZoneLocation zoneLocation, BepInPlugin sourceMod)
+        internal void PrepareLocation(ZoneLocation zoneLocation, BepInPlugin sourceMod)
         {
             zoneLocation.m_prefab.Load();
-            
+
             foreach (var znet in global::Utils.GetEnabledComponentsInChildren<ZNetView>(zoneLocation.m_prefab.Asset))
             {
-                string prefabName = znet.GetPrefabName();
-                if (prefabName.StartsWith(MockManager.JVLMockPrefix))
-                {
-                    continue;
-                }
-                
-                if (!ZNetScene.instance.m_namedPrefabs.ContainsKey(prefabName.GetStableHashCode()))
-                {
-                    var prefab = Object.Instantiate(znet.gameObject, PrefabManager.Instance.PrefabContainer.transform);
-                    prefab.name = prefabName;
-                    CustomPrefab customPrefab = new CustomPrefab(prefab, sourceMod);
-                    PrefabManager.Instance.AddPrefab(customPrefab);
-                    PrefabManager.Instance.RegisterToZNetScene(customPrefab.Prefab);
-                }
+                RegisterUnknownPrefab(sourceMod, znet);
             }
-            
+
             RandomSpawn[] randomSpawns = global::Utils.GetEnabledComponentsInChildren<RandomSpawn>(zoneLocation.m_prefab.Asset);
             foreach (var randomSpawn in randomSpawns)
             {
                 randomSpawn.Prepare();
             }
-            
+
             foreach (var znet in randomSpawns.SelectMany(x => x.m_childNetViews))
             {
-                string prefabName = znet.GetPrefabName();
-                if (prefabName.StartsWith(MockManager.JVLMockPrefix))
-                {
-                    continue;
-                }
-                
-                if (!ZNetScene.instance.m_namedPrefabs.ContainsKey(prefabName.GetStableHashCode()))
-                {
-                    var prefab = Object.Instantiate(znet.gameObject, PrefabManager.Instance.PrefabContainer.transform);
-                    prefab.name = prefabName;
-                    CustomPrefab customPrefab = new CustomPrefab(prefab, sourceMod);
-                    PrefabManager.Instance.AddPrefab(customPrefab);
-                    PrefabManager.Instance.RegisterToZNetScene(customPrefab.Prefab);
-                }
+                RegisterUnknownPrefab(sourceMod, znet);
+            }
+        }
+
+        private static void RegisterUnknownPrefab(BepInPlugin sourceMod, ZNetView znet) {
+            string prefabName = znet.GetPrefabName();
+
+            if (prefabName.StartsWith(MockManager.JVLMockPrefix))
+            {
+                return;
             }
 
+            if (!ZNetScene.instance.m_namedPrefabs.ContainsKey(prefabName.GetStableHashCode()))
+            {
+                var prefab = Object.Instantiate(znet.gameObject, PrefabManager.Instance.PrefabContainer.transform);
+                prefab.name = prefabName;
+                CustomPrefab customPrefab = new CustomPrefab(prefab, sourceMod);
+                PrefabManager.Instance.AddPrefab(customPrefab);
+                PrefabManager.Instance.RegisterToZNetScene(customPrefab.Prefab);
+            }
+        }
+
+        private void RegisterLocationInZoneSystem(ZoneSystem zoneSystem, ZoneLocation zoneLocation)
+        {
             if (!zoneSystem.m_locationsByHash.ContainsKey(zoneLocation.Hash))
             {
                 zoneSystem.m_locationsByHash.Add(zoneLocation.Hash, zoneLocation);

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -109,36 +109,6 @@ namespace Jotunn.Managers
                 Instance.RegisterLocations(__instance);
                 Instance.RegisterVegetation(__instance);
             }
-            
-            [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.SpawnLocation)), HarmonyPrefix]
-            private static void ZoneSystem_PlaceLocations_Prefix(ZoneSystem __instance, ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
-            {
-                if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
-                {
-                    CustomLocation customLocation = Instance.GetCustomLocation(location.m_prefab.Name);
-                    if (customLocation.FixReference && customLocation.SoftReference)
-                    {
-                        location.m_prefab.Load();
-                        GameObject mockLocationContainer = Object.Instantiate(location.m_prefab.Asset, Instance.LocationContainer.transform);
-                        mockLocationContainer.FixReferences(true);
-                        location.m_prefab.m_loadedAsset = mockLocationContainer;
-                        Object.Destroy(mockLocationContainer);
-                    }
-                }
-            }
-
-            [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.SpawnLocation)), HarmonyPostfix]
-            private static void ZoneSystem_SpawnLocation_Postfix(ZoneSystem __instance, ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
-            {
-                if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
-                {
-                    CustomLocation customLocation = Instance.GetCustomLocation(location.m_prefab.Name);
-                    if (customLocation.FixReference && customLocation.SoftReference)
-                    {
-                        location.m_prefab.Release();
-                    }
-                }
-            }
 
             [HarmonyPatch(typeof(ClutterSystem), nameof(ClutterSystem.Awake)), HarmonyPostfix]
             private static void ClutterSystem_Awake(ClutterSystem __instance) => Instance.ClutterSystem_Awake(__instance);

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -609,8 +609,6 @@ namespace Jotunn.Managers
         /// <param name="sourceMod"><see cref="BepInPlugin"/> which created the location</param>
         private void RegisterLocationInZoneSystem(ZoneSystem zoneSystem, ZoneLocation zoneLocation, BepInPlugin sourceMod)
         {
-            //  zoneLocation.m_prefab.Load();
-
             foreach (var znet in global::Utils.GetEnabledComponentsInChildren<ZNetView>(zoneLocation.m_prefab.Asset))
             {
                 string prefabName = znet.GetPrefabName();

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -637,7 +637,7 @@ namespace Jotunn.Managers
             foreach (var znet in global::Utils.GetEnabledComponentsInChildren<ZNetView>(zoneLocation.m_prefab.Asset))
             {
                 string prefabName = znet.GetPrefabName();
-                if (prefabName.StartsWith("JVLmock_"))
+                if (prefabName.StartsWith(MockManager.JVLMockPrefix))
                 {
                     continue;
                 }
@@ -661,7 +661,7 @@ namespace Jotunn.Managers
             foreach (var znet in randomSpawns.SelectMany(x => x.m_childNetViews))
             {
                 string prefabName = znet.GetPrefabName();
-                if (prefabName.StartsWith("JVLmock_"))
+                if (prefabName.StartsWith(MockManager.JVLMockPrefix))
                 {
                     continue;
                 }

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -646,9 +646,16 @@ namespace Jotunn.Managers
         /// <param name="sourceMod"><see cref="BepInPlugin"/> which created the location</param>
         private void RegisterLocationInZoneSystem(ZoneSystem zoneSystem, ZoneLocation zoneLocation, BepInPlugin sourceMod)
         {
+            zoneLocation.m_prefab.Load();
+            
             foreach (var znet in global::Utils.GetEnabledComponentsInChildren<ZNetView>(zoneLocation.m_prefab.Asset))
             {
                 string prefabName = znet.GetPrefabName();
+                if (prefabName.StartsWith("JVLmock_"))
+                {
+                    continue;
+                }
+                
                 if (!ZNetScene.instance.m_namedPrefabs.ContainsKey(prefabName.GetStableHashCode()))
                 {
                     var prefab = Object.Instantiate(znet.gameObject, PrefabManager.Instance.PrefabContainer.transform);
@@ -658,16 +665,21 @@ namespace Jotunn.Managers
                     PrefabManager.Instance.RegisterToZNetScene(customPrefab.Prefab);
                 }
             }
-
+            
             RandomSpawn[] randomSpawns = global::Utils.GetEnabledComponentsInChildren<RandomSpawn>(zoneLocation.m_prefab.Asset);
             foreach (var randomSpawn in randomSpawns)
             {
                 randomSpawn.Prepare();
             }
-
+            
             foreach (var znet in randomSpawns.SelectMany(x => x.m_childNetViews))
             {
                 string prefabName = znet.GetPrefabName();
+                if (prefabName.StartsWith("JVLmock_"))
+                {
+                    continue;
+                }
+                
                 if (!ZNetScene.instance.m_namedPrefabs.ContainsKey(prefabName.GetStableHashCode()))
                 {
                     var prefab = Object.Instantiate(znet.gameObject, PrefabManager.Instance.PrefabContainer.transform);

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -254,9 +254,7 @@ namespace Jotunn.Managers
                 Logger.LogWarning(customLocation.SourceMod, $"Location {customLocation.Name} already exists");
                 return false;
             }
-
-            customLocation.Prefab.transform.SetParent(LocationContainer.transform);
-
+            
             // The root prefab needs to be active, otherwise ZNetViews are not prepared correctly
             customLocation.Prefab.SetActive(true);
 
@@ -611,7 +609,7 @@ namespace Jotunn.Managers
         /// <param name="sourceMod"><see cref="BepInPlugin"/> which created the location</param>
         private void RegisterLocationInZoneSystem(ZoneSystem zoneSystem, ZoneLocation zoneLocation, BepInPlugin sourceMod)
         {
-            zoneLocation.m_prefab.Load();
+            //  zoneLocation.m_prefab.Load();
 
             foreach (var znet in global::Utils.GetEnabledComponentsInChildren<ZNetView>(zoneLocation.m_prefab.Asset))
             {

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -370,34 +370,6 @@ namespace Jotunn.Managers
         {
             return Locations.Remove(name);
         }
-        
-        /// <summary>
-        ///     Destroy a CustomLocation by its name.<br />
-        ///     Removes the CustomLocation from the manager and from the <see cref="ZoneSystem"/> if instantiated.
-        /// </summary>
-        /// <param name="name">Name of the CustomLocation to search for.</param>
-        public bool DestroyCustomLocation(string name)
-        {
-            if (!Locations.TryGetValue(name, out CustomLocation customLocation))
-            {
-                return false;
-            }
-
-            int hash = name.GetStableHashCode();
-
-            if (ZoneSystem.instance && ZoneSystem.instance.m_locationsByHash.TryGetValue(hash, out ZoneLocation location))
-            {
-                ZoneSystem.instance.m_locationsByHash.Remove(hash);
-                ZoneSystem.instance.m_locations.Remove(location);
-            }
-
-            if (customLocation.Prefab)
-            {
-                Object.Destroy(customLocation.Prefab);
-            }
-
-            return Locations.Remove(name);
-        }
 
         /// <summary>
         ///     Register a CustomVegetation to be added to the ZoneSystem

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -109,7 +109,43 @@ namespace Jotunn.Managers
                 Instance.RegisterLocations(__instance);
                 Instance.RegisterVegetation(__instance);
             }
+            
+            [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.SpawnLocation)), HarmonyPrefix]
+            private static void ZoneSystem_PlaceLocations_Prefix(ZoneSystem __instance, ZoneSystem.ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
+            {
+                
+                ZoneSystem.LocationInstance locationInstance;
+                    if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
+                    {
+                        CustomLocation customLocation = Instance.GetCustomLocation(location.m_prefab.Name);
+                        if (customLocation.FixReference && customLocation.SoftReference)
+                        {
+                            location.m_prefab.Load();
+                            GameObject mockLocationContainer = GameObject.Instantiate(location.m_prefab.Asset, ZoneManager.Instance.LocationContainer.transform);
+                            mockLocationContainer.FixReferences(true);
+                            location.m_prefab.m_loadedAsset = mockLocationContainer;
+                            Object.Destroy(mockLocationContainer);
+                            
+                        }
+                    }
+                
+            }
 
+            [HarmonyPatch(typeof(ZoneSystem), nameof(ZoneSystem.SpawnLocation)), HarmonyPostfix]
+            private static void ZoneSystem_SpawnLocation_Postfix(ZoneSystem __instance, ZoneSystem.ZoneLocation location, int seed, Vector3 pos, Quaternion rot, ZoneSystem.SpawnMode mode, List<GameObject> spawnedGhostObjects)
+            {    
+                if (CustomLocation.IsCustomLocation(location.m_prefab.Name))
+                {
+                    CustomLocation customLocation =
+                        Instance.GetCustomLocation(location.m_prefab.Name);
+                    if (customLocation.FixReference && customLocation.SoftReference)
+                    {
+                        location.m_prefab.Release();
+                    }
+                }
+            }
+            
+            
             [HarmonyPatch(typeof(ClutterSystem), nameof(ClutterSystem.Awake)), HarmonyPostfix]
             private static void ClutterSystem_Awake(ClutterSystem __instance) => Instance.ClutterSystem_Awake(__instance);
         }

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -164,6 +164,25 @@ namespace Jotunn.Managers
             container.transform.SetParent(LocationContainer.transform);
             return container;
         }
+        
+        /// <summary>
+        ///     Destroy a child GameObject of LocationContainer with the specified name.
+        /// </summary>
+        /// <param name="name">Name of the location container to destroy</param>
+        public void DestroyLocationContainer(string name)
+        {
+            // Find the container under the LocationContainer by name
+            Transform container = LocationContainer.transform.Find(name);
+    
+            if (container != null)
+            {
+                GameObject.Destroy(container.gameObject);
+            }
+            else
+            {
+                Debug.LogWarning($"LocationContainer with name '{name}' not found.");
+            }
+        }
 
         /// <summary>
         ///     Create a copy that is disabled, so any Components in instantiated child GameObjects will not start their lifecycle.<br />


### PR DESCRIPTION
The goal of this PR is to change where a Location's prefab is stored. 

The current implementation of Jotunn.ZoneManager stores all CustomLocation prefabs in a LocationContainer GameObject, which is held in the DontDestroyOnLoaded scene. This approach causes CustomLocations prefabs to always be held in the client's memory and therefore leads to very high RAM usage when large numbers of CustomLocations are added. This PR transitions CustomLocation prefabs to use the [new vanilla SoftReferenceableAsset system](https://www.valheimgame.com/support/modding-faq-for-the-asset-bundle-update-0-217-40/), which allows prefabs to be loaded from AssetBundles on disk only when they are needed. 

This PR solves the above problem by making changes to three files in Jotunn. Mod developers will still need to follow additional steps to make their assetBundles available to the SoftReferenceableAssets system. The steps will be outlined in a future documentation page.

**CustomLocation.cs** 
- A new bool softReference field. This field is used in ZoneManager Harmony patches to check if mocks should be resolved for the customLocation.
- A new CustomLocation constructor which gets the CustomLocations SoftRef prefab.

**PrefabManager.cs**
- Add a new check if prefab name is has "JVLmock_". SoftReference mocks are resolved at a later point that before therefore many of the prefabs with the "JVLmock_" prefix were being automatically added to PrefabManager.

**ZoneManager.cs**
- Add a Harmony Prefix to ZoneSystem.SpawnLocation(). This prefix is where we now resolve mocks for softReference locations.
- Add a Harmony PostFix to ZoneSystemSpawnLocation() to add an additional Release(). We added an additional Load() call in our prefix so we must also include an additional Release().
- Add checks if customLocation use softReference to skip existing logic
- Add checks if prefab starts with "JVLmock_" to skip adding to PrefabManager

