### PR TITLE
fix: sync ZoneLocation radii/ClearArea from prefab's Location component

### DIFF
--- a/JotunnLib/Configs/LocationConfig.cs
+++ b/JotunnLib/Configs/LocationConfig.cs
@@ -44,8 +44,9 @@ namespace Jotunn.Configs
 
         /// <summary>
         ///     Radius of the location. Terrain delta is calculated within this circle.
+        ///     If null, falls back to the prefab's <see cref="Location"/> component value when one exists.
         /// </summary>
-        public float ExteriorRadius { get; set; } = 10f;
+        public float? ExteriorRadius { get; set; }
 
         /// <summary>
         ///     Attempt to place in the central zone first
@@ -129,9 +130,10 @@ namespace Jotunn.Configs
         public bool HasInterior { get; set; }
 
         /// <summary>
-        ///     Radius of the interior attached to the location
+        ///     Radius of the interior attached to the location.
+        ///     If null, falls back to the prefab's <see cref="Location"/> component value when one exists.
         /// </summary>
-        public float InteriorRadius { get; set; }
+        public float? InteriorRadius { get; set; }
 
         /// <summary>
         ///     Environment string used by the interior
@@ -159,9 +161,10 @@ namespace Jotunn.Configs
         public bool IconAlways { get; set; }
 
         /// <summary>
-        ///     Enable to forbid Vegetation from spawning inside the circle defined by <see cref="ExteriorRadius"/>
+        ///     Enable to forbid Vegetation from spawning inside the circle defined by <see cref="ExteriorRadius"/>.
+        ///     If null, falls back to the prefab's <see cref="Location"/> component value when one exists.
         /// </summary>
-        public bool ClearArea { get; set; }
+        public bool? ClearArea { get; set; }
 
         /// <summary>
         ///     Create a new <see cref="LocationConfig"/>
@@ -218,9 +221,9 @@ namespace Jotunn.Configs
                 m_biomeArea = BiomeArea,
                 m_quantity = Quantity,
                 m_prioritized = Priotized,
-                m_interiorRadius = InteriorRadius,
-                m_exteriorRadius = ExteriorRadius,
-                m_clearArea = ClearArea,
+                m_interiorRadius = InteriorRadius ?? 0f,
+                m_exteriorRadius = ExteriorRadius ?? 10f,
+                m_clearArea = ClearArea ?? false,
                 m_centerFirst = CenterFirst,
                 m_forestTresholdMin = ForestTresholdMin,
                 m_forestTresholdMax = ForestTrasholdMax,

--- a/JotunnLib/Configs/LocationConfig.cs
+++ b/JotunnLib/Configs/LocationConfig.cs
@@ -42,11 +42,23 @@ namespace Jotunn.Configs
         [Obsolete("This property is unused by Valheim.")]
         public float ChanceToSpawn { get; set; } = 10f;
 
+        private float? _exteriorRadius;
+
         /// <summary>
         ///     Radius of the location. Terrain delta is calculated within this circle.
-        ///     If null, falls back to the prefab's <see cref="Location"/> component value when one exists.
+        ///     If left unset, falls back to the prefab's <see cref="Location"/> component value when one exists.
+        ///     Defaults to 10f when no value has been set and no component is present.
         /// </summary>
-        public float? ExteriorRadius { get; set; }
+        public float ExteriorRadius
+        {
+            get => _exteriorRadius ?? 10f;
+            set => _exteriorRadius = value;
+        }
+
+        /// <summary>
+        ///     True when the caller explicitly assigned a value to <see cref="ExteriorRadius"/>.
+        /// </summary>
+        internal bool HasExteriorRadius => _exteriorRadius.HasValue;
 
         /// <summary>
         ///     Attempt to place in the central zone first
@@ -129,11 +141,22 @@ namespace Jotunn.Configs
         /// </summary>
         public bool HasInterior { get; set; }
 
+        private float? _interiorRadius;
+
         /// <summary>
         ///     Radius of the interior attached to the location.
-        ///     If null, falls back to the prefab's <see cref="Location"/> component value when one exists.
+        ///     If left unset, falls back to the prefab's <see cref="Location"/> component value when one exists.
         /// </summary>
-        public float? InteriorRadius { get; set; }
+        public float InteriorRadius
+        {
+            get => _interiorRadius ?? 0f;
+            set => _interiorRadius = value;
+        }
+
+        /// <summary>
+        ///     True when the caller explicitly assigned a value to <see cref="InteriorRadius"/>.
+        /// </summary>
+        internal bool HasInteriorRadius => _interiorRadius.HasValue;
 
         /// <summary>
         ///     Environment string used by the interior
@@ -160,11 +183,22 @@ namespace Jotunn.Configs
         /// </summary>
         public bool IconAlways { get; set; }
 
+        private bool? _clearArea;
+
         /// <summary>
         ///     Enable to forbid Vegetation from spawning inside the circle defined by <see cref="ExteriorRadius"/>.
-        ///     If null, falls back to the prefab's <see cref="Location"/> component value when one exists.
+        ///     If left unset, falls back to the prefab's <see cref="Location"/> component value when one exists.
         /// </summary>
-        public bool? ClearArea { get; set; }
+        public bool ClearArea
+        {
+            get => _clearArea ?? false;
+            set => _clearArea = value;
+        }
+
+        /// <summary>
+        ///     True when the caller explicitly assigned a value to <see cref="ClearArea"/>.
+        /// </summary>
+        internal bool HasClearArea => _clearArea.HasValue;
 
         /// <summary>
         ///     Create a new <see cref="LocationConfig"/>
@@ -221,9 +255,9 @@ namespace Jotunn.Configs
                 m_biomeArea = BiomeArea,
                 m_quantity = Quantity,
                 m_prioritized = Priotized,
-                m_interiorRadius = InteriorRadius ?? 0f,
-                m_exteriorRadius = ExteriorRadius ?? 10f,
-                m_clearArea = ClearArea ?? false,
+                m_interiorRadius = InteriorRadius,
+                m_exteriorRadius = ExteriorRadius,
+                m_clearArea = ClearArea,
                 m_centerFirst = CenterFirst,
                 m_forestTresholdMin = ForestTresholdMin,
                 m_forestTresholdMax = ForestTrasholdMax,

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -95,11 +95,11 @@ namespace Jotunn.Entities
             else
             {
                 Location = exteriorPrefab.AddComponent<Location>();
-                if (locationConfig.ClearArea.HasValue) Location.m_clearArea = locationConfig.ClearArea.Value;
-                if (locationConfig.ExteriorRadius.HasValue) Location.m_exteriorRadius = locationConfig.ExteriorRadius.Value;
+                if (locationConfig.HasClearArea) Location.m_clearArea = locationConfig.ClearArea;
+                if (locationConfig.HasExteriorRadius) Location.m_exteriorRadius = locationConfig.ExteriorRadius;
                 Location.m_interiorPrefab = interiorPrefab;
                 Location.m_hasInterior = locationConfig.HasInterior;
-                if (locationConfig.InteriorRadius.HasValue) Location.m_interiorRadius = locationConfig.InteriorRadius.Value;
+                if (locationConfig.HasInteriorRadius) Location.m_interiorRadius = locationConfig.InteriorRadius;
                 Location.m_interiorEnvironment = locationConfig.InteriorEnvironment;
             }
 
@@ -159,9 +159,9 @@ namespace Jotunn.Entities
                 return;
             }
 
-            if (!locationConfig.ExteriorRadius.HasValue) ZoneLocation.m_exteriorRadius = location.m_exteriorRadius;
-            if (!locationConfig.InteriorRadius.HasValue) ZoneLocation.m_interiorRadius = location.m_interiorRadius;
-            if (!locationConfig.ClearArea.HasValue) ZoneLocation.m_clearArea = location.m_clearArea;
+            if (!locationConfig.HasExteriorRadius) ZoneLocation.m_exteriorRadius = location.m_exteriorRadius;
+            if (!locationConfig.HasInteriorRadius) ZoneLocation.m_interiorRadius = location.m_interiorRadius;
+            if (!locationConfig.HasClearArea) ZoneLocation.m_clearArea = location.m_clearArea;
         }
 
         /// <summary>

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -15,6 +15,8 @@ namespace Jotunn.Entities
     /// </summary>
     public class CustomLocation : CustomEntity
     {
+        private readonly LocationConfig _locationConfig;
+
         /// <summary>
         ///     The exterior prefab for this custom location.
         /// </summary>
@@ -87,6 +89,7 @@ namespace Jotunn.Entities
         {
             Prefab = exteriorPrefab;
             Name = exteriorPrefab.name;
+            _locationConfig = locationConfig;
 
             if (exteriorPrefab.TryGetComponent<Location>(out var location))
             {
@@ -136,8 +139,6 @@ namespace Jotunn.Entities
             FixReference = fixReference;
             SoftReference = true;
         }
-
-        private readonly LocationConfig _locationConfig;
 
         private void OnLocationResolve(GameObject gameObject)
         {

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -95,17 +95,19 @@ namespace Jotunn.Entities
             else
             {
                 Location = exteriorPrefab.AddComponent<Location>();
-                Location.m_clearArea = locationConfig.ClearArea;
-                Location.m_exteriorRadius = locationConfig.ExteriorRadius;
+                if (locationConfig.ClearArea.HasValue) Location.m_clearArea = locationConfig.ClearArea.Value;
+                if (locationConfig.ExteriorRadius.HasValue) Location.m_exteriorRadius = locationConfig.ExteriorRadius.Value;
                 Location.m_interiorPrefab = interiorPrefab;
                 Location.m_hasInterior = locationConfig.HasInterior;
-                Location.m_interiorRadius = locationConfig.InteriorRadius;
+                if (locationConfig.InteriorRadius.HasValue) Location.m_interiorRadius = locationConfig.InteriorRadius.Value;
                 Location.m_interiorEnvironment = locationConfig.InteriorEnvironment;
             }
 
             ZoneLocation = locationConfig.GetZoneLocation();
             ZoneLocation.m_prefab = new SoftReference<GameObject>(AssetManager.Instance.AddAsset(exteriorPrefab));
             ZoneLocation.m_prefabName = exteriorPrefab.name;
+
+            SyncZoneLocationFromComponent(Location, locationConfig);
 
             FixReference = fixReference;
         }
@@ -124,6 +126,7 @@ namespace Jotunn.Entities
                 return;
             }
 
+            _locationConfig = locationConfig;
             var parent = ZoneManager.Instance.LocationContainer.transform;
             AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab, parent, OnLocationResolve);
             Name = softReferencePrefab.Name;
@@ -134,12 +137,31 @@ namespace Jotunn.Entities
             SoftReference = true;
         }
 
+        private readonly LocationConfig _locationConfig;
+
         private void OnLocationResolve(GameObject gameObject)
         {
+            if (gameObject.TryGetComponent<Location>(out var location))
+            {
+                SyncZoneLocationFromComponent(location, _locationConfig);
+            }
+
             if (gameObject.TryGetComponent<ZoneSystem.ZoneLocation>(out var zoneLocation))
             {
                 ZoneManager.Instance.PrepareLocation(zoneLocation, SourceMod);
             }
+        }
+
+        private void SyncZoneLocationFromComponent(Location location, LocationConfig locationConfig)
+        {
+            if (location == null || ZoneLocation == null)
+            {
+                return;
+            }
+
+            if (!locationConfig.ExteriorRadius.HasValue) ZoneLocation.m_exteriorRadius = location.m_exteriorRadius;
+            if (!locationConfig.InteriorRadius.HasValue) ZoneLocation.m_interiorRadius = location.m_interiorRadius;
+            if (!locationConfig.ClearArea.HasValue) ZoneLocation.m_clearArea = location.m_clearArea;
         }
 
         /// <summary>

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -98,11 +98,11 @@ namespace Jotunn.Entities
             else
             {
                 Location = exteriorPrefab.AddComponent<Location>();
-                if (locationConfig.HasClearArea) Location.m_clearArea = locationConfig.ClearArea;
-                if (locationConfig.HasExteriorRadius) Location.m_exteriorRadius = locationConfig.ExteriorRadius;
+                Location.m_clearArea = locationConfig.ClearArea;
+                Location.m_exteriorRadius = locationConfig.ExteriorRadius;
                 Location.m_interiorPrefab = interiorPrefab;
                 Location.m_hasInterior = locationConfig.HasInterior;
-                if (locationConfig.HasInteriorRadius) Location.m_interiorRadius = locationConfig.InteriorRadius;
+                Location.m_interiorRadius = locationConfig.InteriorRadius;
                 Location.m_interiorEnvironment = locationConfig.InteriorEnvironment;
             }
 


### PR DESCRIPTION
## The Issue

`LocationConfig.ExteriorRadius`, `InteriorRadius`, and `ClearArea` each exist in two independent places:

1. The `Location` MonoBehaviour on the prefab.
2. The `ZoneSystem.ZoneLocation` registration record.

`CustomLocation` sourced `ZoneLocation.m_exteriorRadius` exclusively from `LocationConfig.ExteriorRadius` (defaulting to `10f`). The prefab's `Location` component was preserved when present but never read into the `ZoneLocation`, so the two values could silently diverge.

## Where It Surfaced

The mismatch was caught via [VentureValheim/LocationReset](https://github.com/OrianaVenture/VentureValheim/tree/master/LocationReset), which resets the contents of a location to their originally generated state. Its `LocationReset.LocationPosition` constructor reads the reset boundary from `ZoneSystem.ZoneLocation`:

```csharp
public LocationPosition(LocationProxy loc, ZoneSystem.ZoneLocation zone, Location location)
{
    ...
    GroundDistance = zone.m_exteriorRadius;   // ZoneLocation, NOT the Location component
    SkyDistance    = zone.m_interiorRadius;
    ...
}
```

LocationReset calls `TryResetAfterLoadPrefab`, with `zone` fetched via `ZoneSystem.instance.GetLocation(hash)`. For [More World Locations AIO](https://thunderstore.io/c/valheim/p/warpalicious/More_World_Locations_AIO/) locations, `zone.m_exteriorRadius` carried the `LocationConfig` value while the radius set in UnityEditor was larger. Therefore, LocationReset only reset a subset of the location's actual footprint and left objects beyond the config radius unreset.

## The Fix

### `LocationConfig`

The three shared fields become nullable so Jötunn can distinguish "caller explicitly set this" from "caller left this unset." When a field is `null`, `CustomLocation` treats the prefab's `Location` component as the source of truth; when it has a value, that value wins.

- `GetZoneLocation()` falls back to the prior defaults when unset, preserving behavior for prefabs without a `Location` component. Existing callers that assign a value compile unchanged via implicit conversion from `float` / `bool` to the nullable types.

### `CustomLocation`

Synchronizes the three shared fields onto the `ZoneLocation` from the prefab's `Location` component whenever the corresponding config field is `null`. **Config wins when set; otherwise the component's value flows through.**

- **Non-SoftReference constructor:** `SyncZoneLocationFromComponent()` runs immediately after `GetZoneLocation()`.
- **SoftReference constructor:** `SyncZoneLocationFromComponent()` runs inside `OnLocationResolve(GameObject)` once the asset loads, mutating the already-registered `ZoneLocation` in place. Since `ZoneLocation` is a reference type, `ZoneSystem.m_locations` sees the update.
