### PR TITLE
fix: register custom TerrainOp prefabs in ObjectDB

### DIFF
--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -381,7 +381,7 @@ namespace Jotunn.Managers
                 
                 int hash = name.GetStableHashCode();
 
-                if (znet.m_namedPrefabs.ContainsKey(hash))
+                if (znet.m_namedPrefabs.TryGetValue(hash, out GameObject registeredPrefab))
                 {
                     Logger.LogDebug($"Prefab {name} already in ZNetScene");
                 }
@@ -396,9 +396,42 @@ namespace Jotunn.Managers
                         znet.m_nonNetViewPrefabs.Add(gameObject);
                     }
                     znet.m_namedPrefabs.Add(hash, gameObject);
+                    registeredPrefab = gameObject;
                     Logger.LogDebug($"Added prefab {name}");
                 }
+
+                if (registeredPrefab == gameObject)
+                {
+                    RegisterTerrainOp(gameObject);
+                }
             }
+        }
+
+        private static void RegisterTerrainOp(GameObject gameObject)
+        {
+            ObjectDB objectDB = ObjectDB.instance;
+            TerrainOp terrainOp = gameObject.GetComponent<TerrainOp>();
+            if (!objectDB || !terrainOp)
+            {
+                return;
+            }
+
+            int hash = objectDB.GetPrefabHash(gameObject);
+            if (objectDB.m_terrainOpsByHash.TryGetValue(hash, out TerrainOp registeredTerrainOp))
+            {
+                if (registeredTerrainOp != terrainOp)
+                {
+                    Logger.LogWarning($"TerrainOp prefab hash collision for {gameObject.name} ({hash})");
+                }
+                return;
+            }
+
+            if (!objectDB.m_terrainOps.Contains(terrainOp))
+            {
+                objectDB.m_terrainOps.Add(terrainOp);
+            }
+            objectDB.m_terrainOpsByHash.Add(hash, terrainOp);
+            Logger.LogDebug($"Added TerrainOp {gameObject.name} to ObjectDB");
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Valheim 1.0 serializes `TerrainOp.Settings` using the prefab's stable hash. On the receiving side, `TerrainOp.Settings.Deserialize` resolves that hash only through `ObjectDB.TryGetTerrainOp`. Custom prefabs registered by Jotunn are added to `ZNetScene`, but their `TerrainOp` components are not added to `ObjectDB.m_terrainOps` / `m_terrainOpsByHash`, so deserialization fails and the terrain operation is cancelled.

This affects custom terrain prefabs in multiplayer and after network serialization. The issue was reproduced with [AdvancedTerrainModifiersCompatible 1.4.3](https://thunderstore.io/c/valheim/p/Ostrix/AdvancedTerrainModifiersCompatible/) using `raise_v2_precise` and `paved_road_v2_square`.

## Fix

Register a prefab's `TerrainOp` in both ObjectDB collections from the existing `PrefabManager.RegisterToZNetScene` path. Registration occurs only when the exact prefab instance is the one stored in `ZNetScene`, preserving the existing duplicate/hash-collision behavior.

No new public API or dependency is introduced.

## Validation

- `JotunnLib` compile target passes against the Valheim 1.0.7 assemblies.
- Runtime-tested on Valheim 1.0.7 with both affected terrain prefabs: placement, save, and clean shutdown succeeded.
- The runtime log contained no `Failed to deserialize TerrainOp settings`, exceptions, errors, or prefab hash collisions.
- `git diff --check` passes.

The original investigation and proposed diff were discussed in [#483](https://github.com/Valheim-Modding/Jotunn/pull/483#issuecomment-5607892217), but the TerrainOp registration was not included in that release fix.
