### PR TITLE
ci: fix Valheim dependency setup on a cold cache

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -53,7 +53,9 @@ jobs:
         run: |
           wget -O bepinex.zip "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/"
           unzip bepinex.zip -d ~/BepInExRaw
-          steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_update 896660 validate +exit
+          # app_info_update is required: on a fresh steamcmd, app_update fails
+          # with "Failed to install app '896660' (Missing configuration)".
+          steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_info_update 1 +app_update 896660 validate +exit
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/Valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -53,8 +53,6 @@ jobs:
         run: |
           wget -O bepinex.zip "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/"
           unzip bepinex.zip -d ~/BepInExRaw
-          # app_info_update is required: on a fresh steamcmd, app_update fails
-          # with "Failed to install app '896660' (Missing configuration)".
           steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_info_update 1 +app_update 896660 validate +exit
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/Valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,8 +44,6 @@ jobs:
         run: |
           wget -O bepinex.zip "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/"
           unzip bepinex.zip -d ~/BepInExRaw
-          # app_info_update is required: on a fresh steamcmd, app_update fails
-          # with "Failed to install app '896660' (Missing configuration)".
           steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_info_update 1 +app_update 896660 validate +exit
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/Valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
       # Get Valheim version id
       - name: Get Valheim version id
         id: valheimversion
-        run: echo "valheimversion=$(curl -s https://api.steamcmd.net/v1/info/896660 | jq -r ".data.\"896660\".depots.branches.public.buildid")"
+        run: echo "valheimversion=$(curl -s https://api.steamcmd.net/v1/info/896660 | jq -r ".data.\"896660\".depots.branches.public.buildid")" >> $GITHUB_OUTPUT
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -44,7 +44,9 @@ jobs:
         run: |
           wget -O bepinex.zip "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/"
           unzip bepinex.zip -d ~/BepInExRaw
-          steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_update 896660 validate +exit
+          # app_info_update is required: on a fresh steamcmd, app_update fails
+          # with "Failed to install app '896660' (Missing configuration)".
+          steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_info_update 1 +app_update 896660 validate +exit
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/Valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -54,8 +54,6 @@ jobs:
         run: |
           wget -O bepinex.zip "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/"
           unzip bepinex.zip -d ~/BepInExRaw
-          # app_info_update is required: on a fresh steamcmd, app_update fails
-          # with "Failed to install app '896660' (Missing configuration)".
           steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_info_update 1 +app_update 896660 validate +exit
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/Valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -54,7 +54,9 @@ jobs:
         run: |
           wget -O bepinex.zip "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/"
           unzip bepinex.zip -d ~/BepInExRaw
-          steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_update 896660 validate +exit
+          # app_info_update is required: on a fresh steamcmd, app_update fails
+          # with "Failed to install app '896660' (Missing configuration)".
+          steamcmd +force_install_dir ~/VHINSTALL +login anonymous +app_info_update 1 +app_update 896660 validate +exit
           mv ~/VHINSTALL/valheim_server_Data/ ~/VHINSTALL/Valheim_Data/
           mv ~/BepInExRaw/BepInExPack_Valheim/* ~/VHINSTALL/
 


### PR DESCRIPTION
On a fresh steamcmd, app_update fails immediately with "ERROR! Failed to install app '896660' (Missing configuration)". The following mv then fails because nothing was installed, and the job exits 1 before the solution is ever built. Adding +app_info_update 1 before +app_update fixes it. Runners are ephemeral, so every run and re-run starts from that cold state, and re-running a failed job does not help.

This was masked until now because the PR workflow echoed the Valheim version id to stdout instead of appending it to $GITHUB_OUTPUT, so steps.valheimversion.outputs.valheimversion was always empty and the cache key collapsed to the constant "--BepInExPack-5.4.2333". That constant key kept getting hit, so the steamcmd path never ran. It also meant the cache never invalidated when Valheim updated, so PR builds could run against an arbitrarily stale install. merge.yml and tag-release.yml already had the redirect.