### PR TITLE
Fix: preserve skill names across language changes

### DIFF
--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -169,7 +169,7 @@ namespace Jotunn.Managers
 
                 foreach (var skill in CustomSkills.Values)
                 {
-                    Localization.instance.AddWord($"skill_{skill.UID}", skill.LocalizedName);
+                    LocalizationManager.Instance.JotunnLocalization.AddTranslation($"skill_{skill.UID}", skill.LocalizedName);
                     self.m_skills.Add(skill.ToSkillDef());
                     Logger.LogDebug($"Registered skill {skill.Name} | ID: {skill.Identifier}");
                 }


### PR DESCRIPTION
## Fix: Skill names lost after language change

### Problem

When a skill is registered via `SkillManager.AddSkill()` with a literal string for `Name` (e.g., `Name = "Level"`) instead of a localization token, the skill displays correctly on initial load. However, after the user changes the game language, the skill name becomes `[skill_XXXXXXX]` (the internal skill ID).

### Root Cause

`SkillManager.RegisterCustomSkills()` was adding skill translations directly to `Localization.instance`:

Localization.instance.AddWord($"skill_{skill.UID}", skill.LocalizedName);

When the game language changes, `Localization.SetupLanguage()` clears and rebuilds the localization dictionary. The `LocalizationManager` patch re-adds translations from `CustomLocalization` objects, but skill translations were never stored there—they were lost.

### Fix

Changed to use `LocalizationManager.Instance.JotunnLocalization.AddTranslation()`, which stores translations in the `CustomLocalization` system. This ensures translations persist and are re-applied after language changes.

LocalizationManager.Instance.JotunnLocalization.AddTranslation($"skill_{skill.UID}", skill.LocalizedName);This follows the same pattern used by `PieceManager` for category translations.

### Testing

1. Register a skill with a literal name: `Name = "Level"`
2. Verify skill displays correctly
3. Change game language in settings
4. Verify skill name is preserved (previously showed `[skill_XXXXXXX]`)