### PR TITLE
feat: add SoftReference support for CustomRoom in DungeonManager

### DIFF
--- a/JotunnLib/Entities/CustomRoom.cs
+++ b/JotunnLib/Entities/CustomRoom.cs
@@ -39,6 +39,12 @@ namespace Jotunn.Entities
         public string ThemeName { get; set; }
 
         /// <summary>
+        ///     Indicator if room is added from SoftReferenceableAssets.<br />
+        ///     Used to delay mocking prefabs until DungeonGenerator loads the room.
+        /// </summary>
+        public bool SoftReference { get; set; }
+
+        /// <summary>
         ///     Associated <see cref="DungeonDB.RoomData"/> holding data used during generation.
         /// </summary>
         public DungeonDB.RoomData RoomData { get; private set; }
@@ -116,7 +122,44 @@ namespace Jotunn.Entities
                 m_enabled = Room.m_enabled,
                 m_theme = GetRoomTheme(ThemeName)
             };
-        }        
+        }
+
+        /// <summary>
+        ///     Custom room from a SoftReference prefab with a <see cref="RoomConfig"/> attached. Using SoftReference system.<br />
+        ///     The prefab is not loaded until the DungeonGenerator needs it during generation.
+        /// </summary>
+        /// <param name="softReferencePrefab">A <see cref="SoftReference{T}"/> to the room prefab registered in a SoftRef manifest.</param>
+        /// <param name="fixReference">If true references for <see cref="Entities.Mock{T}"/> objects get resolved at runtime by Jötunn.</param>
+        /// <param name="roomConfig">The config for this custom room.</param>
+        public CustomRoom(SoftReference<GameObject> softReferencePrefab, bool fixReference, RoomConfig roomConfig) : base(Assembly.GetCallingAssembly())
+        {
+            if (!softReferencePrefab.IsValid)
+            {
+                Logger.LogError($"SoftReference invalid for room prefab: {softReferencePrefab.Name}");
+                return;
+            }
+
+            AssetManager.Instance.ResolveMocksOnLoad(softReferencePrefab, DungeonManager.Instance.DungeonRoomContainer.transform, OnRoomResolve);
+
+            Name = softReferencePrefab.Name;
+            ThemeName = roomConfig.ThemeName;
+            FixReference = fixReference;
+            SoftReference = true;
+
+            RoomData = new DungeonDB.RoomData()
+            {
+                m_prefab = softReferencePrefab,
+                m_loadedRoom = null,
+                m_enabled = roomConfig.Enabled ?? true,
+                m_theme = GetRoomTheme(ThemeName)
+            };
+        }
+
+        private void OnRoomResolve(GameObject gameObject)
+        {
+            // Mock references resolved by MockResolutionContext.
+            // Room component lazy-loaded by vanilla's RoomData.RoomInPrefab.
+        }
 
         /// <summary>
         ///     Helper method to determine if a prefab with a given name is a custom room created with Jötunn.

--- a/JotunnLib/Managers/DungeonManager.cs
+++ b/JotunnLib/Managers/DungeonManager.cs
@@ -46,7 +46,7 @@ namespace Jotunn.Managers
         /// <summary>
         ///     Container for Jötunn's DungeonRooms in the DontDestroyOnLoad scene.
         /// </summary>
-        private GameObject DungeonRoomContainer;
+        internal GameObject DungeonRoomContainer;
 
         /// <summary>
         ///     Hide .ctor
@@ -127,8 +127,12 @@ namespace Jotunn.Managers
                 return false;
             }
 
-            customRoom.Prefab.transform.SetParent(DungeonRoomContainer.transform);
-            customRoom.Prefab.SetActive(true);
+            if (!customRoom.SoftReference)
+            {
+                customRoom.Prefab.transform.SetParent(DungeonRoomContainer.transform);
+                customRoom.Prefab.SetActive(true);
+            }
+
             Rooms.Add(customRoom.Name, customRoom);
             return true;
         }
@@ -230,7 +234,7 @@ namespace Jotunn.Managers
 
             foreach (CustomRoom room in Rooms.Values)
             {
-                int stableHashCode = room.Prefab.name.GetStableHashCode();
+                int stableHashCode = room.Name.GetStableHashCode();
                 if (hashToName.ContainsKey(stableHashCode))
                 {
                     Logger.LogWarning($"Room {room.Name} is already registered with hash {stableHashCode}");
@@ -272,7 +276,7 @@ namespace Jotunn.Managers
                     try
                     {
                         Logger.LogDebug($"Adding custom room {customRoom.Name} with {customRoom.ThemeName} theme");
-                        if (customRoom.FixReference)
+                        if (customRoom.FixReference && !customRoom.SoftReference)
                         {
                             customRoom.Prefab.FixReferences(true);
                             customRoom.FixReference = false;
@@ -314,7 +318,7 @@ namespace Jotunn.Managers
                     Logger.LogDebug($"This dungeon generator has a custom theme = {proxy.m_themeName}, adding available rooms");
 
                     var selectedRooms = Rooms.Values
-                        .Where(r => r.Room.m_enabled)
+                        .Where(r => r.RoomData.m_enabled)
                         .Where(r => r.ThemeName == proxy.m_themeName);
 
                     foreach (var room in selectedRooms)
@@ -329,7 +333,7 @@ namespace Jotunn.Managers
                     Logger.LogDebug($"Adding additional rooms of type {self.m_themes} to available rooms");
 
                     var selectedRooms = Rooms.Values
-                        .Where(r => r.Room.m_enabled)
+                        .Where(r => r.RoomData.m_enabled)
                         .Where(r => Enum.TryParse(r.ThemeName, false, out Room.Theme theme) ? theme != Room.Theme.None && self.m_themes.HasFlag(theme) : false);
 
                     foreach (var room in selectedRooms)


### PR DESCRIPTION
## Summary

Adds a new `CustomRoom(SoftReference<GameObject>, bool, RoomConfig)` constructor so mods can register custom dungeon rooms that live in soft-reference bundles, mirroring the existing soft-ref flow for `CustomLocation`. 

## Changes

**`JotunnLib/Entities/CustomRoom.cs`**
- New ctor `CustomRoom(SoftReference<GameObject>, bool, RoomConfig)`.
- Validates `softReferencePrefab.IsValid`; logs and bails if invalid.
- Registers a `ResolveMocksOnLoad` callback parented to `DungeonManager.DungeonRoomContainer.transform`.
- Populates `RoomData` with `m_prefab = softReferencePrefab`, `m_loadedRoom = null`, `m_enabled = roomConfig.Enabled ?? true`, `m_theme = GetRoomTheme(ThemeName)`.
- Sets a new `SoftReference` flag on the custom room so downstream code can branch on it.

**`JotunnLib/Managers/DungeonManager.cs`**
- `DungeonRoomContainer` promoted from `private` to `internal` so the new ctor can parent the resolved asset.
- `AddCustomRoom` skips `Prefab.SetParent` / `SetActive(true)` for soft-ref rooms (no prefab yet).
- `OnDungeonDBStarted` skips `Prefab.FixReferences(true)` for soft-ref rooms — mocks are resolved later by `MockResolutionContext.InstantiateAndResolveAsset` when the asset actually loads.
- `GenerateHashes` hashes `room.Name` instead of `room.Prefab.name` so soft-ref rooms (Prefab still null) still register.
- `OnDungeonGeneratorSetupAvailableRooms` filter switched from `r.Room.m_enabled` to `r.RoomData.m_enabled` to avoid touching the lazy-loaded `Room` component.