### PR TITLE
feat: new Run method in ConsoleCommand that gives the Terminal context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-## Version 2.28.1
+## Version 2.29.0
+* Added new method in ConsoleCommand to take a Terminal context parameter, so mods can write output to either Console or Chat depending on where the command was executed from. Backwards compatible. For more info on that see https://valheim-modding.github.io/Jotunn/tutorials/console-commands.html
 * Added TMPro FontAssets shortcuts to the GUIManager
 
 ## Version 2.28.0

--- a/JotunnLib/Documentation/tutorials/console-commands.md
+++ b/JotunnLib/Documentation/tutorials/console-commands.md
@@ -56,7 +56,7 @@ private void Awake()
 ```
 
 ### Getting the Terminal context
-If you need to know from which Terminal your command was executed from, you can also overwrite `Run(string[] args, Terminal context)` from the base class. This will give you the `Terminal` instance, which is either the Console or the Chat of Valheim. Note that you will have to use `context.AddString()` for output on the calling Terminal instead of directly writing to `Console.instance`.
+If you need to know from which Terminal your command was executed from, you can override `Run(string[] args, Terminal context)` from the base class instead. This will give you the `Terminal` instance, which is either the Console or the Chat of Valheim. Note that you will have to use `context.AddString()` for output on the calling Terminal instead of directly writing to `Console.instance`.
 
 ```cs
 public class EchoCommand : ConsoleCommand

--- a/JotunnLib/Documentation/tutorials/console-commands.md
+++ b/JotunnLib/Documentation/tutorials/console-commands.md
@@ -54,3 +54,25 @@ private void Awake()
     CommandManager.Instance.AddConsoleCommand(new BetterSpawnCommand());
 }
 ```
+
+### Getting the Terminal context
+If you need to know from which Terminal your command was executed from, you can also overwrite `Run(string[] args, Terminal context)` from the base class. This will give you the `Terminal` instance, which is either the Console or the Chat of Valheim. Note that you will have to use `context.AddString()` for output on the calling Terminal instead of directly writing to `Console.instance`.
+
+```cs
+public class EchoCommand : ConsoleCommand
+{
+    public override string Name => "echo";
+
+    public override string Help => "Echoes all text entered to the console or chat";
+
+    public override void Run(string[] args, Terminal context)
+    {
+        if (args.Length < 1)
+        {
+            context.AddString("Usage: echo <text>");
+        }
+
+        context.AddString(string.Join(" ", args, 0, args.Length));
+    }
+}
+```

--- a/JotunnLib/Entities/ConsoleCommand.cs
+++ b/JotunnLib/Entities/ConsoleCommand.cs
@@ -23,12 +23,12 @@ namespace Jotunn.Entities
         public virtual bool IsCheat => false;
 
         /// <summary>
-        ///     If true, this command will be allowed in networked play.
+        ///     If true, this command will only be allowed in networked play.
         /// </summary>
         public virtual bool IsNetwork => false;
 
         /// <summary>
-        ///     If true, and IsNetwork is true, this command will be allowed in networked play, but only for the server.
+        ///     If true, and IsNetwork is true, this command will only be allowed in networked play, but only for the server.
         /// </summary>
         public virtual bool OnlyServer => false;
 
@@ -41,8 +41,25 @@ namespace Jotunn.Entities
         ///     The function that will be called when the user runs your console command, with space-delimited arguments.
         /// </summary>
         /// <param name="args">The arguments the user types, with spaces being the delimiter.</param>
-        public abstract void Run(string[] args);
+        public virtual void Run(string[] args)
+        {
+            
+        }
 
+        /// <summary>
+        ///     The function that will be called when the user runs your console command, with space-delimited arguments and
+        ///     a context <see cref="Terminal"/> object (Console or Chat). Use context?.AddString() to write to the respective
+        ///     output.
+        /// </summary>
+        /// <param name="args">The arguments the user types, with spaces being the delimiter.</param>
+        /// <param name="context">Terminal from which this command is run (Console or Chat window)</param>
+        public virtual void Run(string[] args, Terminal context)
+        {
+            // CommandManager always wires this method to the vanilla Terminal commands
+            // so we call the one without context one for backward compatibility
+            Run(args);
+        }
+        
         /// <summary>
         ///     Override this function to return a list of strings that are valid options for your command
         /// </summary>

--- a/JotunnLib/Main.cs
+++ b/JotunnLib/Main.cs
@@ -21,7 +21,7 @@ namespace Jotunn
         /// <summary>
         ///     The current version of the Jotunn library.
         /// </summary>
-        public const string Version = "2.28.0";
+        public const string Version = "2.29.0";
 
         /// <summary>
         ///     The name of the library.

--- a/JotunnLib/Managers/CommandManager.cs
+++ b/JotunnLib/Managers/CommandManager.cs
@@ -129,7 +129,7 @@ namespace Jotunn.Managers
                 {
                     command.Name,
                     command.Help,
-                    (Terminal.ConsoleEvent)((args) => command.Run(args.Args.Skip(1).ToArray())),
+                    (Terminal.ConsoleEvent)((args) => command.Run(args.Args.Skip(1).ToArray(), args.Context)),
                     command.IsCheat,
                     command.IsNetwork,
                     command.OnlyServer,

--- a/TestMod/ConsoleCommands/EchoCommand.cs
+++ b/TestMod/ConsoleCommands/EchoCommand.cs
@@ -1,0 +1,21 @@
+using Jotunn.Entities;
+
+namespace TestMod.ConsoleCommands
+{
+    public class EchoCommand : ConsoleCommand
+    {
+        public override string Name => "echo";
+
+        public override string Help => "Echoes all text entered to the console or chat";
+
+        public override void Run(string[] args, Terminal context)
+        {
+            if (args.Length < 1)
+            {
+                context.AddString("Usage: echo <text>");
+            }
+
+            context.AddString(string.Join(" ", args, 0, args.Length));
+        }
+    }
+}

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -812,6 +812,7 @@ namespace TestMod
             CommandManager.Instance.AddConsoleCommand(new RemoveCategoryTabCommand());
             CommandManager.Instance.AddConsoleCommand(new ResetCartographyCommand());
             CommandManager.Instance.AddConsoleCommand(new AdminCheckCommand());
+            CommandManager.Instance.AddConsoleCommand(new EchoCommand());
         }
 
         // Register new skills

--- a/TestMod/TestMod.csproj
+++ b/TestMod/TestMod.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <Compile Include="ColorChanger.cs" />
     <Compile Include="ConsoleCommands\AdminCheckCommand.cs" />
+    <Compile Include="ConsoleCommands\EchoCommand.cs" />
     <Compile Include="ConsoleCommands\RemoveCategoryTabCommand.cs" />
     <Compile Include="ConsoleCommands\ResetCartographyCommand.cs" />
     <Compile Include="ConsoleCommands\CreateCategoryTabCommand.cs" />


### PR DESCRIPTION
New Run method in ConsoleCommand that gives the Terminal context. Is the default wired in CommandManager but calls the old Run when not overridden. Docs and stuff.