### PR TITLE
Fix: Release() call during SoftReference location registration causes intermittent NullReferenceException

### DIFF
--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -638,7 +638,11 @@ namespace Jotunn.Managers
                 zoneSystem.m_locations.Add(zoneLocation);
             }
 
-            zoneLocation.m_prefab.Release();
+            // Only release if the asset is currently loaded (meaning PrepareLocation called Load)
+            if (zoneLocation.m_prefab.IsLoaded)
+            {
+                zoneLocation.m_prefab.Release();
+            }
         }
 
         private static void InvokeOnVanillaLocationsAvailable() => OnVanillaLocationsAvailable?.SafeInvoke();


### PR DESCRIPTION
The SoftReference system uses reference counting to manage asset memory - Load() increments the count, Release() decrements it, and when the count reaches zero the asset is unloaded.

When registering SoftReference locations in ZoneManager.cs, PrepareLocation() is skipped (which normally calls Load), but RegisterLocationInZoneSystem() still calls Release(). This causes the reference count to underflow from 0 to uint.MaxValue (since it's unsigned). While the underflow itself doesn't trigger unloading (uint.MaxValue is not <= 0), it causes the count to be off by one for all subsequent operations.

The problem manifests when a location receives multiple Load calls during gameplay (async load from ZoneSystem.LocationPrefabLoadData + sync load from ZoneSystem.SpawnLocation). With the count off by one, releases bring it back to zero one call early, unloading the asset while it's still being accessed elsewhere. This causes intermittent NullReferenceExceptions in ZoneSystem.SpawnLocation when accessing location.m_prefab.Asset.

The fix is to only call Release() in RegisterLocationInZoneSystem() if the prefab was actually loaded during preparation, keeping the reference count balanced from the start.