### PR TITLE
fix: Skip read-only properties in mock resolution

### DIFF
--- a/JotunnLib/Managers/MockSystem/FieldMember.cs
+++ b/JotunnLib/Managers/MockSystem/FieldMember.cs
@@ -14,6 +14,7 @@ namespace Jotunn {
             IsUnityObject = MemberType.IsSameOrSubclass(typeof(Object));
             IsClass = MemberType.IsClass;
             HasGetMethod = true;
+            HasSetMethod = true;
             EnumeratedType = MemberType.GetEnumeratedType();
             IsEnumerableOfUnityObjects = EnumeratedType?.IsSameOrSubclass(typeof(Object)) == true;
             IsEnumeratedClass = EnumeratedType?.IsClass == true;

--- a/JotunnLib/Managers/MockSystem/MemberBase.cs
+++ b/JotunnLib/Managers/MockSystem/MemberBase.cs
@@ -4,6 +4,7 @@ namespace Jotunn {
     internal abstract class MemberBase
     {
         public bool HasGetMethod { get; protected set; }
+        public bool HasSetMethod { get; protected set; }
         public Type MemberType { get; protected set; }
         public Type EnumeratedType { get; protected set; }
         public bool IsUnityObject { get; protected set; }

--- a/JotunnLib/Managers/MockSystem/MockManager.cs
+++ b/JotunnLib/Managers/MockSystem/MockManager.cs
@@ -311,7 +311,7 @@ namespace Jotunn.Managers
                 return;
             }
 
-            if (member.IsUnityObject && member.HasGetMethod)
+            if (member.IsUnityObject && member.HasGetMethod && member.HasSetMethod)
             {
                 var target = (Object)member.GetValue(objectToFix);
                 var realPrefab = GetRealPrefabFromMock(target, member.MemberType);
@@ -324,7 +324,7 @@ namespace Jotunn.Managers
                     TryFixMaterial(material);
                 }
             }
-            else if (member.IsEnumeratedClass && member.IsEnumerableOfUnityObjects)
+            else if (member.IsEnumeratedClass && member.IsEnumerableOfUnityObjects && member.HasSetMethod)
             {
                 var isArray = member.MemberType.IsArray;
                 var isList = member.MemberType.IsGenericType && member.MemberType.GetGenericTypeDefinition() == typeof(List<>);

--- a/JotunnLib/Managers/MockSystem/PropertyMember.cs
+++ b/JotunnLib/Managers/MockSystem/PropertyMember.cs
@@ -14,6 +14,7 @@ namespace Jotunn {
             IsUnityObject = MemberType.IsSameOrSubclass(typeof(Object));
             IsClass = MemberType.IsClass;
             HasGetMethod = propertyInfo.GetIndexParameters().Length == 0 && propertyInfo.GetMethod != null;
+            HasSetMethod = propertyInfo.SetMethod != null;
             EnumeratedType = MemberType.GetEnumeratedType();
             IsEnumerableOfUnityObjects = EnumeratedType?.IsSameOrSubclass(typeof(Object)) == true;
             IsEnumeratedClass = EnumeratedType?.IsClass == true;


### PR DESCRIPTION
# Summary

- Adds `HasSetMethod` property to `MemberBase` to track whether a member has a setter
- Guards `SetValue` calls in `MockManager.FixMemberReferences` with `HasSetMethod` check, preventing crashes on read-only properties like `Component.transform`

## Problem

When mods trigger `FixReferences` on GameObjects with read-only component properties (e.g. `Component.transform`), `MockManager.FixMemberReferences` crashes with:

```
ArgumentException: Set Method not found for 'transform'
  at System.Reflection.RuntimePropertyInfo.SetValue(...)
  at Jotunn.PropertyMember.SetValue(...)
  at Jotunn.Managers.MockManager.FixMemberReferences(...)
```

The method iterates all properties via reflection and calls `SetValue` without checking if a setter exists.

## Steps to reproduce

1. Install Jotunn v2.27.1, ExpandWorldData, and More World Locations AIO
2. Launch the game and load into a world
3. During `ZoneSystem.Start`, EWD triggers `SoftReference.Load()` on MWL location prefabs
4. Jotunn's `AssetManager.SwapResolvedAsset` hook fires, calling `PrefabExtension.FixReferences` on the loaded prefab
5. `MockManager.FixMemberReferences` encounters read-only properties like `Component.transform` and crashes calling `SetValue`

## Fix

Follows the existing `HasGetMethod` pattern — adds a symmetric `HasSetMethod` property and checks it before `SetValue` calls in the two branches that write values back.