### PR TITLE
feat: Add YAML localization file support

### DIFF
--- a/JotunnLib/Documentation/tutorials/localization.md
+++ b/JotunnLib/Documentation/tutorials/localization.md
@@ -27,7 +27,7 @@ No matter if you let Jötunn automatically load your translation files via side 
 
 ### Format
 
-Jötunn supports three translation file formats.
+Jötunn supports two translation file formats.
 
 **JSON** (Crowdin-compatible):
 ```json
@@ -43,6 +43,23 @@ item_evilsword: Sword of Darkness
 item_evilsword_desc: Bringing the light
 ```
 
+**YAML dependency**: YAML files require [YamlDotNet](https://thunderstore.io/c/valheim/p/ValheimModding/YamlDotNet/) in order to be loaded.
+If a YAML file is encountered without YamlDotNet being loaded, Jötunn will log a warning and skip the file.
+Include the dependency in your Thunderstore `manifest.json` like this:
+```json
+{
+  "name": "JotunnModStub",
+  "description": "",
+  "version_number": "0.0.1",
+  "website_url": "",
+  "dependencies": [
+    "denikson-BepInExPack_Valheim-5.4.2333",
+    "ValheimModding-Jotunn-2.27.1",
+    "ValheimModding-YamlDotNet-16.3.1"
+  ]
+}
+```
+
 **Note**: Other than the tokens you supply with your prefabs or Jötunn's configs, the translation keys should not be prefixed with a `$`.
 Jötunn will replace any `$` at the beginning of your translation keys while adding them to it's localization system.
 
@@ -52,8 +69,6 @@ Localizations can be provided through loading side by side with your plugin.
 The folder structure which will be queried will be `Translations/{LanguageName}/{anyname}.json` (or `.yaml` / `.yml`), and can be placed in any sub directory within your plugin.
 An example of a path which will be read for localization at run time may be: `BepInEx/plugins/JotunnModExample/Assets/Translations/English/backpack.json`.
 All `.json`, `.yaml`, and `.yml` files within such a directory will be iterated through and localizations added for each of those languages.
-
-**YAML dependency**: YAML files require `YamlDotNet.dll` to be present at runtime. Jötunn does not ship YamlDotNet itself — mods using `.yaml`/`.yml` translation files must declare it as a dependency in their Thunderstore `manifest.json`. If YAML files are found but YamlDotNet is not loaded, Jötunn will log a warning and skip those files.
 
 You can find a list of language names [here](../data/localization/language-list.md).
 

--- a/JotunnLib/Documentation/tutorials/localization.md
+++ b/JotunnLib/Documentation/tutorials/localization.md
@@ -27,7 +27,9 @@ No matter if you let Jötunn automatically load your translation files via side 
 
 ### Format
 
-The format for localizations is a standard JSON collection as such:
+Jötunn supports three translation file formats.
+
+**JSON** (Crowdin-compatible):
 ```json
 {
   "item_evilsword": "Sword of Darkness",
@@ -35,15 +37,23 @@ The format for localizations is a standard JSON collection as such:
 }
 ```
 
+**YAML** (`.yaml` / `.yml`):
+```yaml
+item_evilsword: Sword of Darkness
+item_evilsword_desc: Bringing the light
+```
+
 **Note**: Other than the tokens you supply with your prefabs or Jötunn's configs, the translation keys should not be prefixed with a `$`.
 Jötunn will replace any `$` at the beginning of your translation keys while adding them to it's localization system.
 
 ### Side loading localizations
 
-Localizations can be provide through loading side by side with your plugin.
-The folder structure which will be queried will be `Translations/{LanguageName}/{anyname}.json`, and can be placed in any sub directory within your plugin.
-An example of a path which will be read for localization at run time may be: `BepInEx/plugins/JotunnModExample/Assets/Translations/English/backpack.json`. 
-All .json files within such a directory will be iterated through and localizations added for each of those languages.
+Localizations can be provided through loading side by side with your plugin.
+The folder structure which will be queried will be `Translations/{LanguageName}/{anyname}.json` (or `.yaml` / `.yml`), and can be placed in any sub directory within your plugin.
+An example of a path which will be read for localization at run time may be: `BepInEx/plugins/JotunnModExample/Assets/Translations/English/backpack.json`.
+All `.json`, `.yaml`, and `.yml` files within such a directory will be iterated through and localizations added for each of those languages.
+
+**YAML dependency**: YAML files require `YamlDotNet.dll` to be present at runtime. Jötunn does not ship YamlDotNet itself — mods using `.yaml`/`.yml` translation files must declare it as a dependency in their Thunderstore `manifest.json`. If YAML files are found but YamlDotNet is not loaded, Jötunn will log a warning and skip those files.
 
 You can find a list of language names [here](../data/localization/language-list.md).
 
@@ -108,7 +118,7 @@ private void AddLocalizations()
 
 ### Prefabs
 
-It is also possible to package `TextAsset`'s inside of your asset bundles, and to load them into game at runtime via [CustomLocalization.AddJsonFile](xref:Jotunn.Entities.CustomLocalization.AddJsonFile(System.String,System.String)).
+It is also possible to package `TextAsset`'s inside of your asset bundles, and to load them into game at runtime via [CustomLocalization.AddJsonFile](xref:Jotunn.Entities.CustomLocalization.AddJsonFile(System.String,System.String)) or [CustomLocalization.AddYamlFile](xref:Jotunn.Entities.CustomLocalization.AddYamlFile(System.String,System.String)).
 In this example, we use our filenames to provide the language which we wish to add the translations for:
 
 ```cs

--- a/JotunnLib/Entities/CustomLocalization.cs
+++ b/JotunnLib/Entities/CustomLocalization.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using BepInEx;
 using Jotunn.Managers;
@@ -15,6 +16,17 @@ namespace Jotunn.Entities
         internal Dictionary<string, Dictionary<string, string>> Map { get; }
         
         private static HashSet<string> loggedInvalidTokens = new HashSet<string>();
+
+        private static bool? _yamlDotNetAvailable;
+
+        /// <summary>
+        ///     Returns true if YamlDotNet is loaded in the current AppDomain.
+        ///     Placed here (not on LocalizationManager) so it can be called without triggering
+        ///     LocalizationManager's static constructor, which requires the game runtime.
+        /// </summary>
+        internal static bool IsYamlDotNetAvailable() =>
+            _yamlDotNetAvailable ??= AppDomain.CurrentDomain.GetAssemblies()
+                .Any(a => a.GetName().Name == "YamlDotNet");
 
         /// <summary>
         ///     Default constructor.
@@ -192,7 +204,7 @@ namespace Jotunn.Entities
             {
                 throw new ArgumentNullException(nameof(path));
             }
-            
+
             var fileContent = File.ReadAllText(path);
 
             if (fileContent is null)
@@ -200,16 +212,26 @@ namespace Jotunn.Entities
                 throw new ArgumentNullException(nameof(fileContent));
             }
 
-            if (isJson)
+            var ext = Path.GetExtension(path).ToLowerInvariant();
+            string format;
+
+            if (ext == ".yaml" || ext == ".yml")
+            {
+                AddYamlFile(Path.GetFileName(Path.GetDirectoryName(path)), fileContent);
+                format = "YAML";
+            }
+            else if (isJson)
             {
                 AddJsonFile(Path.GetFileName(Path.GetDirectoryName(path)), fileContent);
+                format = "JSON";
             }
             else
             {
                 AddLanguageFile(fileContent);
+                format = "";
             }
 
-            Logger.LogDebug($"Added {(isJson ? "Json" : "")} language file: {Path.GetFileName(path)}");
+            Logger.LogDebug($"Added {format} language file: {Path.GetFileName(path)}");
         }
 
         /// <summary> Add a json language file (match crowdin format). </summary>
@@ -255,6 +277,73 @@ namespace Jotunn.Entities
                 }
 
                 AddTranslationToMap(language, cleanedToken, translation);
+            }
+        }
+
+        /// <summary> Add a YAML language file. Keys are flat string-to-string mappings. </summary>
+        /// <param name="language"> Language for the yaml file, for example, "English" </param>
+        /// <param name="fileContent"> Entire file as string </param>
+        public void AddYamlFile(string language, string fileContent)
+        {
+            if (!IsYamlDotNetAvailable())
+            {
+                Logger.LogWarning(SourceMod,
+                    $"Cannot load YAML localization for '{language}': YamlDotNet is not loaded. " +
+                    "Mods using .yaml/.yml localization must include YamlDotNet.dll as a dependency.");
+                return;
+            }
+
+            if (!ValidateLanguage(language))
+            {
+                return;
+            }
+
+            ParseAndAddYaml(language, fileContent);
+        }
+
+        // Isolated in its own method so the JIT only resolves YamlDotNet types when actually called.
+        private void ParseAndAddYaml(string language, string fileContent)
+        {
+            Dictionary<string, string> yaml;
+
+            try
+            {
+                yaml = new YamlDotNet.Serialization.DeserializerBuilder()
+                    .IgnoreFields()
+                    .Build()
+                    .Deserialize<Dictionary<string, string>>(fileContent);
+            }
+            catch (Exception e)
+            {
+                Logger.LogWarning(SourceMod, $"Could not read {language} YAML localization: {e.Message}");
+                return;
+            }
+
+            if (yaml == null)
+            {
+                return;
+            }
+
+            if (!Map.ContainsKey(language))
+            {
+                Map.Add(language, new Dictionary<string, string>());
+            }
+
+            foreach (var tv in yaml)
+            {
+                var cleanedToken = tv.Key.TrimStart(LocalizationManager.TokenFirstChar);
+
+                if (!ValidateToken(cleanedToken))
+                {
+                    continue;
+                }
+
+                if (!ValidateTranslation(tv.Value))
+                {
+                    continue;
+                }
+
+                AddTranslationToMap(language, cleanedToken, tv.Value);
             }
         }
 

--- a/JotunnLib/JotunnLib.csproj
+++ b/JotunnLib/JotunnLib.csproj
@@ -66,6 +66,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="YamlDotNet" Version="16.3.0">
+      <IncludeAssets>compile</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/JotunnLib/Utils/AutomaticLocalizationsLoading.cs
+++ b/JotunnLib/Utils/AutomaticLocalizationsLoading.cs
@@ -15,6 +15,7 @@ namespace Jotunn.Utils
         {
             var jsonFormat = new HashSet<FileInfo>();
             var unityFormat = new HashSet<FileInfo>();
+            var yamlFormat = new HashSet<FileInfo>();
 
             // Json format community files
             foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, CommunityTranslationFileName))
@@ -30,6 +31,16 @@ namespace Jotunn.Utils
             foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.language"))
             {
                 unityFormat.Add(fileInfo);
+            }
+
+            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.yaml"))
+            {
+                yamlFormat.Add(fileInfo);
+            }
+
+            foreach (var fileInfo in GetTranslationFiles(Paths.LanguageTranslationsFolder, "*.yml"))
+            {
+                yamlFormat.Add(fileInfo);
             }
 
             foreach (var fileInfo in jsonFormat)
@@ -55,6 +66,27 @@ namespace Jotunn.Utils
                 catch (Exception ex)
                 {
                     Logger.LogWarning($"Exception caught while loading localization file {fileInfo}: {ex}");
+                }
+            }
+
+            if (yamlFormat.Count > 0 && !Entities.CustomLocalization.IsYamlDotNetAvailable())
+            {
+                Logger.LogWarning($"Found {yamlFormat.Count} YAML localization file(s) but YamlDotNet is not loaded. " +
+                    "Mods using .yaml/.yml localization must include YamlDotNet.dll as a dependency.");
+            }
+            else
+            {
+                foreach (var fileInfo in yamlFormat)
+                {
+                    try
+                    {
+                        var mod = BepInExUtils.GetPluginInfoFromPath(fileInfo)?.Metadata;
+                        LocalizationManager.Instance.GetLocalization(mod ?? Main.Instance.Info.Metadata).AddFileByPath(fileInfo.FullName);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogWarning($"Exception caught while loading localization file {fileInfo}: {ex}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Add YAML Localization File Support

## Summary

- Adds `.yaml` / `.yml` translation file support to Jotunn's automatic localization loading and the `CustomLocalization` API  
- YAML support is gated on **YamlDotNet** being present in the AppDomain at runtime — Jotunn does **not** ship it, ensuring no hard dependency is introduced  
- If YAML files are found but YamlDotNet is not loaded, a single `LogWarning` is emitted and the files are skipped gracefully  
- Mods using YAML translation files must declare **YamlDotNet** as a dependency in their Thunderstore `manifest.json`  
- Documentation updated to cover:
  - The new YAML format  
  - Side-loading usage  
  - The YamlDotNet dependency requirement  

---

## Changed Files

- **JotunnLib.csproj**  
  - `YamlDotNet 16.3.0` added as a compile-only reference  
  - `IncludeAssets: compile`  
  - `PrivateAssets: all`  
  - Not shipped with Jotunn  

- **CustomLocalization.cs**  
  - `IsYamlDotNetAvailable()` runtime check  
  - `AddYamlFile()` public API  
  - `ParseAndAddYaml()` private method isolating YamlDotNet type references from JIT  

- **AutomaticLocalizationsLoading.cs**  
  - Scans `*.yaml` and `*.yml` alongside existing `*.json` / `*.language` formats  

- **Documentation/tutorials/localization.md**  
  - YAML format example  
  - Updated side-loading documentation  
  - YamlDotNet dependency callout  

---

## Notes

- Follows the same graceful-degradation pattern as `ConfigManagerUtils`  
  - No hard dependency  
  - Informative logging  

- `IsYamlDotNetAvailable()` is placed on `CustomLocalization` rather than `LocalizationManager` to avoid triggering `LocalizationManager`'s game-dependent static constructor  