### PR TITLE
Fix soft-reference location proxy spawning for active child ZNetViews

### DIFF
--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -142,6 +142,8 @@ namespace Jotunn.Entities
 
         private void OnLocationResolve(GameObject gameObject)
         {
+            gameObject.SetActive(true);
+
             if (gameObject.TryGetComponent<Location>(out var location))
             {
                 SyncZoneLocationFromComponent(location, _locationConfig);


### PR DESCRIPTION
## Description
This fixes a Valheim client proxy spawning bug for soft-reference custom locations.

Jotunn resolves soft-reference location prefabs under its hidden `LocationContainer`, but the resolved location root stayed inactive. During client proxy spawning, Valheim calls `Utils.GetEnabledComponentsInChildren<ZNetView>()` on the source location prefab, then temporarily disables those child `ZNetView` objects before cloning the proxy.

Because the source root was inactive, Valheim missed active child `ZNetView`s and disabled nothing. That allowed proxy clones to initialize child network objects that should have stayed disabled. For persistent pickable objects like `Pickable_SurtlingCoreStand`, this created unintended persistent ZDOs on reload and produced duplicate collectable objects.

The fix activates the resolved soft-reference location root after mock resolution. The parent `LocationContainer` remains inactive, so the prefab is not made visible in the scene. This matches the existing behavior for non-soft-reference custom locations, where Jotunn already forces location prefab roots active before registration.
