### PR TITLE
Fix `ExtEquipment` and `GameVersions` for `v0.221.13` PTB patch.

### DIFF
--- a/JotunnLib/Utils/ExtEquipment.cs
+++ b/JotunnLib/Utils/ExtEquipment.cs
@@ -9,14 +9,13 @@ namespace Jotunn.Utils
 {
     internal class ExtEquipment : MonoBehaviour
     {
-        const int RightItemVariantHash = -1781447240;       // RightItemVariant
-        const int RightBackItemVariantHash = -1623696695;   // RightBackItemVariant
-        const int ChestItemVariantHash = -1180934665;       // ChestItemVariant
+        private static int RightItemVariantHash = "RightItemVariant".GetStableHashCode();
+        private static int RightBackItemVariantHash = "RightBackItemVariant".GetStableHashCode();
+        private static int ChestItemVariantHash = "ChestItemVariant".GetStableHashCode();
 
         private static bool Enabled;
 
-        private static readonly Dictionary<VisEquipment, ExtEquipment> Instances =
-            new Dictionary<VisEquipment, ExtEquipment>();
+        private static readonly Dictionary<VisEquipment, ExtEquipment> Instances = new Dictionary<VisEquipment, ExtEquipment>();
 
         public static void Enable()
         {
@@ -198,7 +197,7 @@ namespace Jotunn.Utils
             {
                 instance.NewRightBackItemVariant = instance.MyHumanoid.m_hiddenRightItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
-                {                    
+                {
                     zdo.Set(RightBackItemVariantHash, (itemHash != 0) ? instance.NewRightBackItemVariant : 0);
                 }
             }

--- a/JotunnLib/Utils/ExtEquipment.cs
+++ b/JotunnLib/Utils/ExtEquipment.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using HarmonyLib;
 using Mono.Cecil.Cil;
@@ -9,6 +9,10 @@ namespace Jotunn.Utils
 {
     internal class ExtEquipment : MonoBehaviour
     {
+        const int RightItemVariantHash = -1781447240;       // RightItemVariant
+        const int RightBackItemVariantHash = -1623696695;   // RightBackItemVariant
+        const int ChestItemVariantHash = -1180934665;       // ChestItemVariant
+
         private static bool Enabled;
 
         private static readonly Dictionary<VisEquipment, ExtEquipment> Instances =
@@ -42,9 +46,9 @@ namespace Jotunn.Utils
             {
                 if (Instances.TryGetValue(__instance, out var instance))
                 {
-                    instance.NewRightItemVariant = zdo.GetInt("RightItemVariant");
-                    instance.NewChestVariant = zdo.GetInt("ChestItemVariant");
-                    instance.NewRightBackItemVariant = zdo.GetInt("RightBackItemVariant");
+                    instance.NewRightItemVariant = zdo.GetInt(RightItemVariantHash);
+                    instance.NewChestVariant = zdo.GetInt(ChestItemVariantHash);
+                    instance.NewRightBackItemVariant = zdo.GetInt(RightBackItemVariantHash);
                 }
             }
         }
@@ -168,16 +172,16 @@ namespace Jotunn.Utils
         ///     Store the variant index of the right hand item to the ZDO if the variant has changed
         /// </summary>
         [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightItem)), HarmonyPrefix]
-        private static void VisEquipment_SetRightItem(VisEquipment __instance, string name)
+        private static void VisEquipment_SetRightItem(VisEquipment __instance, int itemHash)
         {
             if (Instances.TryGetValue(__instance, out var instance) &&
                 instance.MyHumanoid && instance.MyHumanoid.m_rightItem != null &&
-                !(__instance.m_rightItem == name && instance.MyHumanoid.m_rightItem.m_variant == instance.CurrentRightItemVariant))
+                !(__instance.m_rightItem == itemHash && instance.MyHumanoid.m_rightItem.m_variant == instance.CurrentRightItemVariant))
             {
                 instance.NewRightItemVariant = instance.MyHumanoid.m_rightItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
                 {
-                    zdo.Set("RightItemVariant", (!string.IsNullOrEmpty(name)) ? instance.NewRightItemVariant : 0);
+                    zdo.Set(RightItemVariantHash, (itemHash != 0) ? instance.NewRightItemVariant : 0);
                 }
             }
         }
@@ -186,16 +190,16 @@ namespace Jotunn.Utils
         ///     Store the variant index of the right back item to the ZDO if the variant has changed
         /// </summary>
         [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightBackItem)), HarmonyPrefix]
-        private static void VisEquipment_SetRightBackItem(VisEquipment __instance, string name)
+        private static void VisEquipment_SetRightBackItem(VisEquipment __instance, int itemHash)
         {
             if (Instances.TryGetValue(__instance, out var instance) &&
                 instance.MyHumanoid && instance.MyHumanoid.m_hiddenRightItem != null &&
-                !(__instance.m_rightBackItem == name && instance.MyHumanoid.m_hiddenRightItem.m_variant == instance.CurrentRightBackItemVariant))
+                !(__instance.m_rightBackItem == itemHash && instance.MyHumanoid.m_hiddenRightItem.m_variant == instance.CurrentRightBackItemVariant))
             {
                 instance.NewRightBackItemVariant = instance.MyHumanoid.m_hiddenRightItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
-                {
-                    zdo.Set("RightBackItemVariant", (!string.IsNullOrEmpty(name)) ? instance.NewRightBackItemVariant : 0);
+                {                    
+                    zdo.Set(RightBackItemVariantHash, (itemHash != 0) ? instance.NewRightBackItemVariant : 0);
                 }
             }
         }
@@ -204,16 +208,16 @@ namespace Jotunn.Utils
         ///     Store the variant index of the chest item to the ZDO if the variant has changed
         /// </summary>
         [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetChestItem)), HarmonyPrefix]
-        private static void VisEquipment_SetChestItem(VisEquipment __instance, string name)
+        private static void VisEquipment_SetChestItem(VisEquipment __instance, int itemHash)
         {
             if (Instances.TryGetValue(__instance, out var instance) &&
                 instance.MyHumanoid && instance.MyHumanoid.m_chestItem != null &&
-                !(__instance.m_chestItem == name && instance.MyHumanoid.m_chestItem.m_variant == instance.CurrentChestVariant))
+                !(__instance.m_chestItem == itemHash && instance.MyHumanoid.m_chestItem.m_variant == instance.CurrentChestVariant))
             {
                 instance.NewChestVariant = instance.MyHumanoid.m_chestItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
                 {
-                    zdo.Set("ChestItemVariant", (!string.IsNullOrEmpty(name)) ? instance.NewChestVariant : 0);
+                    zdo.Set(ChestItemVariantHash, (itemHash != 0) ? instance.NewChestVariant : 0);
                 }
             }
         }

--- a/JotunnLib/Utils/GameVersions.cs
+++ b/JotunnLib/Utils/GameVersions.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Diagnostics;
-using System.Reflection;
 using HarmonyLib;
 
 namespace Jotunn.Utils
@@ -27,8 +24,8 @@ namespace Jotunn.Utils
 
         private static uint GetNetworkVersion()
         {
-            // use Reflection because Version.m_networkVersion is a constant field, i.e. evaluated at compile time
-            return (uint)AccessTools.Field(typeof(Version), nameof(Version.m_networkVersion)).GetValue(null);
+            // Use reflection because Version.c_networkVersion is a constant field, i.e. evaluated at compile time
+            return (uint) AccessTools.Field(typeof(Version), nameof(Version.c_networkVersion)).GetValue(null);
         }
     }
 }

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -206,7 +206,7 @@ namespace TestMod
 
                 // Use the name of the ButtonConfig to identify the button pressed
                 if (EvilSwordSpecialButton != null && MessageHud.instance != null &&
-                    Player.m_localPlayer != null && Player.m_localPlayer.m_visEquipment.m_rightItem == "EvilSword")
+                    Player.m_localPlayer != null && Player.m_localPlayer.m_visEquipment.m_rightItem == "EvilSword".GetStableHashCode())
                 {
                     if (ZInput.GetButton(EvilSwordSpecialButton.Name) && MessageHud.instance.m_msgQeue.Count == 0)
                     {


### PR DESCRIPTION
Minor optimization with precalculating the hashes for the three variants and defining them as `const int` values.