### PR TITLE
Fix Valheim 1.0 compatibility

### DIFF
--- a/JotunnLib/DebugUtils/DebugInfo.cs
+++ b/JotunnLib/DebugUtils/DebugInfo.cs
@@ -214,11 +214,11 @@ namespace Jotunn.DebugUtils
 
             _zoneAltitudeValue.text = $"<color=#ffe082>{altitude:0}</color>";
 
-            Vector2i sector = ZoneSystem.GetZone(position);
+            Vector2s sector = ZoneSystem.GetZone(position);
 
             _zoneSectorValue.text = $"<color=#ffe082>{sector.x}</color>, <color=#a5d6a7>{sector.y}</color>";
 
-            int sectorIndex = ZDOMan.instance.SectorToIndex(sector);
+            int sectorIndex = (int)ZoneSystem.SectorToIndex(sector).Sector;
             long zdoCount =
                 sectorIndex >= 0 && ZDOMan.instance.m_objectsBySector[sectorIndex] != null
                     ? ZDOMan.instance.m_objectsBySector[sectorIndex].Count

--- a/JotunnLib/Entities/CustomLocation.cs
+++ b/JotunnLib/Entities/CustomLocation.cs
@@ -4,7 +4,6 @@ using Jotunn.Configs;
 using Jotunn.Managers;
 using SoftReferenceableAssets;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace Jotunn.Entities
 {
@@ -125,7 +124,7 @@ namespace Jotunn.Entities
         {
             if (!softReferencePrefab.IsValid)
             {
-                Logger.LogError($"SoftReference invalid for prefab: {softReferencePrefab.Name}");
+                Logger.LogError($"SoftReference invalid for location prefab AssetID {softReferencePrefab.m_assetID}");
                 return;
             }
 
@@ -149,10 +148,7 @@ namespace Jotunn.Entities
                 SyncZoneLocationFromComponent(location, _locationConfig);
             }
 
-            if (gameObject.TryGetComponent<ZoneSystem.ZoneLocation>(out var zoneLocation))
-            {
-                ZoneManager.Instance.PrepareLocation(zoneLocation, SourceMod);
-            }
+            ZoneManager.Instance.PrepareLocation(ZoneLocation, SourceMod);
         }
 
         private void SyncZoneLocationFromComponent(Location location, LocationConfig locationConfig)

--- a/JotunnLib/Entities/CustomRoom.cs
+++ b/JotunnLib/Entities/CustomRoom.cs
@@ -135,7 +135,7 @@ namespace Jotunn.Entities
         {
             if (!softReferencePrefab.IsValid)
             {
-                Logger.LogError($"SoftReference invalid for room prefab: {softReferencePrefab.Name}");
+                Logger.LogError($"SoftReference invalid for room prefab AssetID {softReferencePrefab.m_assetID}");
                 return;
             }
 

--- a/JotunnLib/Managers/CommandManager.cs
+++ b/JotunnLib/Managers/CommandManager.cs
@@ -117,6 +117,7 @@ namespace Jotunn.Managers
                 typeof(bool),
                 typeof(bool),
                 typeof(bool),
+                typeof(bool), // hideBehindDevCommands
                 typeof(Terminal.ConsoleOptionsFetcher),
                 typeof(bool),
                 typeof(bool),
@@ -135,6 +136,7 @@ namespace Jotunn.Managers
                     command.OnlyServer,
                     command.IsSecret,
                     false, // allowInDevBuild
+                    false, // hideBehindDevCommands
                     (Terminal.ConsoleOptionsFetcher)command.CommandOptionList,
                     false, // alwaysRefreshTabOptions
                     false, // remoteCommand

--- a/JotunnLib/Managers/DungeonManager.cs
+++ b/JotunnLib/Managers/DungeonManager.cs
@@ -111,6 +111,12 @@ namespace Jotunn.Managers
                 throw new ArgumentException("Cannot be null", nameof(customRoom));
             }
 
+            if (string.IsNullOrEmpty(customRoom.Name) || customRoom.RoomData == null)
+            {
+                Logger.LogWarning(customRoom.SourceMod, "Cannot add an invalid custom room");
+                return false;
+            }
+
             if (string.IsNullOrEmpty(customRoom.ThemeName))
             {
                 throw new ArgumentException($"ThemeName of this room must have a value.", nameof(customRoom));

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -698,20 +698,20 @@ namespace Jotunn.Managers
 
         private static void ExpandAvailablePieces(PieceTable __instance)
         {
-            if (__instance.m_availablePieces.Count > 0)
+            if (__instance.m_availablePiecesByCategory.Count > 0)
             {
-                int missing = MaxCategory() - __instance.m_availablePieces.Count;
+                int missing = MaxCategory() - __instance.m_availablePiecesByCategory.Count;
                 for (int i = 0; i < missing; i++)
                 {
-                    __instance.m_availablePieces.Add(new List<Piece>());
+                    __instance.m_availablePiecesByCategory.Add(new List<Piece>());
                 }
             }
         }
 
         private static void AdjustPieceTableArray(PieceTable pieceTable)
         {
-            Array.Resize(ref pieceTable.m_selectedPiece, pieceTable.m_availablePieces.Count);
-            Array.Resize(ref pieceTable.m_lastSelectedPiece, pieceTable.m_availablePieces.Count);
+            Array.Resize(ref pieceTable.m_selectedPiece, pieceTable.m_availablePiecesByCategory.Count);
+            Array.Resize(ref pieceTable.m_lastSelectedPiece, pieceTable.m_availablePiecesByCategory.Count);
         }
 
         private static void ReorderAllCategoryPieces(PieceTable pieceTable)
@@ -719,7 +719,7 @@ namespace Jotunn.Managers
             List<Piece> pieces = pieceTable.m_pieces.Select(i => i.GetComponent<Piece>()).ToList();
             List<Piece> piecesWithAllCategory = pieces.FindAll(i => i && i.m_category == PieceUtils.VanillaAllPieceCategory);
 
-            foreach (List<Piece> availablePieces in pieceTable.m_availablePieces)
+            foreach (List<Piece> availablePieces in pieceTable.m_availablePiecesByCategory)
             {
                 int listPosition = 0;
 
@@ -727,7 +727,7 @@ namespace Jotunn.Managers
                 {
                     // m_availablePieces are already populated. Add pieces at the beginning of the list, to replicate vanilla behaviour
                     availablePieces.Remove(piece);
-                    availablePieces.Insert(Mathf.Min(listPosition, pieceTable.m_availablePieces.Count), piece);
+                    availablePieces.Insert(Mathf.Min(listPosition, pieceTable.m_availablePiecesByCategory.Count), piece);
                     listPosition++;
                 }
             }

--- a/JotunnLib/Managers/ZoneManager.cs
+++ b/JotunnLib/Managers/ZoneManager.cs
@@ -230,6 +230,17 @@ namespace Jotunn.Managers
         /// <returns>true if the custom location could be added to the manager</returns>
         public bool AddCustomLocation(CustomLocation customLocation)
         {
+            if (customLocation == null)
+            {
+                throw new ArgumentNullException(nameof(customLocation));
+            }
+
+            if (string.IsNullOrEmpty(customLocation.Name) || customLocation.ZoneLocation == null)
+            {
+                Logger.LogWarning(customLocation.SourceMod, "Cannot add an invalid custom location");
+                return false;
+            }
+
             if (Locations.ContainsKey(customLocation.Name))
             {
                 Logger.LogWarning(customLocation.SourceMod, $"Location {customLocation.Name} already exists");

--- a/JotunnLib/Utils/ExtEquipment.cs
+++ b/JotunnLib/Utils/ExtEquipment.cs
@@ -9,6 +9,10 @@ namespace Jotunn.Utils
 {
     internal class ExtEquipment : MonoBehaviour
     {
+        private static readonly int RightItemVariantHash = "RightItemVariant".GetStableHashCode();
+        private static readonly int RightBackItemVariantHash = "RightBackItemVariant".GetStableHashCode();
+        private static readonly int ChestItemVariantHash = "ChestItemVariant".GetStableHashCode();
+
         private static bool Enabled;
 
         private static readonly Dictionary<VisEquipment, ExtEquipment> Instances =
@@ -42,9 +46,9 @@ namespace Jotunn.Utils
             {
                 if (Instances.TryGetValue(__instance, out var instance))
                 {
-                    instance.NewRightItemVariant = zdo.GetInt("RightItemVariant");
-                    instance.NewChestVariant = zdo.GetInt("ChestItemVariant");
-                    instance.NewRightBackItemVariant = zdo.GetInt("RightBackItemVariant");
+                    instance.NewRightItemVariant = zdo.GetInt(RightItemVariantHash);
+                    instance.NewChestVariant = zdo.GetInt(ChestItemVariantHash);
+                    instance.NewRightBackItemVariant = zdo.GetInt(RightBackItemVariantHash);
                 }
             }
         }
@@ -168,16 +172,16 @@ namespace Jotunn.Utils
         ///     Store the variant index of the right hand item to the ZDO if the variant has changed
         /// </summary>
         [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightItem)), HarmonyPrefix]
-        private static void VisEquipment_SetRightItem(VisEquipment __instance, string name)
+        private static void VisEquipment_SetRightItem(VisEquipment __instance, int itemHash)
         {
             if (Instances.TryGetValue(__instance, out var instance) &&
                 instance.MyHumanoid && instance.MyHumanoid.m_rightItem != null &&
-                !(__instance.m_rightItem == name && instance.MyHumanoid.m_rightItem.m_variant == instance.CurrentRightItemVariant))
+                !(__instance.m_rightItem == itemHash && instance.MyHumanoid.m_rightItem.m_variant == instance.CurrentRightItemVariant))
             {
                 instance.NewRightItemVariant = instance.MyHumanoid.m_rightItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
                 {
-                    zdo.Set("RightItemVariant", (!string.IsNullOrEmpty(name)) ? instance.NewRightItemVariant : 0);
+                    zdo.Set(RightItemVariantHash, itemHash != 0 ? instance.NewRightItemVariant : 0);
                 }
             }
         }
@@ -186,16 +190,16 @@ namespace Jotunn.Utils
         ///     Store the variant index of the right back item to the ZDO if the variant has changed
         /// </summary>
         [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightBackItem)), HarmonyPrefix]
-        private static void VisEquipment_SetRightBackItem(VisEquipment __instance, string name)
+        private static void VisEquipment_SetRightBackItem(VisEquipment __instance, int itemHash)
         {
             if (Instances.TryGetValue(__instance, out var instance) &&
                 instance.MyHumanoid && instance.MyHumanoid.m_hiddenRightItem != null &&
-                !(__instance.m_rightBackItem == name && instance.MyHumanoid.m_hiddenRightItem.m_variant == instance.CurrentRightBackItemVariant))
+                !(__instance.m_rightBackItem == itemHash && instance.MyHumanoid.m_hiddenRightItem.m_variant == instance.CurrentRightBackItemVariant))
             {
                 instance.NewRightBackItemVariant = instance.MyHumanoid.m_hiddenRightItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
                 {
-                    zdo.Set("RightBackItemVariant", (!string.IsNullOrEmpty(name)) ? instance.NewRightBackItemVariant : 0);
+                    zdo.Set(RightBackItemVariantHash, itemHash != 0 ? instance.NewRightBackItemVariant : 0);
                 }
             }
         }
@@ -204,16 +208,16 @@ namespace Jotunn.Utils
         ///     Store the variant index of the chest item to the ZDO if the variant has changed
         /// </summary>
         [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetChestItem)), HarmonyPrefix]
-        private static void VisEquipment_SetChestItem(VisEquipment __instance, string name)
+        private static void VisEquipment_SetChestItem(VisEquipment __instance, int itemHash)
         {
             if (Instances.TryGetValue(__instance, out var instance) &&
                 instance.MyHumanoid && instance.MyHumanoid.m_chestItem != null &&
-                !(__instance.m_chestItem == name && instance.MyHumanoid.m_chestItem.m_variant == instance.CurrentChestVariant))
+                !(__instance.m_chestItem == itemHash && instance.MyHumanoid.m_chestItem.m_variant == instance.CurrentChestVariant))
             {
                 instance.NewChestVariant = instance.MyHumanoid.m_chestItem.m_variant;
                 if (__instance.m_nview && __instance.m_nview.GetZDO() is ZDO zdo)
                 {
-                    zdo.Set("ChestItemVariant", (!string.IsNullOrEmpty(name)) ? instance.NewChestVariant : 0);
+                    zdo.Set(ChestItemVariantHash, itemHash != 0 ? instance.NewChestVariant : 0);
                 }
             }
         }

--- a/JotunnLib/Utils/GameVersions.cs
+++ b/JotunnLib/Utils/GameVersions.cs
@@ -25,7 +25,7 @@ namespace Jotunn.Utils
         private static uint GetNetworkVersion()
         {
             // Use reflection because networkVersion is a constant field, i.e. evaluated at compile time
-            var field = typeof(Version).GetField(nameof(Version.m_networkVersion))
+            var field = typeof(Version).GetField("m_networkVersion")
                 ?? typeof(Version).GetField("c_networkVersion") // Valheim 0.221.13+
                 ?? throw new Exception("Could not find network version field in Version class");
             return (uint)field.GetValue(null);

--- a/JotunnLib/Utils/UndoActions.cs
+++ b/JotunnLib/Utils/UndoActions.cs
@@ -160,7 +160,7 @@ namespace Jotunn.Utils
                 compiler.m_lastOpPoint = Vector3.zero;
                 compiler.m_lastOpRadius = 0f;
                 compiler.Save();
-                compiler.m_hmap.Poke(false);
+                compiler.m_hmap.Poke();
             }
 
             public static BinarySearchDictionary<TKey, TValue> CloneBinarySearchDictionary<TKey, TValue>(BinarySearchDictionary<TKey, TValue> dict) where TKey : IComparable<TKey>

--- a/TestMod/ConsoleCommands/ResetCartographyCommand.cs
+++ b/TestMod/ConsoleCommands/ResetCartographyCommand.cs
@@ -24,7 +24,7 @@ namespace TestMod.ConsoleCommands
             }
             Minimap.instance.m_pins = playerpins;
 
-            Minimap.instance.m_exploredOthers = new bool[Minimap.instance.m_exploredOthers.Length];
+            Minimap.instance.m_exploredOthers.SetAll(false);
             if (Minimap.instance.m_sharedMapHint)
             {
                 UnityEngine.Object.Destroy(Minimap.instance.m_sharedMapHint);

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -33,6 +33,7 @@ namespace TestMod
         private const string ModName = "Jotunn Test Mod #1";
         private const string ModVersion = "0.1.0";
         private const string JotunnTestModConfigSection = "JotunnTest";
+        private static readonly int EvilSwordHash = "EvilSword".GetStableHashCode();
 
         private Sprite TestSprite;
         private Texture2D TestTex;
@@ -211,7 +212,7 @@ namespace TestMod
 
                 // Use the name of the ButtonConfig to identify the button pressed
                 if (EvilSwordSpecialButton != null && MessageHud.instance != null &&
-                    Player.m_localPlayer != null && Player.m_localPlayer.m_visEquipment.m_rightItem == "EvilSword")
+                    Player.m_localPlayer != null && Player.m_localPlayer.m_visEquipment.m_rightItem == EvilSwordHash)
                 {
                     if (ZInput.GetButton(EvilSwordSpecialButton.Name) && MessageHud.instance.m_msgQeue.Count == 0)
                     {


### PR DESCRIPTION
## Summary

- update Jotunn for Valheim 1.0 sector, terrain, equipment, network-version, and piece-table APIs
- update bundled test-mod code for the new map and equipment types
- prepare the actual ZoneLocation after a soft-reference location resolves
- reject invalid soft-reference locations and rooms without accessing an unavailable asset name

This pull request intentionally excludes the macOS publicizer and build-path changes. Those remain on the mac-dev branch for local development only.

## Validation

- Valheim 1.0.7, Steam build 25185596
- dotnet build JotunnLib.sln --no-restore -p:ExecutePrebuild=false: passed
- xUnit console: 28 passed, 0 failed
- Valheim 1.0 startup reproduced the invalid AssetID location exception before the fix

The updated soft-reference behavior has not yet been validated by spawning a custom location or generating a custom dungeon. The build retains existing netstandard reference and source warnings. No warning originates from these changes.